### PR TITLE
Fixed utils/build-dists.py which was broken by 49ae7c7

### DIFF
--- a/opensearchpy/helpers/__init__.py
+++ b/opensearchpy/helpers/__init__.py
@@ -59,7 +59,6 @@ __all__ = [
 
 # Asyncio only supported on Python 3.6+
 if sys.version_info >= (3, 6):
-
     from .._async.helpers import (
         async_bulk,
         async_reindex,

--- a/opensearchpy/helpers/__init__.py
+++ b/opensearchpy/helpers/__init__.py
@@ -57,10 +57,8 @@ __all__ = [
 ]
 
 
-try:
-    # Asyncio only supported on Python 3.6+
-    if sys.version_info < (3, 6):
-        raise ImportError
+# Asyncio only supported on Python 3.6+
+if sys.version_info >= (3, 6):
 
     from .._async.helpers import (
         async_bulk,
@@ -70,5 +68,3 @@ try:
     )
 
     __all__ += ["async_scan", "async_bulk", "async_reindex", "async_streaming_bulk"]
-except (ImportError, SyntaxError):
-    pass

--- a/utils/build-dists.py
+++ b/utils/build-dists.py
@@ -105,11 +105,12 @@ def test_dist(dist):
             f"from {dist_name} import AsyncOpenSearch",
             expect_exit_code=256,
         )
+
+        # Ensure async helpers are available regardless of aiohttp installation
         run(
             venv_python,
             "-c",
             f"from {dist_name}.helpers import async_scan, async_bulk, async_streaming_bulk, async_reindex",
-            expect_exit_code=256,
         )
 
         # Install aiohttp and see that async is now available


### PR DESCRIPTION
### Description

Follow up to #311 which broke `utils/build-dists.py` by no longer causing the async helper to fail to import if aiohttp is not installed.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
