### PR TITLE
Fix DeprecationWarning raised by urllib3 1.26.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
-
+- Fixed DeprecationWarning emitted from urllib3 1.26.13+ ([#246](https://github.com/opensearch-project/opensearch-py/pull/246))
 ### Security
 
 

--- a/opensearchpy/connection/http_urllib3.py
+++ b/opensearchpy/connection/http_urllib3.py
@@ -273,7 +273,7 @@ class Urllib3HttpConnection(Connection):
             method, full_url, url, orig_body, response.status, raw_data, duration
         )
 
-        return response.status, response.getheaders(), raw_data
+        return response.status, response.headers, raw_data
 
     def get_response_headers(self, response):
         return {header.lower(): value for header, value in response.headers.items()}


### PR DESCRIPTION
### Description
urllib3 has started to emit a DeprecationWarning whenever HTTPResponse.getheaders() is called since version 1.26.13.

This changes the one place where this is done to instead use HTTPResponse.headers instead, which is the recommend way of retrieving the headers going forwards.

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).