### PR TITLE
Added timeout to available input query parameters

### DIFF
--- a/opensearchpy/transport.py
+++ b/opensearchpy/transport.py
@@ -454,6 +454,8 @@ class Transport(object):
         timeout = None
         if params:
             timeout = params.pop("request_timeout", None)
+            if not timeout:
+                timeout = params.pop("timeout", None)
             ignore = params.pop("ignore", ())
             if isinstance(ignore, int):
                 ignore = (ignore,)

--- a/test_opensearchpy/test_async/test_transport.py
+++ b/test_opensearchpy/test_async/test_transport.py
@@ -139,6 +139,18 @@ class TestTransport:
             "headers": None,
         } == t.get_connection().calls[0][1]
 
+    async def test_timeout_extracted_from_params_and_passed(self):
+        t = AsyncTransport([{}], connection_class=DummyConnection)
+
+        await t.perform_request("GET", "/", params={"timeout": 84})
+        assert 1 == len(t.get_connection().calls)
+        assert ("GET", "/", {}, None) == t.get_connection().calls[0][0]
+        assert {
+            "timeout": 84,
+            "ignore": (),
+            "headers": None,
+        } == t.get_connection().calls[0][1]
+
     async def test_opaque_id(self):
         t = AsyncTransport([{}], opaque_id="app-1", connection_class=DummyConnection)
 

--- a/test_opensearchpy/test_transport.py
+++ b/test_opensearchpy/test_transport.py
@@ -141,6 +141,17 @@ class TestTransport(TestCase):
             t.get_connection().calls[0][1],
         )
 
+    def test_timeout_extracted_from_params_and_passed(self):
+        t = Transport([{}], connection_class=DummyConnection)
+
+        t.perform_request("GET", "/", params={"timeout": 84})
+        self.assertEqual(1, len(t.get_connection().calls))
+        self.assertEqual(("GET", "/", {}, None), t.get_connection().calls[0][0])
+        self.assertEqual(
+            {"timeout": 84, "ignore": (), "headers": None},
+            t.get_connection().calls[0][1],
+        )
+
     def test_opaque_id(self):
         t = Transport([{}], opaque_id="app-1", connection_class=DummyConnection)
 


### PR DESCRIPTION
Signed-off-by: Harsha Vamsi Kalluri <harshavamsi096@gmail.com>

### Description
Fixes the timeout query parameter to allow for not just `request_timeout` but also `timeout` like the examples say.

### Issues Resolved
Fixes #209 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
