### PR TITLE
Add *.whl to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ parts/
 sdist/
 var/
 wheels/
+*.whl
 share/python-wheels/
 *.egg-info/
 .installed.cfg


### PR DESCRIPTION
Signed-off-by: Rushi Agrawal <rushi.agr@gmail.com>

### Description
Ignores *.whl files from git repo
 
### Issues Resolved
None
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
