### PR TITLE
Adding Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+updates:
+  - directory: /
+    open-pull-requests-limit: 3
+    package-ecosystem: pip
+    schedule:
+      interval: weekly
+version: 2


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Add Dependabot configuration to keep dependencies up-to-date.

It has opened PRs on my fork: https://github.com/VachaShah/opensearch-py/pulls

### Issues Resolved
As part of https://github.com/opensearch-project/opensearch-clients/issues/11

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
