### PR TITLE
Removes elastic support from opensearch-py library

### DIFF
--- a/opensearchpy/_async/http_aiohttp.py
+++ b/opensearchpy/_async/http_aiohttp.py
@@ -95,8 +95,6 @@ class AIOHttpConnection(AsyncConnection):
         headers=None,
         ssl_context=None,
         http_compress=None,
-        cloud_id=None,
-        api_key=None,
         opaque_id=None,
         loop=None,
         **kwargs,
@@ -130,9 +128,6 @@ class AIOHttpConnection(AsyncConnection):
             information.
         :arg headers: any custom http headers to be add to requests
         :arg http_compress: Use gzip compression
-        :arg cloud_id: The Cloud ID from ElasticCloud. Convenient way to connect to cloud instances.
-            Other host connection params will be ignored.
-        :arg api_key: optional API Key authentication as either base64 encoded string or a tuple.
         :arg opaque_id: Send this value in the 'X-Opaque-Id' HTTP header
             For tracing all requests made by this transport.
         :arg loop: asyncio Event Loop to use with aiohttp. This is set by default to the currently running loop.
@@ -146,8 +141,6 @@ class AIOHttpConnection(AsyncConnection):
             use_ssl=use_ssl,
             headers=headers,
             http_compress=http_compress,
-            cloud_id=cloud_id,
-            api_key=api_key,
             opaque_id=opaque_id,
             **kwargs,
         )

--- a/opensearchpy/_async/http_aiohttp.pyi
+++ b/opensearchpy/_async/http_aiohttp.pyi
@@ -62,8 +62,6 @@ class AIOHttpConnection(AsyncConnection):
         headers: Optional[Mapping[str, str]] = ...,
         ssl_context: Optional[Any] = ...,
         http_compress: Optional[bool] = ...,
-        cloud_id: Optional[str] = ...,
-        api_key: Optional[Any] = ...,
         opaque_id: Optional[str] = ...,
         loop: Any = ...,
         **kwargs: Any,

--- a/opensearchpy/_async/transport.py
+++ b/opensearchpy/_async/transport.py
@@ -99,10 +99,6 @@ class AsyncTransport(Transport):
             *args, hosts=[], sniff_on_start=False, **kwargs
         )
 
-        # Don't enable sniffing on Cloud instances.
-        if kwargs.get("cloud_id", False):
-            sniff_on_start = False
-
         # Since we defer connections / sniffing to not occur
         # within the constructor we never want to signal to
         # our parent to 'sniff_on_start' or non-empty 'hosts'.

--- a/opensearchpy/connection/base.pyi
+++ b/opensearchpy/connection/base.pyi
@@ -61,8 +61,6 @@ class Connection(object):
         timeout: Optional[Union[float, int]] = ...,
         headers: Optional[Mapping[str, str]] = ...,
         http_compress: Optional[bool] = ...,
-        cloud_id: Optional[str] = ...,
-        api_key: Optional[Union[Tuple[str, str], List[str], str]] = ...,
         opaque_id: Optional[str] = ...,
         **kwargs: Any
     ) -> None: ...
@@ -116,4 +114,3 @@ class Connection(object):
         self, status_code: int, raw_data: str, content_type: Optional[str]
     ) -> NoReturn: ...
     def _get_default_user_agent(self) -> str: ...
-    def _get_api_key_header_val(self, api_key: Any) -> str: ...

--- a/opensearchpy/connection/http_requests.py
+++ b/opensearchpy/connection/http_requests.py
@@ -61,9 +61,6 @@ class RequestsHttpConnection(Connection):
         separate cert and key files (client_cert will contain only the cert)
     :arg headers: any custom http headers to be add to requests
     :arg http_compress: Use gzip compression
