### PR TITLE
trust_env to the aiohttp.ClientSession

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,20 +34,19 @@ jobs:
       - name: Build project for distribution
         run: |
           python3.7 -m build
-
   test-linux:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
         experimental: [false]
         include:
-          - os: 'ubuntu-20.04'
-            python-version: '3.5'
+          - os: "ubuntu-20.04"
+            python-version: "3.5"
             experimental: false
-          - os: 'ubuntu-20.04'
-            python-version: '3.6'
+          - os: "ubuntu-20.04"
+            python-version: "3.6"
             experimental: false
 
     runs-on: ${{ matrix.os }}
@@ -69,6 +68,11 @@ jobs:
       - name: Run Tests
         run: |
           python setup.py test
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./junit/opensearch-py-codecov.xml
 
   twine-check:
     runs-on: ubuntu-latest
@@ -77,7 +81,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Added async support for helpers that are merged from opensearch-dsl-py ([#329](https://github.com/opensearch-project/opensearch-py/pull/329))
 ### Changed
+- Upgrading pytest-asyncio to latest version - 0.21.0 ([#339](https://github.com/opensearch-project/opensearch-py/pull/339))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -20,5 +20,5 @@ twine
 
 # Requirements for testing [async] extra
 aiohttp; python_version>="3.6"
-pytest-asyncio<=0.18.3; python_version>="3.6"
+pytest-asyncio<=0.21.0; python_version>="3.6"
 unasync; python_version>="3.6"

--- a/opensearchpy/_async/http_aiohttp.py
+++ b/opensearchpy/_async/http_aiohttp.py
@@ -91,6 +91,7 @@ class AIOHttpConnection(AsyncConnection):
         http_compress=None,
         opaque_id=None,
         loop=None,
+        trust_env=False,
         **kwargs
     ):
         """
@@ -219,6 +220,7 @@ class AIOHttpConnection(AsyncConnection):
         self._limit = maxsize
         self._http_auth = http_auth
         self._ssl_context = ssl_context
+        self._trust_env = trust_env
 
     async def perform_request(
         self, method, url, params=None, body=None, timeout=None, ignore=(), headers=None
@@ -354,6 +356,7 @@ class AIOHttpConnection(AsyncConnection):
         if self.loop is None:
             self.loop = get_running_loop()
         self.session = aiohttp.ClientSession(
+            trust_env=self._trust_env,
             headers=self.headers,
             skip_auto_headers=("accept", "accept-encoding"),
             auto_decompress=True,

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ ignore = E203, E266, E501, W503
 
 [tool:pytest]
 junit_family=legacy
+asyncio_mode=auto
 
 [tool:isort]
 profile=black

--- a/test_opensearchpy/run_tests.py
+++ b/test_opensearchpy/run_tests.py
@@ -94,13 +94,17 @@ def run_all(argv=None):
         junit_xml = join(
             abspath(dirname(dirname(__file__))), "junit", "opensearch-py-junit.xml"
         )
+        codecov_xml = join(
+            abspath(dirname(dirname(__file__))), "junit", "opensearch-py-codecov.xml"
+        )
         argv = [
             "pytest",
-            "--cov=opensearch",
+            "--cov=opensearchpy",
             "--junitxml=%s" % junit_xml,
             "--log-level=DEBUG",
             "--cache-clear",
             "-vv",
+            "--cov-report=xml:%s" % codecov_xml,
         ]
 
         secured = False

--- a/test_opensearchpy/test_async/test_connection.py
+++ b/test_opensearchpy/test_async/test_connection.py
@@ -101,7 +101,6 @@ class TestAIOHttpConnection:
         con = AIOHttpConnection(trust_env=True)
         assert con.session.connector.trust_env
 
-
     async def test_async_opensearch_trust_env(self):
         # Create an instance of AsyncOpenSearch with trust_env set to True
         async with AsyncOpenSearch(

--- a/test_opensearchpy/test_async/test_connection.py
+++ b/test_opensearchpy/test_async/test_connection.py
@@ -101,6 +101,7 @@ class TestAIOHttpConnection:
         con = AIOHttpConnection(trust_env=True)
         assert con.session.connector.trust_env
 
+
     async def test_async_opensearch_trust_env(self):
         # Create an instance of AsyncOpenSearch with trust_env set to True
         async with AsyncOpenSearch(

--- a/test_opensearchpy/test_async/test_connection.py
+++ b/test_opensearchpy/test_async/test_connection.py
@@ -103,6 +103,7 @@ class TestAIOHttpConnection:
 
     async def test_async_opensearch_trust_env(self):
         # Create an instance of AsyncOpenSearch with trust_env set to True
+        # and check that the connector instance used by the client has trust_env set to Truetest_async
         async with AsyncOpenSearch(
                 trust_env=True,
                 headers={"User-Agent": "TestClient"},


### PR DESCRIPTION
### Description
Passed `trust_env=True` to the `aiohttp.ClientSession `

Issues Resolved
closes [#368](https://github.com/opensearch-project/opensearch-py/issues/368)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
