### PR TITLE
Update readme to mention the high-level python client already available

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ OpenSearch Python Client
 of elasticsearch-py licensed under the [Apache v2.0 License](https://github.com/opensearch-project/opensearch-py/blob/main/LICENSE.txt). 
 For more information, see [opensearch.org](https://opensearch.org/) and the [API Doc](https://opensearch-project.github.io/opensearch-py/).
 
-This is the low-level client. A high-level Python client is in the works, and will be available soon.
+This is the low-level client. A high-level Python client is available here [opensearch-dsl-py](https://github.com/opensearch-project/opensearch-dsl-py).
 
 ## Getting Started
 


### PR DESCRIPTION
### Description
The README file is outdated, it still mentions the high-level python client to be available soon. While as per this https://github.com/opensearch-project/opensearch-py/issues/50 [opensearch-dsl-py](https://github.com/opensearch-project/opensearch-dsl-py) is already released

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
