### PR TITLE
Bump client version to 2.0.0

### DIFF
--- a/.github/workflows/integration-unreleased.yml
+++ b/.github/workflows/integration-unreleased.yml
@@ -1,25 +1,24 @@
 name: Integration with Unreleased OpenSearch
 
-on:
-  push:
-    branches:
-      - "main"
-  pull_request:
-    branches:
-      - "main"
-
-env:
-  OPENSEARCH_VERSION: '2.0'
+on: [push, pull_request]
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        entry:
+          - { opensearch_ref: '1.x' }
+          - { opensearch_ref: '2.0' }
+          - { opensearch_ref: '2.x' }
+          - { opensearch_ref: 'main' }
     steps:
       - name: Checkout OpenSearch
         uses: actions/checkout@v2
         with:
           repository: opensearch-project/opensearch
-          ref: ${{ env.OPENSEARCH_VERSION }}
+          ref: ${{ matrix.entry.opensearch_ref }}
           path: opensearch
 
         # This step builds the docker image tagged as opensearch:test. It will be further used in /ci/run-tests to test against unreleased OpenSearch.
@@ -28,8 +27,9 @@ jobs:
         run: |
           cd opensearch
           ./gradlew assemble
+
       - name: Checkout Python Client
         uses: actions/checkout@v2
 
       - name: Run Integration Test
-        run: "./.ci/run-tests opensearch false ${{ env.OPENSEARCH_VERSION }}.0-SNAPSHOT"
+        run: "./.ci/run-tests opensearch false SNAPSHOT"

--- a/.github/workflows/unified-release.yml
+++ b/.github/workflows/unified-release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack_version: ['1.1.0']
+        stack_version: ['2.0.0']
 
     steps:
       - name: Checkout

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,4 +1,5 @@
 - [Compatibility with OpenSearch](#compatibility-with-opensearch)
+- [Upgrading](#upgrading)
 
 ## Compatibility with OpenSearch
 
@@ -16,3 +17,8 @@ The below matrix shows the compatibility of the [`opensearch-py`](https://pypi.o
 | 1.2.4 | 1.0.0 |
 | 1.3.0 | 1.1.0 |
 | 1.3.1 | 1.1.0 |
+| 2.0.0 | 2.0.0 |
+
+## Upgrading
+
+Major versions of OpenSearch introduce breaking changes that require careful upgrades of the client. While `opensearch-py-client` 2.0.0 works against OpenSearch 1.3.1, certain deprecated features removed in OpenSearch 2.0 have also been removed from the client. Please refer to the [OpenSearch documentation](https://opensearch.org/docs/latest/clients/index/) for more information.

--- a/opensearchpy/_version.py
+++ b/opensearchpy/_version.py
@@ -24,4 +24,4 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-__versionstr__ = "1.1.0"
+__versionstr__ = "2.0.0"


### PR DESCRIPTION
### Description
Bumping the client version to 2.0.0. Also adding more unreleased branches to test against in the test workflow.

### Issues Resolved
Part of #166 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
