### PR TITLE
Removed patch versions in integration tests for OpenSearch 1.0.0-2.3.0 to reduce Github Action jobs            

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,22 +11,12 @@ jobs:
       matrix:
         secured: ["true", "false"]
         entry:
-          - { opensearch_version: 1.0.0 }
           - { opensearch_version: 1.0.1 }
           - { opensearch_version: 1.1.0 }
-          - { opensearch_version: 1.2.0 }
-          - { opensearch_version: 1.2.1 }
-          - { opensearch_version: 1.2.2 }
-          - { opensearch_version: 1.2.3 }
           - { opensearch_version: 1.2.4 }
-          - { opensearch_version: 1.3.0 }
-          - { opensearch_version: 1.3.1 }
-          - { opensearch_version: 1.3.2 }
-          - { opensearch_version: 1.3.3 }
-          - { opensearch_version: 2.0.0 }
+          - { opensearch_version: 1.3.7 }
           - { opensearch_version: 2.0.1 }
           - { opensearch_version: 2.1.0 }
-          - { opensearch_version: 2.2.0 }
           - { opensearch_version: 2.2.1 }
           - { opensearch_version: 2.3.0 }
           - { opensearch_version: 2.4.0 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 
 ### Removed
-
+- Removed patch versions in integration tests for OpenSearch 1.0.0 - 2.3.0 to reduce Github Action jobs ([#262](https://github.com/opensearch-project/opensearch-py/pull/262))
 ### Fixed
 - Fixed DeprecationWarning emitted from urllib3 1.26.13+ ([#246](https://github.com/opensearch-project/opensearch-py/pull/246))
 ### Security


### PR DESCRIPTION

Signed-off-by: saimedhi <saimedhi@amazon.com>

### Description
Removed patch versions in integration tests for OpenSearch 1.0.0 - 2.3.0 to reduce Github Action jobs

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
