### PR TITLE
Adds various client docs within Opensearch client

### DIFF
--- a/docs/source/api-ref.md
+++ b/docs/source/api-ref.md
@@ -7,5 +7,6 @@ titlesonly:
 maxdepth: 2
 ---
 
+api-ref/client
 api-ref/*
 ```

--- a/docs/source/api-ref/client.md
+++ b/docs/source/api-ref/client.md
@@ -1,5 +1,34 @@
-# client
+# Clients
 
-```{eval-rst}
-.. autoclass:: opensearchpy.OpenSearch
+```{toctree}
+---
+glob:
+titlesonly:
+maxdepth: 1
+---
+
+clients/opensearch_client
+```
+
+## Clients within Opensearch
+
+OpenSearch Client includes several clients:
+
+```{toctree}
+---
+glob:
+titlesonly:
+maxdepth: 1
+---
+
+clients/cat_client
+clients/cluster_client
+clients/dangling_indices_client
+clients/ingest_client
+clients/indices_client
+clients/nodes_client
+clients/remote_client
+clients/snapshot_client
+clients/tasks_client
+clients/features_client
 ```

--- a/docs/source/api-ref/clients/cat_client.md
+++ b/docs/source/api-ref/clients/cat_client.md
@@ -1,0 +1,5 @@
+# Compact and aligned text (CAT) Client
+
+```{eval-rst}
+.. autoclass:: opensearchpy.client.cat.CatClient
+```

--- a/docs/source/api-ref/clients/cluster_client.md
+++ b/docs/source/api-ref/clients/cluster_client.md
@@ -1,0 +1,5 @@
+# Cluster Client
+
+```{eval-rst}
+.. autoclass:: opensearchpy.client.cluster.ClusterClient
+```

--- a/docs/source/api-ref/clients/dangling_indices_client.md
+++ b/docs/source/api-ref/clients/dangling_indices_client.md
@@ -1,0 +1,5 @@
+# Dangling Indices Client
+
+```{eval-rst}
+.. autoclass:: opensearchpy.client.dangling_indices.DanglingIndicesClient
+```

--- a/docs/source/api-ref/clients/features_client.md
+++ b/docs/source/api-ref/clients/features_client.md
@@ -1,0 +1,5 @@
+# Features Client
+
+```{eval-rst}
+.. autoclass:: opensearchpy.client.features.FeaturesClient
+```

--- a/docs/source/api-ref/clients/indices_client.md
+++ b/docs/source/api-ref/clients/indices_client.md
@@ -1,0 +1,5 @@
+# Indices Client
+
+```{eval-rst}
+.. autoclass:: opensearchpy.client.indices.IndicesClient
+```

--- a/docs/source/api-ref/clients/ingest_client.md
+++ b/docs/source/api-ref/clients/ingest_client.md
@@ -1,0 +1,5 @@
+# Ingest Client
+
+```{eval-rst}
+.. autoclass:: opensearchpy.client.ingest.IngestClient
+```

--- a/docs/source/api-ref/clients/nodes_client.md
+++ b/docs/source/api-ref/clients/nodes_client.md
@@ -1,0 +1,5 @@
+# Nodes Client
+
+```{eval-rst}
+.. autoclass:: opensearchpy.client.nodes.NodesClient
+```

--- a/docs/source/api-ref/clients/opensearch_client.md
+++ b/docs/source/api-ref/clients/opensearch_client.md
@@ -1,0 +1,5 @@
+# OpenSearch Client
+
+```{eval-rst}
+.. autoclass:: opensearchpy.OpenSearch
+```

--- a/docs/source/api-ref/clients/remote_client.md
+++ b/docs/source/api-ref/clients/remote_client.md
@@ -1,0 +1,5 @@
+# Remote Client
+
+```{eval-rst}
+.. autoclass:: opensearchpy.client.remote.RemoteClient
+```

--- a/docs/source/api-ref/clients/snapshot_client.md
+++ b/docs/source/api-ref/clients/snapshot_client.md
@@ -1,0 +1,5 @@
+# Snapshot Client
+
+```{eval-rst}
+.. autoclass:: opensearchpy.client.snapshot.SnapshotClient
+```

--- a/docs/source/api-ref/clients/tasks_client.md
+++ b/docs/source/api-ref/clients/tasks_client.md
@@ -1,0 +1,5 @@
+# Tasks Client
+
+```{eval-rst}
+.. autoclass:: opensearchpy.client.tasks.TasksClient
+```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,6 +1,7 @@
 # OpenSearch Python Client Documentation
 
 ## Table of Contents
+
 ```{toctree}
 ---
 maxdepth: 1
@@ -16,4 +17,5 @@ GitHub Repository <https://github.com/opensearch-project/opensearch-py>
 ```
 
 ```{include} README.md
+
 ```


### PR DESCRIPTION
### Description
This PR adds documentation to Sphinx for the clients within the Opensearch client. To include this, the docs were slightly restructured.

### Issues Resolved
Addresses #171 by adding docs for clients included within the Opensearch client.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
