### PR TITLE
Renaming Getting started to User guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added Point in time API rest API([#191](https://github.com/opensearch-project/opensearch-py/pull/191))
 - Github workflow for changelog verification ([#218](https://github.com/opensearch-project/opensearch-py/pull/218))
 ### Changed
-- Renaming Get started to User guide 
+- Renaming Get started to User guide([#230](https://github.com/opensearch-project/opensearch-py/pull/230) )
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added Point in time API rest API([#191](https://github.com/opensearch-project/opensearch-py/pull/191))
 - Github workflow for changelog verification ([#218](https://github.com/opensearch-project/opensearch-py/pull/218))
 ### Changed
-
+- Renaming Get started to User guide 
 ### Deprecated
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ For more information, see [opensearch.org](https://opensearch.org/) and the [API
 
 This is the low-level client. A high-level Python client is in the works, and will be available soon.
 
-## Getting Started
+## User guide
 
-To get started with the OpenSearch Python Client, see [Getting Started](https://github.com/opensearch-project/opensearch-py/blob/main/GETTING_STARTED.md).
+For User guide of OpenSearch Python Client, see [User guide](https://github.com/opensearch-project/opensearch-py/blob/main/USER_GUIDE.md).
 
 ## Compatibility with OpenSearch
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,4 +1,4 @@
-- [Getting Started with the OpenSearch Python Client](#getting-started-with-the-opensearch-python-client)
+- [User guide of OpenSearch Python Client](#user-guide-of-opensearch-python-client)
   - [Setup](#setup)
   - [Sample code](#sample-code)
     - [Creating a client](#creating-a-client)


### PR DESCRIPTION
- Renamed from Getting started to User guide.

- Updated USER_GUIDE.md

- Updated CHANGELOG.md

- Updated README.md

Signed-off-by: Sai Medhini Reddy Maryada <saimedhi@amazon.com>

### Description
_Describe what this change achieves._
This change is made to follow documentation convention

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 
Closes[[FEATURE] Rename GETTIING_STARTED to USER_GUIDE #227]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Sai Medhini Reddy Maryada <saimedhi@amazon.com>
