### PR TITLE
updates version for 1.1 release

### DIFF
--- a/.github/workflows/unified-release.yml
+++ b/.github/workflows/unified-release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack_version: ['1.0.0']
+        stack_version: ['1.1.0']
 
     steps:
       - name: Checkout

--- a/opensearchpy/_version.py
+++ b/opensearchpy/_version.py
@@ -24,4 +24,4 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-__versionstr__ = "1.0.0"
+__versionstr__ = "1.1.0"


### PR DESCRIPTION
Signed-off-by: Shivam Dhar <dhshivam@amazon.com>

### Description
Bumps up the minor release version to point to `1.1.0`.

 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
