### PR TITLE
Update package name to opensearch-py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,10 @@ from os.path import abspath, dirname, join
 
 from setuptools import find_packages, setup
 
-package_name = "opensearchpy"
+package_name = "opensearch-py"
 base_dir = abspath(dirname(__file__))
 
-with open(join(base_dir, package_name, "_version.py")) as f:
+with open(join(base_dir, package_name.replace("-", ""), "_version.py")) as f:
     package_version = re.search(
         r"__versionstr__\s+=\s+[\"\']([^\"\']+)[\"\']", f.read()
     ).group(1)

--- a/utils/build-dists.py
+++ b/utils/build-dists.py
@@ -70,7 +70,12 @@ def run(*argv, expect_exit_code=0):
 
 def test_dist(dist):
     with set_tmp_dir() as tmp_dir:
-        dist_name = re.match(r"^(opensearchpy\d*)-", os.path.basename(dist)).group(1)
+        dist_name = re.match(
+            r"^(opensearchpy\d*)-",
+            os.path.basename(dist)
+            .replace("opensearch-py", "opensearchpy")
+            .replace("opensearch_py", "opensearchpy"),
+        ).group(1)
 
         # Build the venv and install the dist
         run("python", "-m", "venv", os.path.join(tmp_dir, "venv"))
@@ -251,11 +256,11 @@ def main():
             setup_py = f.read()
         with open(setup_py_path, "w") as f:
             f.truncate()
-            assert 'package_name = "opensearchpy"' in setup_py
+            assert 'package_name = "opensearch-py"' in setup_py
             f.write(
                 setup_py.replace(
-                    'package_name = "opensearchpy"',
-                    'package_name = "opensearchpy%s"' % suffix,
+                    'package_name = "opensearch-py"',
+                    'package_name = "opensearch-py%s"' % suffix,
                 )
             )
 


### PR DESCRIPTION
### Description

- Since opensearch is alredy taken, update distribution name to opensearch-py.
- Update build utils accordingly to fix package name change.

 
### Issues Resolved
#68
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
