### PR TITLE
feat(single-test): add single test run capability

### DIFF
--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -38,7 +38,10 @@ docker run \
   --env "TEST_SUITE=${TEST_SUITE}" \
   --env "PYTHON_CONNECTION_CLASS=${PYTHON_CONNECTION_CLASS}" \
   --env "TEST_TYPE=server" \
+  --env "TEST_NAME=${TEST_NAME}" \
   --name opensearch-py \
   --rm \
   opensearch-project/opensearch-py \
   python setup.py test
+
+unset TEST_NAME

--- a/.ci/run-tests
+++ b/.ci/run-tests
@@ -9,6 +9,7 @@ export PYTHON_CONNECTION_CLASS="${PYTHON_CONNECTION_CLASS:=Urllib3HttpConnection
 export CLUSTER="${CLUSTER:-opensearch}"
 export SECURE_INTEGRATION="${1:-false}"
 export OPENSEARCH_VERSION="${2:-latest}"
+export TEST_NAME="${3:-}"
 if [[ "$SECURE_INTEGRATION" == "true" ]]; then
     export OPENSEARCH_URL_EXTENSION="https"
 else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Added async support for helpers that are merged from opensearch-dsl-py ([#329](https://github.com/opensearch-project/opensearch-py/pull/329))
+- Added the ability to run individual tests in the test suite ([#325](https://github.com/opensearch-project/opensearch-py/pull/325))
 ### Changed
 ### Deprecated
 ### Removed

--- a/test_opensearchpy/run_tests.py
+++ b/test_opensearchpy/run_tests.py
@@ -149,8 +149,9 @@ def run_all(argv=None):
             argv.append(abspath(dirname(__file__)))
 
     # check TEST_NAME env var for specific test to run
-    if "TEST_NAME" in environ:
-        argv = ["pytest", "-k", environ["TEST_NAME"]]
+    test_name = environ.get("TEST_NAME")
+    if test_name:
+        argv = ["pytest", "-k", test_name]
 
     exit_code = 0
     try:

--- a/test_opensearchpy/run_tests.py
+++ b/test_opensearchpy/run_tests.py
@@ -148,6 +148,10 @@ def run_all(argv=None):
         else:
             argv.append(abspath(dirname(__file__)))
 
+    # check TEST_NAME env var for specific test to run
+    if "TEST_NAME" in environ:
+        argv = ["pytest", "-k", environ["TEST_NAME"]]
+
     exit_code = 0
     try:
         subprocess.check_call(argv, stdout=sys.stdout, stderr=sys.stderr)


### PR DESCRIPTION
### Description
This PR adds the ability to run a single test from the test suite using the -k flag for pytest, making it easier for developers to test specific functionality during development.
Now it is possible to test a single test by running:
`./.ci/run-tests true 1.3.0 name_of_the_test`

### Issues Resolved
Closes #317

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
