### PR TITLE
Make doc_type optional parameter to .index() operation.

### DIFF
--- a/opensearchpy/client/__init__.py
+++ b/opensearchpy/client/__init__.py
@@ -310,13 +310,14 @@ class OpenSearch(object):
         "version_type",
         "wait_for_active_shards",
     )
-    def index(self, index, body, id=None, params=None, headers=None):
+    def index(self, index, body, doc_type="_doc", id=None, params=None, headers=None):
         """
         Creates or overwrites a document in an index.
 
 
         :arg index: The name of the index
         :arg body: The document
+        :arg doc_type: The document type
         :arg id: Document ID
         :arg if_primary_term: only perform the index operation if the
             last operation that has changed the document has the specified primary
@@ -349,8 +350,6 @@ class OpenSearch(object):
         for param in (index, body):
             if param in SKIP_IN_PATH:
                 raise ValueError("Empty value passed for a required argument.")
-
-        doc_type = "_doc"
 
         return self.transport.perform_request(
             "POST" if id in SKIP_IN_PATH else "PUT",


### PR DESCRIPTION
Make doc_type an optional parameter

### Description
Allows the user to define the _type parameter of the document when performing the .index() operation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
