### PR TITLE
Add default `needs-triage` label to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
@@ -2,7 +2,7 @@
 name: 🐛 Bug report
 about: Create a report to help us improve
 title: '[BUG]'
-labels: 'bug, untriaged'
+labels: 'bug, needs-triage
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 name: 🎆 Feature request
 about: Request a feature in this project
 title: '[FEATURE]'
-labels: enhancement
+labels: enhancement, needs-triage
 assignees: ''
 ---
 **Is your feature request related to a problem?**

--- a/.github/ISSUE_TEMPLATE/PROPOSAL_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/PROPOSAL_TEMPLATE.md
@@ -2,7 +2,7 @@
 name: 💭 Proposal
 about: Suggest an idea for a specific feature you wish to propose to the community for comment
 title: '[PROPOSAL]'
-labels: proposal
+labels: proposal, needs-triage
 assignees: ''
 ---
 ## What kind of business use case are you trying to solve? What are your requirements?


### PR DESCRIPTION
### Description
Currently, there is no convenient way to get a list of untriaged issues. This PR adds `needs-triage` label to newly created issues.
 
### Issues Resolved
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
