### PR TITLE
fix hosts specification to parent Transport class from AsyncTransport

### DIFF
--- a/opensearchpy/_async/transport.py
+++ b/opensearchpy/_async/transport.py
@@ -120,11 +120,7 @@ class AsyncTransport(Transport):
 
 
         super(AsyncTransport, self).__init__(
-            hosts=self.__ensure_compatability_with_legacy_test_cases(
-                hosts=hosts,
-                connection_class=connection_class,
-                connection_pool_class=connection_pool_class,
-            ),
+            hosts=[],
             connection_class=connection_class,
             connection_pool_class=connection_pool_class,
             host_info_callback=host_info_callback,
@@ -148,29 +144,6 @@ class AsyncTransport(Transport):
         self.hosts = hosts
         self.sniff_on_start = sniff_on_start
 
-    def __ensure_compatability_with_legacy_test_cases(
-            self,
-            hosts,
-            connection_class,
-            connection_pool_class) -> list:
-        """
-        Function required for ensuring compatability with legacy test cases
-
-        Args:
-        param: hosts: specified host paramters
-        param: connection_class: specified connection class
-        param: connection_pool_class: specified connection pool class
-
-        Returns:
-        list: list of hosts parameters
-        """
-        has_many_hosts = len(hosts) > 0
-        is_aiohttp_conn = isinstance(connection_class, AIOHttpConnection)
-        is_connection_pool = isinstance(connection_pool_class, ConnectionPool)
-        output = self.DEFAULT_HOSTS_PARENT_CLASS_ARG
-        if is_connection_pool and is_aiohttp_conn and has_many_hosts:
-            output = hosts
-        return output
 
     async def _async_init(self):
         """This is our stand-in for an async constructor. Everything

--- a/opensearchpy/_async/transport.py
+++ b/opensearchpy/_async/transport.py
@@ -30,6 +30,7 @@ import logging
 import sys
 from itertools import chain
 
+from .http_aiohttp import AIOHttpConnection
 from ..connection_pool import ConnectionPool
 from ..exceptions import (
     ConnectionError,
@@ -54,6 +55,7 @@ class AsyncTransport(Transport):
     """
 
     DEFAULT_CONNECTION_CLASS = AIOHttpConnection
+    DEFAULT_HOSTS_PARENT_CLASS_ARG = []
 
     def __init__(
         self,
@@ -116,8 +118,13 @@ class AsyncTransport(Transport):
         self._async_init_called = False
         self._sniff_on_start_event = None  # type: asyncio.Event
 
+
         super(AsyncTransport, self).__init__(
-            hosts=[],
+            hosts=self.__ensure_compatability_with_legacy_test_cases(
+                hosts=hosts,
+                connection_class=connection_class,
+                connection_pool_class=connection_pool_class,
+            ),
             connection_class=connection_class,
             connection_pool_class=connection_pool_class,
             host_info_callback=host_info_callback,
@@ -140,6 +147,30 @@ class AsyncTransport(Transport):
         # our parent to 'sniff_on_start' or non-empty 'hosts'.
         self.hosts = hosts
         self.sniff_on_start = sniff_on_start
+
+    def __ensure_compatability_with_legacy_test_cases(
+            self,
+            hosts,
+            connection_class,
+            connection_pool_class) -> list:
+        """
+        Function required for ensuring compatability with legacy test cases
+
+        Args:
+        param: hosts: specified host paramters
+        param: connection_class: specified connection class
+        param: connection_pool_class: specified connection pool class
+
+        Returns:
+        list: list of hosts parameters
+        """
+        has_many_hosts = len(hosts) > 0
+        is_aiohttp_conn = isinstance(connection_class, AIOHttpConnection)
+        is_connection_pool = isinstance(connection_pool_class, ConnectionPool)
+        output = self.DEFAULT_HOSTS_PARENT_CLASS_ARG
+        if is_connection_pool and is_aiohttp_conn and has_many_hosts:
+            output = hosts
+        return output
 
     async def _async_init(self):
         """This is our stand-in for an async constructor. Everything

--- a/opensearchpy/_async/transport.py
+++ b/opensearchpy/_async/transport.py
@@ -30,7 +30,6 @@ import logging
 import sys
 from itertools import chain
 
-from .http_aiohttp import AIOHttpConnection
 from ..connection_pool import ConnectionPool
 from ..exceptions import (
     ConnectionError,
@@ -118,7 +117,6 @@ class AsyncTransport(Transport):
         self._async_init_called = False
         self._sniff_on_start_event = None  # type: asyncio.Event
 
-
         super(AsyncTransport, self).__init__(
             hosts=[],
             connection_class=connection_class,
@@ -143,7 +141,6 @@ class AsyncTransport(Transport):
         # our parent to 'sniff_on_start' or non-empty 'hosts'.
         self.hosts = hosts
         self.sniff_on_start = sniff_on_start
-
 
     async def _async_init(self):
         """This is our stand-in for an async constructor. Everything

--- a/test_opensearchpy/test_async/test_transport.py
+++ b/test_opensearchpy/test_async/test_transport.py
@@ -34,9 +34,7 @@ import json
 import pytest
 from mock import patch
 
-from opensearchpy import AIOHttpConnection
-from opensearchpy import AsyncTransport
-from opensearchpy import ConnectionPool
+from opensearchpy import AIOHttpConnection, AsyncTransport
 from opensearchpy.connection import Connection
 from opensearchpy.connection_pool import DummyConnectionPool
 from opensearchpy.exceptions import ConnectionError, TransportError
@@ -550,6 +548,14 @@ class TestTransport:
         assert len(t.connection_pool.connections) == amt_connection
 
     async def test_init_connection_pool_with_many_hosts(self):
+        """
+        Check init of connection pool with multiple connections.
+
+        NOTE: since AsyncTransport performs internal hosts sniffing
+        after building a connection the actual init of connection_class
+        instances is reallocated from AsyncTransport.__init__()
+        to AsyncTransport._async_init
+        """
         amt_hosts = 4
         hosts = [{"host": "localhost", "port": 9092}] * amt_hosts
         t = AsyncTransport(
@@ -563,6 +569,14 @@ class TestTransport:
         await t._async_call()
 
     async def test_init_pool_with_connection_class_to_many_hosts(self):
+        """
+        Check init of connection pool with user specified connection_class.
+
+        NOTE: since AsyncTransport performs internal hosts sniffing
+        after building a connection the actual init of connection_class
+        instances is reallocated from AsyncTransport.__init__()
+        to AsyncTransport._async_init
+        """
         amt_hosts = 4
         hosts = [{"host": "localhost", "port": 9092}] * amt_hosts
         t = AsyncTransport(
@@ -578,4 +592,3 @@ class TestTransport:
             t.connection_pool.connections[0],
             AIOHttpConnection,
         )
-        

--- a/test_opensearchpy/test_async/test_transport.py
+++ b/test_opensearchpy/test_async/test_transport.py
@@ -547,10 +547,7 @@ class TestTransport:
         assert duration < 1
 
     def __assure_connection_pool_create(self, t: AsyncTransport, amt_connection):
-        assert (
-            len(t.connection_pool.connections) == amt_connection,
-            "Pool of connections must be created"
-        )
+        assert len(t.connection_pool.connections) == amt_connection
 
     async def test_init_connection_pool_with_many_hosts(self):
         amt_hosts = 4
@@ -558,23 +555,25 @@ class TestTransport:
         t = AsyncTransport(
             hosts=hosts,
         )
-        self.__assure_connection_pool_create(
-            t=t,
-            amt_connection=amt_hosts,
-        )
-
-    async def test_init_pool_with_connection_class_to_many_hosts(self):
-        amt_hosts = 4
-        hosts = [{"host": "localhost", "port": 9092}]
-        t = AsyncTransport(
-            hosts=hosts,
-            connection_class=AIOHttpConnection,
-        )
+        await t._async_init()
         self.__assure_connection_pool_create(
             t=t,
             amt_connection=amt_hosts,
         )
         await t._async_call()
+
+    async def test_init_pool_with_connection_class_to_many_hosts(self):
+        amt_hosts = 4
+        hosts = [{"host": "localhost", "port": 9092}] * amt_hosts
+        t = AsyncTransport(
+            hosts=hosts,
+            connection_class=AIOHttpConnection,
+        )
+        await t._async_init()
+        self.__assure_connection_pool_create(
+            t=t,
+            amt_connection=amt_hosts,
+        )
         assert isinstance(
             t.connection_pool.connections[0],
             AIOHttpConnection,


### PR DESCRIPTION
### Description
During the implementation connector based on `AsyncOpenSearch` client for a personal use i've noticed that in spite of specification many hosts i constantly derive `EmptyPool()` object under `connection_class` attribute of instance `AsyncTransport` class. During the small investigation i've noticed that AsyncTransport passes empty list to it's parent, after replace empty list by hosts provided over argument, i was able to get `ConnectionPool` object populated by my `AIOHttpConnection` class instances.

### Opensearch().transport.__dict__ iterate before fix:
```
2023-02-28 16:40:13,080 - root - INFO - sniffing_task :: None
2023-02-28 16:40:13,080 - root - INFO - loop :: None
2023-02-28 16:40:13,080 - root - INFO - _async_init_called :: False
2023-02-28 16:40:13,081 - root - INFO - _sniff_on_start_event :: None
2023-02-28 16:40:13,081 - root - INFO - deserializer :: <opensearchpy.serializer.Deserializer object at 0x106011c90>
2023-02-28 16:40:13,081 - root - INFO - max_retries :: 3
2023-02-28 16:40:13,081 - root - INFO - retry_on_timeout :: False
2023-02-28 16:40:13,081 - root - INFO - retry_on_status :: (502, 503, 504)
2023-02-28 16:40:13,081 - root - INFO - send_get_body_as :: GET
2023-02-28 16:40:13,081 - root - INFO - serializer :: <opensearchpy.serializer.JSONSerializer object at 0x104a7c310>
2023-02-28 16:40:13,081 - root - INFO - connection_pool_class :: <class 'opensearchpy.connection_pool.ConnectionPool'>
2023-02-28 16:40:13,081 - root - INFO - connection_class :: <class 'opensearchpy._async.http_aiohttp.AIOHttpConnection'>
2023-02-28 16:40:13,081 - root - INFO - kwargs :: {'http_compress': (True,), 'use_ssl': (True,), 'verify_certs': (False,), 'ssl_assert_hostname': (False,), 'ssl_show_warn': (False,), 'dead_timeout': 120}
2023-02-28 16:40:13,081 - root - INFO - hosts :: [{'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}]
2023-02-28 16:40:13,081 - root - INFO - connection_pool :: <EmptyConnectionPool: []>
2023-02-28 16:40:13,081 - root - INFO - seed_connections :: []
2023-02-28 16:40:13,081 - root - INFO - sniffer_timeout :: None
2023-02-28 16:40:13,081 - root - INFO - sniff_on_start :: False
2023-02-28 16:40:13,081 - root - INFO - sniff_on_connection_fail :: False
2023-02-28 16:40:13,081 - root - INFO - last_sniff :: 1677580813.080736
2023-02-28 16:40:13,081 - root - INFO - sniff_timeout :: 0.1
2023-02-28 16:40:13,081 - root - INFO - host_info_callback :: <function get_host_info at 0x103d96160>
2023-02-28 16:40:13,081 - root - INFO - <EmptyConnectionPool: []>
```

### Opensearch().transport.__dict__ iterate after fix:
```
2023-02-28 16:41:55,699 - root - INFO - sniffing_task :: None
2023-02-28 16:41:55,699 - root - INFO - loop :: None
2023-02-28 16:41:55,699 - root - INFO - _async_init_called :: False
2023-02-28 16:41:55,699 - root - INFO - _sniff_on_start_event :: None
2023-02-28 16:41:55,700 - root - INFO - deserializer :: <opensearchpy.serializer.Deserializer object at 0x104e9df90>
2023-02-28 16:41:55,700 - root - INFO - max_retries :: 3
2023-02-28 16:41:55,700 - root - INFO - retry_on_timeout :: False
2023-02-28 16:41:55,700 - root - INFO - retry_on_status :: (502, 503, 504)
2023-02-28 16:41:55,700 - root - INFO - send_get_body_as :: GET
2023-02-28 16:41:55,700 - root - INFO - serializer :: <opensearchpy.serializer.JSONSerializer object at 0x101be45d0>
2023-02-28 16:41:55,700 - root - INFO - connection_pool_class :: <class 'opensearchpy.connection_pool.ConnectionPool'>
2023-02-28 16:41:55,700 - root - INFO - connection_class :: <class 'opensearchpy._async.http_aiohttp.AIOHttpConnection'>
2023-02-28 16:41:55,700 - root - INFO - kwargs :: {'http_compress': (True,), 'use_ssl': (True,), 'verify_certs': (False,), 'ssl_assert_hostname': (False,), 'ssl_show_warn': (False,), 'dead_timeout': 120}
2023-02-28 16:41:55,700 - root - INFO - hosts :: [{'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}, {'host': 'localhost', 'port': 9200, 'use_ssl': True, 'http_auth': 'admin:admin'}]
2023-02-28 16:41:55,700 - root - INFO - connection_pool :: <ConnectionPool: [<AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>]>
2023-02-28 16:41:55,700 - root - INFO - seed_connections :: [<AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>]
2023-02-28 16:41:55,700 - root - INFO - sniffer_timeout :: None
2023-02-28 16:41:55,700 - root - INFO - sniff_on_start :: False
2023-02-28 16:41:55,700 - root - INFO - sniff_on_connection_fail :: False
2023-02-28 16:41:55,700 - root - INFO - last_sniff :: 1677580915.699476
2023-02-28 16:41:55,700 - root - INFO - sniff_timeout :: 0.1
2023-02-28 16:41:55,700 - root - INFO - host_info_callback :: <function get_host_info at 0x1014fe160>
2023-02-28 16:41:55,700 - root - INFO - <ConnectionPool: [<AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>, <AIOHttpConnection: https://localhost:9200>]>```


### Issues Resolved
No issues found

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
