### PR TITLE
Move requests to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ packages = [
 install_requires = [
     "urllib3>=1.21.1, <2",
     "certifi",
+    "requests>=2.4.0, <3.0.0",
 ]
 tests_require = [
     "requests>=2.0.0, <3.0.0",
@@ -112,7 +113,6 @@ setup(
     extras_require={
         "develop": tests_require + docs_require + generate_require,
         "docs": docs_require,
-        "requests": ["requests>=2.4.0, <3.0.0"],
         "async": async_require,
     },
 )


### PR DESCRIPTION
Signed-off-by: Sam Foster <sfoster.ka@gmail.com>

### Description
Includes requests in install_requires, as it is now needed in order to even import the module.
 
### Issues Resolved
[BUG] requests actually required in version 1.1.0, but not listed as install_requires #141
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
