### PR TITLE
Fix async client without http auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+## [2.1.2]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Fixed Async Client without http_auth argument ([#297](https://github.com/opensearch-project/opensearch-py/pull/297))
+### Security
 
 ## [2.1.1]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
-## [2.1.2]
+## [Unreleased]
 ### Added
 ### Changed
 ### Deprecated

--- a/opensearchpy/connection/http_async.py
+++ b/opensearchpy/connection/http_async.py
@@ -190,10 +190,8 @@ class AsyncHttpConnection(AIOHttpConnection):
             body = self._gzip_compress(body)
             req_headers["content-encoding"] = "gzip"
 
-        req_headers = {
-            **req_headers,
-            **self._http_auth(method, url, query_string, body),
-        }
+        if self._http_auth is not None:
+            req_headers.update(**self._http_auth(method, url, query_string, body))
 
         start = self.loop.time()
         try:

--- a/test_opensearchpy/test_async/test_connection.py
+++ b/test_opensearchpy/test_async/test_connection.py
@@ -38,7 +38,7 @@ import pytest
 from mock import patch
 from multidict import CIMultiDict
 
-from opensearchpy import AIOHttpConnection, __versionstr__
+from opensearchpy import AIOHttpConnection, AsyncHttpConnection, __versionstr__
 from opensearchpy.compat import reraise_exceptions
 from opensearchpy.connection import Connection
 from opensearchpy.exceptions import ConnectionError
@@ -371,5 +371,82 @@ class TestConnectionHttpbin:
 
     async def test_aiohttp_connection_error(self):
         conn = AIOHttpConnection("not.a.host.name")
+        with pytest.raises(ConnectionError):
+            await conn.perform_request("GET", "/")
+
+
+# TODO: add mock tests for AsyncHttpConnection as well (similar to TestAIOHttpConnection class)
+class TestAsyncConnectionHttpbin:
+    async def httpbin_anything(self, conn, **kwargs):
+        status, headers, data = await conn.perform_request("GET", "/anything", **kwargs)
+        data = json.loads(data)
+        data["headers"].pop(
+            "X-Amzn-Trace-Id", None
+        )  # Remove this header as it's put there by AWS.
+        return (status, data)
+
+
+    async def test_async_connection(self):
+        # Defaults
+        conn = AsyncHttpConnection("httpbin.org", port=443, use_ssl=True)
+        user_agent = conn._get_default_user_agent()
+        status, data = await self.httpbin_anything(conn)
+        assert status == 200
+        assert data["method"] == "GET"
+        assert data["headers"] == {
+            "Content-Type": "application/json",
+            "Host": "httpbin.org",
+            "User-Agent": user_agent,
+        }
+
+        # http_compress=False
+        conn = AsyncHttpConnection(
+            "httpbin.org", port=443, use_ssl=True, http_compress=False
+        )
+        status, data = await self.httpbin_anything(conn)
+        assert status == 200
+        assert data["method"] == "GET"
+        assert data["headers"] == {
+            "Content-Type": "application/json",
+            "Host": "httpbin.org",
+            "User-Agent": user_agent,
+        }
+
+        # http_compress=True
+        conn = AsyncHttpConnection(
+            "httpbin.org", port=443, use_ssl=True, http_compress=True
+        )
+        status, data = await self.httpbin_anything(conn)
+        assert status == 200
+        assert data["headers"] == {
+            "Accept-Encoding": "gzip,deflate",
+            "Content-Type": "application/json",
+            "Host": "httpbin.org",
+            "User-Agent": user_agent,
+        }
+
+        # Headers
+        conn = AsyncHttpConnection(
+            "httpbin.org",
+            port=443,
+            use_ssl=True,
+            http_compress=True,
+            headers={"header1": "value1"},
+        )
+        status, data = await self.httpbin_anything(
+            conn, headers={"header2": "value2", "header1": "override!"}
+        )
+        assert status == 200
+        assert data["headers"] == {
+            "Accept-Encoding": "gzip,deflate",
+            "Content-Type": "application/json",
+            "Host": "httpbin.org",
+            "Header1": "override!",
+            "Header2": "value2",
+            "User-Agent": user_agent,
+        }
+
+    async def test_aiohttp_connection_error(self):
+        conn = AsyncHttpConnection("not.a.host.name")
         with pytest.raises(ConnectionError):
             await conn.perform_request("GET", "/")


### PR DESCRIPTION
### Description
Fix for async connection that is used without http auth

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-py/issues/283

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
