### PR TITLE
Fix async helpers import cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fixed import cycle when importing async helpers ([#311](https://github.com/opensearch-project/opensearch-py/pull/311))
 
-## [2.1.1]
+## [2.2.0]
 ### Added
 - Merging opensearch-dsl-py into opensearch-py ([#287](https://github.com/opensearch-project/opensearch-py/pull/287))
 - Added upgrading.md file and updated it for opensearch-py 2.2.0 release ([#293](https://github.com/opensearch-project/opensearch-py/pull/293))
@@ -13,10 +13,19 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 - Removed 'out/opensearchpy' folder which was produced while generating pyi files for plugins ([#288](https://github.com/opensearch-project/opensearch-py/pull/288))
+- Removed low-level and high-level client terminology from guides ([#298](https://github.com/opensearch-project/opensearch-py/pull/298))
+### Fixed
+- Fixed CVE - issue 86 mentioned in opensearch-dsl-py repo ([#295](https://github.com/opensearch-project/opensearch-py/pull/295))
+### Security
+
+## [2.1.1]
+### Added
+### Changed
+### Deprecated
+### Removed
 ### Fixed
 - Fixed SigV4 Signing for Managed Service ([#279](https://github.com/opensearch-project/opensearch-py/pull/279))
 - Fixed SigV4 Signing for Async Requests with QueryStrings ([#272](https://github.com/opensearch-project/opensearch-py/pull/279))
-- Fixed CVE - issue 86 mentioned in opensearch-dsl-py repo ([#295](https://github.com/opensearch-project/opensearch-py/pull/295))
 ### Security
 
 ## [2.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
-## [2.2.1]
+## [Unreleased]
 ### Fixed
 - Fixed import cycle when importing async helpers ([#311](https://github.com/opensearch-project/opensearch-py/pull/311))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [2.2.1]
+### Fixed
+- Fixed import cycle when importing async helpers ([#311](https://github.com/opensearch-project/opensearch-py/pull/311))
+
 ## [2.1.1]
 ### Added
 - Merging opensearch-dsl-py into opensearch-py ([#287](https://github.com/opensearch-project/opensearch-py/pull/287))

--- a/opensearchpy/_async/helpers.py
+++ b/opensearchpy/_async/helpers.py
@@ -41,7 +41,6 @@ from ..helpers.actions import (
     expand_action,
 )
 from ..helpers.errors import ScanError
-from .client import AsyncOpenSearch  # noqa
 
 logger = logging.getLogger("opensearchpy.helpers")
 

--- a/test_opensearchpy/test_async/test_server/test_helpers.py
+++ b/test_opensearchpy/test_async/test_server/test_helpers.py
@@ -34,8 +34,7 @@ import asyncio
 import pytest
 from mock import MagicMock, patch
 
-from opensearchpy import TransportError
-from opensearchpy._async import helpers
+from opensearchpy import TransportError, helpers
 from opensearchpy.helpers import BulkIndexError, ScanError
 
 pytestmark = pytest.mark.asyncio


### PR DESCRIPTION
### Description
Fixes the import cycle that prevents async helpers from being imported since v2.2.0

### Issues Resolved
- Closes #310 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
