### PR TITLE
Replace elastic maintainers with Rushi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,21 +19,6 @@ jobs:
       - name: Lint the code
         run: nox -s lint
 
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v1
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - name: Install dependencies
-        run: |
-          python3.7 -m pip install nox
-      - name: Build the docs
-        run: nox -s docs
-
   test-linux:
     strategy:
       fail-fast: false

--- a/setup.py
+++ b/setup.py
@@ -61,21 +61,21 @@ tests_require = [
 ]
 async_require = ["aiohttp>=3,<4"]
 
-docs_require = ["sphinx<1.7", "sphinx_rtd_theme"]
+docs_require = []
 generate_require = ["black", "jinja2"]
 
 setup(
     name=package_name,
-    description="Python client for OpenSearch",
+    description="Python low-level client for OpenSearch",
     license="Apache-2.0",
     url="https://github.com/opensearch-project/opensearch-py",
     long_description=long_description,
     long_description_content_type="text/x-rst",
     version=package_version,
-    author="Honza Král, Nick Lang",
-    author_email="honza.kral@gmail.com, nick@nicklang.com",
-    maintainer="Seth Michael Larson",
-    maintainer_email="seth.larson@elastic.co",
+    author="Rushi Agrawal",
+    author_email="rushi.agr@gmail.com",
+    maintainer="Rushi Agrawal",
+    maintainer_email="rushi.agr@gmail.com",
     project_urls={
         "Documentation": "https://opensearch-py.readthedocs.io",
         "Source Code": "https://github.com/opensearch-project/opensearch-py",


### PR DESCRIPTION
Rushi is added as temporary maintainer for now. Should ideally be
replaced with an email list

Also removed doc requirements, and updated description to mention
'low-level' client explicitly

Signed-off-by: Rushi Agrawal <rushi.agr@gmail.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
