### PR TITLE
adds AwsV4Signer implementation in the library

### DIFF
--- a/opensearchpy/__init__.py
+++ b/opensearchpy/__init__.py
@@ -61,6 +61,7 @@ from .exceptions import (
     SSLError,
     TransportError,
 )
+from .helpers import AWSV4Signer
 from .serializer import JSONSerializer
 from .transport import Transport
 
@@ -92,6 +93,7 @@ __all__ = [
     "AuthorizationException",
     "OpenSearchWarning",
     "OpenSearchDeprecationWarning",
+    "AWSV4Signer",
 ]
 
 try:

--- a/opensearchpy/__init__.pyi
+++ b/opensearchpy/__init__.pyi
@@ -57,6 +57,7 @@ try:
     from ._async.client import AsyncOpenSearch as AsyncOpenSearch
     from ._async.http_aiohttp import AIOHttpConnection as AIOHttpConnection
     from ._async.transport import AsyncTransport as AsyncTransport
+    from .helpers import AWSV4Signer as AWSV4Signer
 except (ImportError, SyntaxError):
     pass
 

--- a/opensearchpy/connection_pool.pyi
+++ b/opensearchpy/connection_pool.pyi
@@ -30,7 +30,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 from .connection import Connection
 
 try:
-    from Queue import PriorityQueue  # type: ignore
+    from Queue import PriorityQueue
 except ImportError:
     from queue import PriorityQueue
 

--- a/opensearchpy/helpers/__init__.py
+++ b/opensearchpy/helpers/__init__.py
@@ -37,6 +37,7 @@ from .actions import (
     streaming_bulk,
 )
 from .errors import BulkIndexError, ScanError
+from .signer import AWSV4Signer
 
 __all__ = [
     "BulkIndexError",
@@ -49,6 +50,7 @@ __all__ = [
     "reindex",
     "_chunk_actions",
     "_process_bulk_chunk",
+    "AWSV4Signer",
 ]
 
 

--- a/opensearchpy/helpers/__init__.pyi
+++ b/opensearchpy/helpers/__init__.pyi
@@ -46,5 +46,6 @@ try:
     from .._async.helpers import async_reindex as async_reindex
     from .._async.helpers import async_scan as async_scan
     from .._async.helpers import async_streaming_bulk as async_streaming_bulk
+    from .signer import AWSV4Signer as AWSV4Signer
 except (ImportError, SyntaxError):
     pass

--- a/opensearchpy/helpers/signer.py
+++ b/opensearchpy/helpers/signer.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+#
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import sys
+
+import requests
+
+from ..exceptions import ImproperlyConfigured
+
+OPENSEARCH_SERVICE = "es"
+
+
+def python_version_gte_36():  # type: ignore
+    """
+    A util method to check python version.
+    :return: boolean that returns true if python version running is greater than
+    equal to 3.6 otherwise returns false
+    """
+    if sys.hexversion >= 0x03060000:
+        return True
+    else:
+        return False
+
+
+try:
+    if python_version_gte_36():  # type: ignore
+        from urllib.parse import parse_qs, urlencode, urlparse
+except ImportError:
+    raise ImproperlyConfigured(
+        "Please upgrade the python version to 3.6 or above to use AWS Signer."
+    )
+
+
+class AWSV4Signer(requests.auth.AuthBase):
+    """
+    AWS V4 Request Signer for Requests.
+    """
+
+    def __init__(self, credentials, region):  # type: ignore
+        if not region:
+            raise ValueError("AWS region can not be null")
+        self.credentials = credentials
+        self.region = region
+
+    def __call__(self, request):  # type: ignore
+        if python_version_gte_36():  # type: ignore
+            return self.inject_headers(request)  # type: ignore
+        else:
+            raise ImproperlyConfigured(
+                "Please upgrade the python version to 3.6 or above to use AWS Signer."
+            )
+
+    def inject_headers(self, prepared_request):  # type: ignore
+        """
+        This method helps in signing the request by injecting the required headers.
+        :param prepared_request: unsigned request
+        :return: signed request
+        """
+        try:
+            from botocore.auth import SigV4Auth
+            from botocore.awsrequest import AWSRequest
+
+            url = self.fetch_url(prepared_request)  # type: ignore
+
+            # create an AWS request object and sign it using SigV4Auth
+            aws_request = AWSRequest(
+                method=prepared_request.method.upper(),
+                url=url,
+                data=prepared_request.body,
+            )
+            SigV4Auth(self.credentials, OPENSEARCH_SERVICE, self.region).add_auth(
+                aws_request
+            )
+
+            # copy the headers from AWS request object into the prepared_request
+            prepared_request.headers.update(dict(aws_request.headers.items()))
+
+            return prepared_request
+        except ImportError:
+            raise ImproperlyConfigured("Please install botocore to use AwsV4Signer.")
+
+    def fetch_url(self, prepared_request):  # type: ignore
+        """
+        This is a util method that helps in reconstructing the request url.
+        :param prepared_request: unsigned request
+        :return: reconstructed url
+        """
+        url = urlparse(prepared_request.url)
+        path = url.path or "/"
+
+        # fetch the query string if present in the request
+        querystring = ""
+        if url.query:
+            querystring = "?" + urlencode(
+                parse_qs(url.query, keep_blank_values=True), doseq=True
+            )
+
+        # fetch the host information from headers
+        headers = dict(
+            (key.lower(), value) for key, value in prepared_request.headers.items()
+        )
+        location = headers.get("host") or url.netloc
+
+        # construct the url and return
+        return url.scheme + "://" + location + path + querystring

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,6 @@ junit_family=legacy
 
 [tool:isort]
 profile=black
+
+[mypy]
+ignore_missing_imports=True

--- a/test_opensearchpy/test_connection.py
+++ b/test_opensearchpy/test_connection.py
@@ -31,7 +31,9 @@ import json
 import os
 import re
 import ssl
+import sys
 import unittest
+import uuid
 import warnings
 from platform import python_version
 
@@ -407,6 +409,24 @@ class TestRequestsConnection(TestCase):
         c = RequestsHttpConnection(http_auth=auth)
 
         self.assertEqual(auth, c.session.auth)
+
+    def test_aws_signer_http_auth_is_allowed(self):
+        access_key = uuid.uuid4().hex
+        secret_key = uuid.uuid4().hex
+        token = uuid.uuid4().hex
+        dummy_session = Mock()
+        dummy_session.access_key = access_key
+        dummy_session.secret_key = secret_key
+        dummy_session.token = token
+        region = "us-west-2"
+
+        if sys.hexversion >= 0x03060000:
+            from opensearchpy.helpers.signer import AWSV4Signer
+
+            auth = AWSV4Signer(region, dummy_session)
+            c = RequestsHttpConnection(http_auth=auth)
+
+            self.assertEqual(auth, c.session.auth)
 
     def test_timeout_set(self):
         con = RequestsHttpConnection(timeout=42)


### PR DESCRIPTION
Signed-off-by: Shivam Dhar <dhshivam@amazon.com>

### Description
Incorporate AWS IAM signing support in the library
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-py/issues/85

### Usage

```
from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4Signer
import boto3

host = ''
region = 'us-west-2' # e.g. us-west-1
service = 'es'
credentials = boto3.Session().get_credentials()
auth = AWSV4Signer(credentials, region)

search = OpenSearch(
    hosts = [{'host': host, 'port': 443}],
    http_auth = auth,
    use_ssl = True,
    verify_certs = True,
    connection_class = RequestsHttpConnection
)
```
 
**Requirement**: _The consumers who want to make use of AWSV4Signer, should have python version 3.6 or above._

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
