### PR TITLE
Add support for Elasticsearch api versioning header

### DIFF
--- a/opensearch/connection/base.py
+++ b/opensearch/connection/base.py
@@ -28,6 +28,7 @@ import binascii
 import gzip
 import io
 import logging
+import os
 import re
 import warnings
 from platform import python_version
@@ -126,6 +127,11 @@ class Connection(object):
             self.headers[key.lower()] = headers[key]
         if opaque_id:
             self.headers["x-opaque-id"] = opaque_id
+
+        if os.getenv("ELASTIC_CLIENT_APIVERSIONING") == "1":
+            self.headers.setdefault(
+                "accept", "application/vnd.elasticsearch+json;compatible-with=7"
+            )
 
         self.headers.setdefault("content-type", "application/json")
         self.headers.setdefault("user-agent", self._get_default_user_agent())

--- a/opensearch/serializer.py
+++ b/opensearch/serializer.py
@@ -163,6 +163,11 @@ class Deserializer(object):
         if not mimetype:
             deserializer = self.default
         else:
+            # Treat 'application/vnd.elasticsearch+json'
+            # as application/json for compatibility.
+            if mimetype == "application/vnd.elasticsearch+json":
+                mimetype = "application/json"
+
             # split out charset
             mimetype, _, _ = mimetype.partition(";")
             try:

--- a/test_opensearch/test_connection.py
+++ b/test_opensearch/test_connection.py
@@ -28,6 +28,7 @@
 import gzip
 import io
 import json
+import os
 import re
 import ssl
 import warnings
@@ -172,6 +173,26 @@ class TestBaseConnection(TestCase):
         ]:
             conn = Connection(**kwargs)
             assert conn.host == expected_host
+
+    def test_compatibility_accept_header(self):
+        try:
+            conn = Connection()
+            assert "accept" not in conn.headers
+
+            os.environ["ELASTIC_CLIENT_APIVERSIONING"] = "0"
+
+            conn = Connection()
+            assert "accept" not in conn.headers
+
+            os.environ["ELASTIC_CLIENT_APIVERSIONING"] = "1"
+
+            conn = Connection()
+            assert (
+                conn.headers["accept"]
+                == "application/vnd.elasticsearch+json;compatible-with=7"
+            )
+        finally:
+            os.environ.pop("ELASTIC_CLIENT_APIVERSIONING")
 
 
 class TestUrllib3Connection(TestCase):


### PR DESCRIPTION
Originally added in Elasticsearch in commit
2c5f1d15697e75f932a2c82634927e22931d4879, removed in OpenSearch in
3eac282c57552ef196e16c35132cca1d06f122b2

Note that this just adds support of 'elasticsearch' header, there's no
'opensearch' header support as such.

Signed-off-by: Rushi Agrawal <rushi.agr@gmail.com>

### Description
Add support for Elasticsearch api versioning header
 
### Issues Resolved
#56 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
