### PR TITLE
Add condition for shallow clone

### DIFF
--- a/test_opensearchpy/run_tests.py
+++ b/test_opensearchpy/run_tests.py
@@ -43,13 +43,6 @@ def fetch_opensearch_repo():
         abspath(join(dirname(__file__), pardir, pardir, "opensearch")),
     )
 
-    # no repo
-    if not exists(repo_path) or not exists(join(repo_path, ".git")):
-        subprocess.check_call(
-            "git clone https://github.com/opensearch-project/opensearch %s" % repo_path,
-            shell=True,
-        )
-
     # set YAML test dir
     environ["TEST_OPENSEARCH_YAML_DIR"] = join(
         repo_path, "rest-api-spec", "src", "main", "resources", "rest-api-spec", "test"
@@ -70,16 +63,23 @@ def fetch_opensearch_repo():
         print("No running opensearch >1.X server...")
         return
 
-    # fetch new commits to be sure...
-    print("Fetching opensearch repo...")
+    # no test directory
+    if not exists(repo_path):
+        subprocess.check_call("mkdir %s" % repo_path, shell=True)
+
+    # make a new blank repository in the test directory
+    subprocess.check_call("cd %s && git init" % repo_path, shell=True)
+
+    # add a remote
     subprocess.check_call(
-        "cd %s && git fetch https://github.com/opensearch-project/opensearch.git"
+        "cd %s && git remote add origin https://github.com/opensearch-project/opensearch.git"
         % repo_path,
         shell=True,
     )
-    # reset to the version from info()
-    subprocess.check_call("cd %s && git fetch" % repo_path, shell=True)
-    subprocess.check_call("cd %s && git reset --hard %s" % (repo_path, sha), shell=True)
+
+    # fetch the sha commit, version from info()
+    print("Fetching opensearch repo...")
+    subprocess.check_call("cd %s && git fetch origin %s" % (repo_path, sha), shell=True)
 
 
 def run_all(argv=None):


### PR DESCRIPTION
### Description
The integration tests performs a deep checkout of the opensearch repository. Instead, we can perform a shallow clone the main branch to improve the speed and performance of the tests.
 
### Issues Resolved
Fixes #52

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