-    :arg cloud_id: The Cloud ID from ElasticCloud. Convenient way to connect to cloud instances.
-        Other host connection params will be ignored.
-    :arg api_key: optional API Key authentication as either base64 encoded string or a tuple.
     :arg opaque_id: Send this value in the 'X-Opaque-Id' HTTP header
         For tracing all requests made by this transport.
     """
@@ -81,8 +78,6 @@ class RequestsHttpConnection(Connection):
         client_key=None,
         headers=None,
         http_compress=None,
-        cloud_id=None,
-        api_key=None,
         opaque_id=None,
         **kwargs
     ):
@@ -102,8 +97,6 @@ class RequestsHttpConnection(Connection):
             use_ssl=use_ssl,
             headers=headers,
             http_compress=http_compress,
-            cloud_id=cloud_id,
-            api_key=api_key,
             opaque_id=opaque_id,
             **kwargs
         )

--- a/opensearchpy/connection/http_requests.pyi
+++ b/opensearchpy/connection/http_requests.pyi
@@ -45,8 +45,6 @@ class RequestsHttpConnection(Connection):
         client_key: Optional[Any] = ...,
         headers: Optional[Mapping[str, str]] = ...,
         http_compress: Optional[bool] = ...,
-        cloud_id: Optional[str] = ...,
-        api_key: Optional[Any] = ...,
         opaque_id: Optional[str] = ...,
         **kwargs: Any
     ) -> None: ...

--- a/opensearchpy/connection/http_urllib3.py
+++ b/opensearchpy/connection/http_urllib3.py
@@ -100,9 +100,6 @@ class Urllib3HttpConnection(Connection):
         information.
     :arg headers: any custom http headers to be add to requests
     :arg http_compress: Use gzip compression
-    :arg cloud_id: The Cloud ID from ElasticCloud. Convenient way to connect to cloud instances.
-        Other host connection params will be ignored.
-    :arg api_key: optional API Key authentication as either base64 encoded string or a tuple.
     :arg opaque_id: Send this value in the 'X-Opaque-Id' HTTP header
         For tracing all requests made by this transport.
     """
@@ -125,8 +122,6 @@ class Urllib3HttpConnection(Connection):
         headers=None,
         ssl_context=None,
         http_compress=None,
-        cloud_id=None,
-        api_key=None,
         opaque_id=None,
         **kwargs
     ):
@@ -139,8 +134,6 @@ class Urllib3HttpConnection(Connection):
             use_ssl=use_ssl,
             headers=headers,
             http_compress=http_compress,
-            cloud_id=cloud_id,
-            api_key=api_key,
             opaque_id=opaque_id,
             **kwargs
         )

--- a/opensearchpy/connection/http_urllib3.pyi
+++ b/opensearchpy/connection/http_urllib3.pyi
@@ -59,8 +59,6 @@ class Urllib3HttpConnection(Connection):
         headers: Optional[Mapping[str, str]] = ...,
         ssl_context: Optional[Any] = ...,
         http_compress: Optional[bool] = ...,
-        cloud_id: Optional[str] = ...,
-        api_key: Optional[Any] = ...,
         opaque_id: Optional[str] = ...,
         **kwargs: Any
     ) -> None: ...

--- a/opensearchpy/transport.py
+++ b/opensearchpy/transport.py
@@ -166,11 +166,6 @@ class Transport(object):
         else:
             self.seed_connections = []
 
-        # Don't enable sniffing on Cloud instances.
-        if kwargs.get("cloud_id", False):
-            sniff_on_start = False
-            sniff_on_connection_fail = False
-
         # sniffing data
         self.sniffer_timeout = sniffer_timeout
         self.sniff_on_start = sniff_on_start

--- a/test_opensearchpy/test_async/test_connection.py
+++ b/test_opensearchpy/test_async/test_connection.py
@@ -94,53 +94,6 @@ class TestAIOHttpConnection:
         con = AIOHttpConnection(opaque_id="app-1")
         assert con.headers["x-opaque-id"] == "app-1"
 
