### PR TITLE
Upgrade pyyaml to fix dependabot alert

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,8 +11,9 @@ jinja2
 numpy; python_version<"3.10"
 pandas; python_version<"3.10"
 
+pyyaml==5.3.1; python_version=="3.5"
 pyyaml>=5.4; python_version>="3.6"
-pyyaml==5.3.1; python_version<"3.6"
+pyyaml>=5.4; python_version<"3.5"
 
 isort
 black; python_version>="3.6"


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Upgrading `pyyaml` to use version >= 5.4 to fix Dependabot alert. This will still not fully fix the alert since pyyaml `5.4` is not supported for python 3.5. So for python 3.5, we would still have to use `5.3.1` as long as we support python 3.5. (Reference: https://pypi.org/project/PyYAML/5.4/)
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
