### PR TITLE
Add twine-check to the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,21 @@ jobs:
       - name: Run Tests
         run: |
           python setup.py test
+
+  twine-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools wheel twine
+      - name: Build source distribution
+        run: python setup.py sdist bdist_wheel
+      - name: Check with Twine
+        working-directory: dist
+        run: twine check *


### PR DESCRIPTION
### Description
Sometimes changes can impact the ability to produce a distributable artifact. This commit adds a condition in the CI workflow to check if the distributions using twine.
 
### Issues Resolved
Fixes #61 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
