### PR TITLE
Use 1.0.0 instead of latest tag

### DIFF
--- a/.ci/opensearch/Dockerfile
+++ b/.ci/opensearch/Dockerfile
@@ -1,5 +1,5 @@
-ARG OPENSEARCH_VERSION
-FROM opensearchproject/opensearch:latest
+ARG OPENSEARCH_VERSION=1.0.0
+FROM opensearchproject/opensearch:$OPENSEARCH_VERSION
 
 ARG opensearch_path=/usr/share/opensearch
 ARG opensearch_yml=$opensearch_path/config/opensearch.yml


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Add default value as 1.0.0.
 
### Issues Resolved
#97 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
