### PR TITLE
Removing low-level and high-level client terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ OpenSearch Python Client
 of elasticsearch-py licensed under the [Apache v2.0 License](https://github.com/opensearch-project/opensearch-py/blob/main/LICENSE.txt). 
 For more information, see [opensearch.org](https://opensearch.org/) and the [API Doc](https://opensearch-project.github.io/opensearch-py/).
 
-This is the low-level client. A high-level Python client is in the works, and will be available soon.
-
 ## User Guide
 
 To get started with the OpenSearch Python Client, see [User Guide](https://github.com/opensearch-project/opensearch-py/blob/main/USER_GUIDE.md).

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -11,7 +11,7 @@
     - [Deleting an index](#deleting-an-index)
   - [Making API calls](#making-api-calls)
     - [Point in time API](#point-in-time-api)
-  - [Using High-level Python client](#using-high-level-python-client)
+  - [Using DSL features from opensearch-dsl-py](#using-dsl-features-from-opensearch-dsl-py)
     - [Searching for documents with filters](#searching-for-documents-with-filters)
   - [Using plugins](#using-plugins)
     - [Alerting plugin](#alerting-plugin)
@@ -230,12 +230,12 @@ print('\n The deleted point in time:')
 print(response)
 ```
 
-## Using High-level Python client
-High-level python client is now merged into Low-level python client. Thus, opensearch-py supports creating and indexing documents, searching with and without filters, and updating documents using queries.[High-level Python client documentation](https://opensearch.org/docs/latest/clients/python-high-level/).
+## Using DSL features from opensearch-dsl-py
+opensearch-dsl-py client is now merged into the opensearch-py client. Thus, opensearch-py supports creating and indexing documents, searching with and without filters, and updating documents using queries. See [opensearch-dsl-py client documentation](https://opensearch.org/docs/latest/clients/python-high-level/) for details.
 
 All the APIs newly added from opensearch-dsl-py are listed in [docs](https://github.com/opensearch-project/opensearch-py/tree/main/docs/source/api-ref). 
 
-In the below example, 'Search' API from High-level Python Client is used. 
+In the below example, [Search API](https://github.com/opensearch-project/opensearch-py/blob/main/opensearchpy/helpers/search.py) from opensearch-dsl-py client is used. 
 
 ### Searching for documents with filters
 

--- a/opensearchpy/_async/client/__init__.py
+++ b/opensearchpy/_async/client/__init__.py
@@ -48,7 +48,7 @@ logger = logging.getLogger("opensearch")
 
 class AsyncOpenSearch(object):
     """
-    OpenSearch low-level client. Provides a straightforward mapping from
+    OpenSearch client. Provides a straightforward mapping from
     Python to OpenSearch REST endpoints.
 
     The instance has attributes ``cat``, ``cluster``, ``indices``, ``ingest``,

--- a/opensearchpy/client/__init__.py
+++ b/opensearchpy/client/__init__.py
@@ -49,7 +49,7 @@ logger = logging.getLogger("opensearch")
 
 class OpenSearch(object):
     """
-    OpenSearch low-level client. Provides a straightforward mapping from
+    OpenSearch client. Provides a straightforward mapping from
     Python to OpenSearch REST endpoints.
 
     The instance has attributes ``cat``, ``cluster``, ``indices``, ``ingest``,


### PR DESCRIPTION
### Description
Removing low-level and high-level client terminology from guides.

### Issues Resolved
Closes #117 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
