### PR TITLE
Fix potential security issues with jinja2 and pyyaml dep

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,7 +12,7 @@ numpy; python_version<"3.10"
 pandas; python_version<"3.10"
 
 pyyaml>=5.4; python_version>="3.6"
-pyyaml<5.3.1; python_version<"3.6"
+pyyaml==5.3.1; python_version<"3.6"
 
 isort
 black; python_version>="3.6"

--- a/utils/generate-api.py
+++ b/utils/generate-api.py
@@ -42,7 +42,7 @@ import black
 import unasync
 import urllib3
 from click.testing import CliRunner
-from jinja2 import Environment, FileSystemLoader, TemplateNotFound
+from jinja2 import Environment, FileSystemLoader, TemplateNotFound, select_autoescape
 
 http = urllib3.PoolManager()
 
@@ -67,6 +67,7 @@ GLOBAL_QUERY_PARAMS = {
 }
 
 jinja_env = Environment(
+    autoescape=select_autoescape(["html", "xml"]),
     loader=FileSystemLoader([CODE_ROOT / "utils" / "templates"]),
     trim_blocks=True,
     lstrip_blocks=True,


### PR DESCRIPTION
### Description


Added escaping to jinja templates. With PyYAML dependency, accidentally
added '<3.4.1' whereas the intent was to make it '==3.4.1', while fixing
as per dependabot alert. Fixed it now.

Signed-off-by: Rushi Agrawal <rushi.agr@gmail.com>

### Issues Resolved
No issue created for this. 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
