### PR TITLE
Fixed CVE - issue 86 mentioned in opensearch-dsl-py repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fixed SigV4 Signing for Managed Service ([#279](https://github.com/opensearch-project/opensearch-py/pull/279))
 - Fixed SigV4 Signing for Async Requests with QueryStrings ([#272](https://github.com/opensearch-project/opensearch-py/pull/279))
+- Fixed CVE - issue 86 mentioned in opensearch-dsl-py repo ([#295](https://github.com/opensearch-project/opensearch-py/pull/295))
 ### Security
 
 ## [2.1.0]

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ packages = [
 ]
 install_requires = [
     "urllib3>=1.21.1, <2",
-    "certifi",
     "requests>=2.4.0, <3.0.0",
     "six",
     "python-dateutil",
@@ -70,6 +69,8 @@ tests_require = [
 ]
 if sys.version_info >= (3, 6):
     tests_require.append("pytest-mock<4.0.0")
+    install_requires.append("certifi>=2022.12.07")
+
 async_require = ["aiohttp>=3,<4"]
 
 docs_require = ["sphinx", "sphinx_rtd_theme", "myst_parser", "sphinx_copybutton"]


### PR DESCRIPTION
### Description
Fixed CVE - issue 86 mentioned in opensearch-dsl-py repo

Closes https://github.com/opensearch-project/opensearch-dsl-py/issues/86

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
