### PR TITLE
Re-enable integration tests across multiple versions of OpenSearch

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,10 +11,20 @@ jobs:
       matrix:
         cluster: ["opensearch"]
         secured: ["true", "false"]
-        opensearch_version: [1.0.0, 1.0.1, 1.1.0, 1.2.0, 1.2.1, 1.2.2, 1.2.3, 1.2.4, 1.3.0, 1.3.1]
+        entry:
+          - { opensearch_version: 1.0.0 }
+          - { opensearch_version: 1.0.1 }
+          - { opensearch_version: 1.1.0 }
+          - { opensearch_version: 1.2.0 }
+          - { opensearch_version: 1.2.1 }
+          - { opensearch_version: 1.2.2 }
+          - { opensearch_version: 1.2.3 }
+          - { opensearch_version: 1.2.4 }
+          - { opensearch_version: 1.3.0 }
+          - { opensearch_version: 1.3.1 }
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Integ ${{ matrix.cluster }} secured=${{ matrix.secured }} version=${{matrix.opensearch_version}}
-        run: "./.ci/run-tests ${{ matrix.cluster }} ${{ matrix.secured }} ${{ matrix.opensearch_version }}"
+      - name: Integ ${{ matrix.cluster }} secured=${{ matrix.secured }} version=${{matrix.entry.opensearch_version}}
+        run: "./.ci/run-tests ${{ matrix.cluster }} ${{ matrix.secured }} ${{ matrix.entry.opensearch_version }}"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,13 +11,10 @@ jobs:
       matrix:
         cluster: ["opensearch"]
         secured: ["true", "false"]
-        opensearch_version: [""]
+        opensearch_version: [1.0.0, 1.0.1, 1.1.0, 1.2.0, 1.2.1, 1.2.2, 1.2.3, 1.2.4, 1.3.0, 1.3.1]
 
     steps:
       - name: Checkout
-        if: ${{ matrix.opensearch_version != ''}}
         uses: actions/checkout@v2
-
       - name: Integ ${{ matrix.cluster }} secured=${{ matrix.secured }} version=${{matrix.opensearch_version}}
-        if: ${{ matrix.opensearch_version != ''}}
         run: "./.ci/run-tests ${{ matrix.cluster }} ${{ matrix.secured }} ${{ matrix.opensearch_version }}"

--- a/test_opensearchpy/test_async/test_server/test_helpers.py
+++ b/test_opensearchpy/test_async/test_server/test_helpers.py
@@ -872,28 +872,11 @@ class TestParentChildReindex:
     ):
         await helpers.async_reindex(async_client, "test-index", "real-index")
 
-        q = await async_client.get(index="real-index", id=42)
-        assert {
-            "_id": "42",
-            "_index": "real-index",
-            "_primary_term": 1,
-            "_seq_no": 0,
-            "_source": {"question_answer": "question"},
-            "_version": 1,
-            "found": True,
-        } == q
+        assert {"question_answer": "question"} == (
+            await async_client.get(index="real-index", id=42)
+        )["_source"]
 
-        q = await async_client.get(index="test-index", id=47, routing=42)
         assert {
-            "_routing": "42",
-            "_id": "47",
-            "_index": "test-index",
-            "_primary_term": 1,
-            "_seq_no": 1,
-            "_source": {
-                "some": "data",
-                "question_answer": {"name": "answer", "parent": 42},
-            },
-            "_version": 1,
-            "found": True,
-        } == q
+            "some": "data",
+            "question_answer": {"name": "answer", "parent": 42},
+        } == (await async_client.get(index="test-index", id=47, routing=42))["_source"]

--- a/test_opensearchpy/test_server/test_helpers.py
+++ b/test_opensearchpy/test_server/test_helpers.py
@@ -738,33 +738,12 @@ class TestParentChildReindex(OpenSearchTestCase):
     def test_children_are_reindexed_correctly(self):
         helpers.reindex(self.client, "test-index", "real-index")
 
-        q = self.client.get(index="real-index", id=42)
         self.assertEqual(
-            {
-                "_id": "42",
-                "_index": "real-index",
-                "_primary_term": 1,
-                "_seq_no": 0,
-                "_source": {"question_answer": "question"},
-                "_version": 1,
-                "found": True,
-            },
-            q,
+            {"question_answer": "question"},
+            self.client.get(index="real-index", id=42)["_source"],
         )
-        q = self.client.get(index="test-index", id=47, routing=42)
+
         self.assertEqual(
-            {
-                "_routing": "42",
-                "_id": "47",
-                "_index": "test-index",
-                "_primary_term": 1,
-                "_seq_no": 1,
-                "_source": {
-                    "some": "data",
-                    "question_answer": {"name": "answer", "parent": 42},
-                },
-                "_version": 1,
-                "found": True,
-            },
-            q,
+            {"some": "data", "question_answer": {"name": "answer", "parent": 42}},
+            self.client.get(index="test-index", id=47, routing=42)["_source"],
         )


### PR DESCRIPTION
### Description
Re-enabling integration tests across 1.x versions of OpenSearch to show that the new version of the client works against OpenSearch 1.x.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
