### PR TITLE
Fix async client without http auth

### DIFF
--- a/opensearchpy/connection/http_async.py
+++ b/opensearchpy/connection/http_async.py
@@ -190,10 +190,8 @@ class AsyncHttpConnection(AIOHttpConnection):
             body = self._gzip_compress(body)
             req_headers["content-encoding"] = "gzip"
 
-        req_headers = {
-            **req_headers,
-            **self._http_auth(method, url, query_string, body),
-        }
+        if self._http_auth is not None:
+            req_headers.update(**self._http_auth(method, url, query_string, body))
 
         start = self.loop.time()
         try:


### PR DESCRIPTION
### Description
Fix for async connection that is used without http auth

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-py/issues/283

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
