### PR TITLE
Add 2PR approval to release workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,17 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
+      - id: get_approvers
+        run: |
+          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
+      - uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ github.TOKEN }}
+          approvers: ${{ steps.get_approvers.outputs.approvers }}
+          minimum-approvals: 2
+          issue-title: 'Release opensearch-py'
+          issue-body: "Please approve or deny the release of opensearch-dsl-py. **Tag**: ${{ github.ref_name }}  **Commit**: ${{ github.sha }}"
+          exclude-workflow-initiator-as-approver: true
       - name: Set up Python 3
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,7 +20,7 @@ jobs:
           approvers: ${{ steps.get_approvers.outputs.approvers }}
           minimum-approvals: 2
           issue-title: 'Release opensearch-py'
-          issue-body: "Please approve or deny the release of opensearch-dsl-py. **Tag**: ${{ github.ref_name }}  **Commit**: ${{ github.sha }}"
+          issue-body: "Please approve or deny the release of opensearch-py. **Tag**: ${{ github.ref_name }}  **Commit**: ${{ github.sha }}"
           exclude-workflow-initiator-as-approver: true
       - name: Set up Python 3
         uses: actions/setup-python@v3


### PR DESCRIPTION
### Description
### Description
This change retrieves the codeowner's list from .github/codeowners file and adds them as approvers for releasing opensearch-py.
Here is a sample issue that is created when this workflow runs: https://github.com/gaiksaya/opensearch-py/issues/1
Once approved, the workflow continues to run as usual.
**_Note: This approval duration is subject to the broader 72 hours timeout for a workflow._**

### Issues Resolved
related https://github.com/opensearch-project/opensearch-build/issues/3111

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
