### PR TITLE
Fix and remove unused "type: ignore" comment

### DIFF
--- a/opensearchpy/connection/http_urllib3.pyi
+++ b/opensearchpy/connection/http_urllib3.pyi
@@ -27,7 +27,7 @@
 import ssl
 from typing import Any, Mapping, Optional, Union
 
-import urllib3  # type: ignore
+import urllib3
 
 from .base import Connection
 


### PR DESCRIPTION
### Description
This line:

https://github.com/opensearch-project/opensearch-py/blob/25ff092c8f3fd9762a9feabfbafc1a3b6d4d252f/opensearchpy/connection/http_urllib3.pyi#L30

causes the following error with mypy:

```text
$ mypy --strict opensearchpy
opensearchpy/connection/http_urllib3.pyi:30: error: Unused "type: ignore" comment
```

See CI here: https://github.com/PhilipMay/opensearch-py/runs/4887692937?check_suite_focus=true#step:5:169

I just removed it to fix it.
 
### Issues Resolved
none
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
