### PR TITLE
Rename needs-triage label to untriaged according org conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
@@ -2,7 +2,7 @@
 name: 🐛 Bug report
 about: Create a report to help us improve
 title: '[BUG]'
-labels: bug, needs-triage
+labels: bug, untriaged
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 name: 🎆 Feature request
 about: Request a feature in this project
 title: '[FEATURE]'
-labels: enhancement, needs-triage
+labels: enhancement, untriaged
 assignees: ''
 ---
 **Is your feature request related to a problem?**

--- a/.github/ISSUE_TEMPLATE/PROPOSAL_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/PROPOSAL_TEMPLATE.md
@@ -2,7 +2,7 @@
 name: 💭 Proposal
 about: Suggest an idea for a specific feature you wish to propose to the community for comment
 title: '[PROPOSAL]'
-labels: proposal, needs-triage
+labels: proposal, untriaged
 assignees: ''
 ---
 ## What kind of business use case are you trying to solve? What are your requirements?


### PR DESCRIPTION
Signed-off-by: Aleksei Atavin <axeo@aiven.io>

### Description
As was mentioned in https://github.com/opensearch-project/opensearch-py/pull/100#issuecomment-1033964738: a proper label across the organization is `untriaged`
 
### Issues Resolved

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
