### PR TITLE
trust_env added

### DIFF
--- a/opensearchpy/_async/http_aiohttp.py
+++ b/opensearchpy/_async/http_aiohttp.py
@@ -91,6 +91,7 @@ class AIOHttpConnection(AsyncConnection):
         http_compress=None,
         opaque_id=None,
         loop=None,
+        trust_env = False,
         **kwargs
     ):
         """
@@ -219,6 +220,7 @@ class AIOHttpConnection(AsyncConnection):
         self._limit = maxsize
         self._http_auth = http_auth
         self._ssl_context = ssl_context
+        self._trust_env = trust_env
 
     async def perform_request(
         self, method, url, params=None, body=None, timeout=None, ignore=(), headers=None
@@ -355,6 +357,7 @@ class AIOHttpConnection(AsyncConnection):
             self.loop = get_running_loop()
         self.session = aiohttp.ClientSession(
             headers=self.headers,
+            trust_env = self._trust_env,
             skip_auto_headers=("accept", "accept-encoding"),
             auto_decompress=True,
             loop=self.loop,


### PR DESCRIPTION
### Description
Allowed passing trust_env to aiohttp.ClientSession

### Issues Resolved
Closes [#368](https://github.com/opensearch-project/opensearch-py/issues/368).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