-    def test_http_cloud_id(self):
-        con = AIOHttpConnection(
-            cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng=="
-        )
-        assert con.use_ssl
-        assert (
-            con.host
-            == "https://4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io"
-        )
-        assert con.port is None
-        assert con.hostname == "4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io"
-        assert con.http_compress
-
-        con = AIOHttpConnection(
-            cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
-            port=9243,
-        )
-        assert (
-            con.host
-            == "https://4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io:9243"
-        )
-        assert con.port == 9243
-        assert con.hostname == "4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io"
-
-    def test_api_key_auth(self):
-        # test with tuple
-        con = AIOHttpConnection(
-            cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
-            api_key=("elastic", "changeme1"),
-        )
-        assert con.headers["authorization"] == "ApiKey ZWxhc3RpYzpjaGFuZ2VtZTE="
-        assert (
-            con.host
-            == "https://4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io"
-        )
-
-        # test with base64 encoded string
-        con = AIOHttpConnection(
-            cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
-            api_key="ZWxhc3RpYzpjaGFuZ2VtZTI=",
-        )
-        assert con.headers["authorization"] == "ApiKey ZWxhc3RpYzpjaGFuZ2VtZTI="
-        assert (
-            con.host
-            == "https://4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io"
-        )
-
     async def test_no_http_compression(self):
         con = await self._get_mock_connection()
         assert not con.http_compress
@@ -178,26 +131,6 @@ class TestAIOHttpConnection:
         assert not kwargs["data"]
         assert kwargs["headers"]["accept-encoding"] == "gzip,deflate"
         assert "content-encoding" not in kwargs["headers"]
-
-    def test_cloud_id_http_compress_override(self):
-        # 'http_compress' will be 'True' by default for connections with
-        # 'cloud_id' set but should prioritize user-defined values.
-        con = AIOHttpConnection(
-            cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
-        )
-        assert con.http_compress is True
-
-        con = AIOHttpConnection(
-            cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
-            http_compress=False,
-        )
-        assert con.http_compress is False
-
-        con = AIOHttpConnection(
-            cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
-            http_compress=True,
-        )
-        assert con.http_compress is True
 
     async def test_url_prefix(self):
         con = await self._get_mock_connection(

--- a/test_opensearchpy/test_async/test_transport.py
+++ b/test_opensearchpy/test_async/test_transport.py
@@ -436,23 +436,6 @@ class TestTransport:
             "port": 123,
         }
 
-    @patch("opensearchpy._async.transport.AsyncTransport.sniff_hosts")
-    async def test_sniffing_disabled_on_cloud_instances(self, sniff_hosts):
-        t = AsyncTransport(
-            [{}],
-            sniff_on_start=True,
-            sniff_on_connection_fail=True,
-            connection_class=DummyConnection,
-            cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
-        )
-        await t._async_call()
-
-        assert not t.sniff_on_connection_fail
-        assert sniff_hosts.call_args is None  # Assert not called.
-        await t.perform_request("GET", "/", body={})
-        assert 1 == len(t.get_connection().calls)
-        assert ("GET", "/", None, b"{}") == t.get_connection().calls[0][0]
-
     async def test_transport_close_closes_all_pool_connections(self):
         t = AsyncTransport([{}], connection_class=DummyConnection)
         await t._async_call()

--- a/test_opensearchpy/test_transport.py
+++ b/test_opensearchpy/test_transport.py
@@ -393,15 +393,3 @@ class TestTransport(TestCase):
             t.connection_pool.connection_opts[0][1],
             {"host": "somehost.tld", "port": 123},
         )
-
-    @patch("opensearchpy.transport.Transport.sniff_hosts")
-    def test_sniffing_disabled_on_cloud_instances(self, sniff_hosts):
-        t = Transport(
-            [{}],
-            sniff_on_start=True,
-            sniff_on_connection_fail=True,
-            cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
-        )
-
-        self.assertFalse(t.sniff_on_connection_fail)
-        self.assertIs(sniff_hosts.call_args, None)  # Assert not called.


### PR DESCRIPTION
Signed-off-by: Shivam Dhar <dhshivam@amazon.com>

### Description
The commit removes elastic cloud support from the opensearch library like references to `cloud_id` and the corresponding `api_key`.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-py/issues/29
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
