### PR TITLE
Fixes opensearch URL for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install -r dev-requirements.txt
+      - name: 'Setup: OpenSearch environment'
+        run: echo "OPENSEARCH_URL=http://localhost:9200" >> $GITHUB_ENV
       - name: Run Tests
         run: |
           python setup.py test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed patch versions in integration tests for OpenSearch 1.0.0 - 2.3.0 to reduce Github Action jobs ([#262](https://github.com/opensearch-project/opensearch-py/pull/262))
 ### Fixed
 - Fixed DeprecationWarning emitted from urllib3 1.26.13+ ([#246](https://github.com/opensearch-project/opensearch-py/pull/246))
+- Fixed OpenSearch port in github workflows ([#266](https://github.com/opensearch-project/opensearch-py/pull/266))
 ### Security
 
 


### PR DESCRIPTION
Signed-off-by: Harsha Vamsi Kalluri <harshavamsi096@gmail.com>

### Description
Appends OpenSearch URL to env variables before running unit tests.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
