### PR TITLE
Add support for API versioning header

### DIFF
--- a/opensearch/serializer.py
+++ b/opensearch/serializer.py
@@ -163,6 +163,13 @@ class Deserializer(object):
         if not mimetype:
             deserializer = self.default
         else:
+            # Treat 'application/vnd.[opensearch|elasticsearch]+json'
+            # as application/json for compatibility.
+            if mimetype == "application/vnd.opensearch+json":
+                mimetype = "application/json"
+            elif mimetype == "application/vnd.elasticsearch+json":
+                mimetype = "application/json"
+
             # split out charset
             mimetype, _, _ = mimetype.partition(";")
             try:

--- a/test_opensearch/test_connection.py
+++ b/test_opensearch/test_connection.py
@@ -28,6 +28,7 @@
 import gzip
 import io
 import json
+import os
 import re
 import ssl
 import warnings
@@ -172,6 +173,44 @@ class TestBaseConnection(TestCase):
         ]:
             conn = Connection(**kwargs)
             assert conn.host == expected_host
+
+    def test_compatibility_accept_header(self):
+        try:
+            conn = Connection()
+            assert "accept" not in conn.headers
+
+            os.environ["ELASTIC_CLIENT_APIVERSIONING"] = "0"
+
+            conn = Connection()
+            assert "accept" not in conn.headers
+
+            os.environ["OPENSEARCH_CLIENT_APIVERSIONING"] = "0"
+
+            conn = Connection()
+            assert "accept" not in conn.headers
+
+            os.environ["ELASTIC_CLIENT_APIVERSIONING"] = "1"
+
+            conn = Connection()
+            assert (
+                conn.headers["accept"]
+                == "application/vnd.elasticsearch+json;compatible-with=7"
+            )
+
+            os.environ["OPENSEARCH_CLIENT_APIVERSIONING"] = "1"
+
+            self.assertRaises(RuntimeError, Connection)
+
+            os.environ["ELASTIC_CLIENT_APIVERSIONING"] = "0"
+
+            conn = Connection()
+            assert (
+                conn.headers["accept"]
+                == "application/vnd.opensearch+json;compatible-with=1"
+            )
+        finally:
+            os.environ.pop("ELASTIC_CLIENT_APIVERSIONING")
+            os.environ.pop("OPENSEARCH_CLIENT_APIVERSIONING")
 
 
 class TestUrllib3Connection(TestCase):


### PR DESCRIPTION
Signed-off-by: Rushi Agrawal <rushi.agr@gmail.com>

### Description
Adds back API versioning header, and also adds back support for  specifying either of OpenSearch or Elastic header

### Issues Resolved
Solves https://github.com/opensearch-project/opensearch-py/issues/46
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
