### PR TITLE
Fixed flaky CI tests by adding httpbin docker container to the github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
     name: test-${{ matrix.python-version }}
     continue-on-error: ${{ matrix.experimental }}
     steps:
+      - name: Start httpbin container
+        run: docker run --name httpbin -d -p 8000:80 kennethreitz/httpbin 
+      - name: Wait for httpbin to start
+        run: sleep 60
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Set Up Python - ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added 'point in time' APIs to the pyi files in sync and async client ([#378](https://github.com/opensearch-project/opensearch-py/pull/378))
 ### Changed
 - Upgrading pytest-asyncio to latest version - 0.21.0 ([#339](https://github.com/opensearch-project/opensearch-py/pull/339))
+- Fixed flaky CI tests by adding httpbin docker container to the github workflows ([#383](https://github.com/opensearch-project/opensearch-py/pull/383))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -18,6 +18,11 @@ $ nox -rs format
 # Run the test suite
 $ nox -rs test
 ```
+Note that unit tests require docker to be installed and httpbin container running. 
+
+```
+docker run --name httpbin -d -p 8000:80 kennethreitz/httpbin
+```
 
 ## Integration Tests
 To run the integration tests locally, run:

--- a/test_opensearchpy/test_async/test_connection.py
+++ b/test_opensearchpy/test_async/test_connection.py
@@ -312,48 +312,51 @@ class TestConnectionHttpbin:
 
     async def test_aiohttp_connection(self):
         # Defaults
-        conn = AIOHttpConnection("httpbin.org", port=443, use_ssl=True)
+        conn = AIOHttpConnection("localhost", port=8000, use_ssl=False)
         user_agent = conn._get_default_user_agent()
         status, data = await self.httpbin_anything(conn)
         assert status == 200
         assert data["method"] == "GET"
         assert data["headers"] == {
+            "Connection": "keep-alive",
             "Content-Type": "application/json",
-            "Host": "httpbin.org",
+            "Host": "localhost:8000",
             "User-Agent": user_agent,
         }
 
         # http_compress=False
         conn = AIOHttpConnection(
-            "httpbin.org", port=443, use_ssl=True, http_compress=False
+            "localhost", port=8000, use_ssl=False, http_compress=False
         )
         status, data = await self.httpbin_anything(conn)
         assert status == 200
         assert data["method"] == "GET"
         assert data["headers"] == {
+            "Connection": "keep-alive",
             "Content-Type": "application/json",
-            "Host": "httpbin.org",
+            "Host": "localhost:8000",
             "User-Agent": user_agent,
         }
 
         # http_compress=True
         conn = AIOHttpConnection(
-            "httpbin.org", port=443, use_ssl=True, http_compress=True
+            "localhost", port=8000, use_ssl=False, http_compress=True
         )
         status, data = await self.httpbin_anything(conn)
         assert status == 200
         assert data["headers"] == {
             "Accept-Encoding": "gzip,deflate",
+            "Connection": "keep-alive",
             "Content-Type": "application/json",
-            "Host": "httpbin.org",
+            "Host": "localhost:8000",
             "User-Agent": user_agent,
         }
 
         # Headers
         conn = AIOHttpConnection(
-            "httpbin.org",
-            port=443,
-            use_ssl=True,
+            "localhost",
+            port=8000,
+            use_ssl=False,
             http_compress=True,
             headers={"header1": "value1"},
         )
@@ -363,8 +366,9 @@ class TestConnectionHttpbin:
         assert status == 200
         assert data["headers"] == {
             "Accept-Encoding": "gzip,deflate",
+            "Connection": "keep-alive",
             "Content-Type": "application/json",
-            "Host": "httpbin.org",
+            "Host": "localhost:8000",
             "Header1": "override!",
             "Header2": "value2",
             "User-Agent": user_agent,

--- a/test_opensearchpy/test_connection.py
+++ b/test_opensearchpy/test_connection.py
@@ -870,51 +870,54 @@ class TestConnectionHttpbin:
 
     def test_urllib3_connection(self):
         # Defaults
-        # httpbin.org can be slow sometimes. Hence the timeout
-        conn = Urllib3HttpConnection("httpbin.org", port=443, use_ssl=True, timeout=60)
+        # httpbin can be slow sometimes. Hence the timeout
+        conn = Urllib3HttpConnection("localhost", port=8000, use_ssl=False, timeout=60)
         user_agent = conn._get_default_user_agent()
         status, data = self.httpbin_anything(conn)
         assert status == 200
         assert data["method"] == "GET"
         assert data["headers"] == {
             "Accept-Encoding": "identity",
+            "Connection": "keep-alive",
             "Content-Type": "application/json",
-            "Host": "httpbin.org",
+            "Host": "localhost:8000",
             "User-Agent": user_agent,
         }
 
         # http_compress=False
         conn = Urllib3HttpConnection(
-            "httpbin.org", port=443, use_ssl=True, http_compress=False, timeout=60
+            "localhost", port=8000, use_ssl=False, http_compress=False, timeout=60
         )
         status, data = self.httpbin_anything(conn)
         assert status == 200
         assert data["method"] == "GET"
         assert data["headers"] == {
             "Accept-Encoding": "identity",
+            "Connection": "keep-alive",
             "Content-Type": "application/json",
-            "Host": "httpbin.org",
+            "Host": "localhost:8000",
             "User-Agent": user_agent,
         }
 
         # http_compress=True
         conn = Urllib3HttpConnection(
-            "httpbin.org", port=443, use_ssl=True, http_compress=True, timeout=60
+            "localhost", port=8000, use_ssl=False, http_compress=True, timeout=60
         )
         status, data = self.httpbin_anything(conn)
         assert status == 200
         assert data["headers"] == {
             "Accept-Encoding": "gzip,deflate",
+            "Connection": "keep-alive",
             "Content-Type": "application/json",
-            "Host": "httpbin.org",
+            "Host": "localhost:8000",
             "User-Agent": user_agent,
         }
 
         # Headers
         conn = Urllib3HttpConnection(
-            "httpbin.org",
-            port=443,
-            use_ssl=True,
+            "localhost",
+            port=8000,
+            use_ssl=False,
             http_compress=True,
             headers={"header1": "value1"},
             timeout=60,
@@ -925,8 +928,9 @@ class TestConnectionHttpbin:
         assert status == 200
         assert data["headers"] == {
             "Accept-Encoding": "gzip,deflate",
+            "Connection": "keep-alive",
             "Content-Type": "application/json",
-            "Host": "httpbin.org",
+            "Host": "localhost:8000",
             "Header1": "override!",
             "Header2": "value2",
             "User-Agent": user_agent,
@@ -939,7 +943,7 @@ class TestConnectionHttpbin:
 
     def test_requests_connection(self):
         # Defaults
-        conn = RequestsHttpConnection("httpbin.org", port=443, use_ssl=True, timeout=60)
+        conn = RequestsHttpConnection("localhost", port=8000, use_ssl=False, timeout=60)
         user_agent = conn._get_default_user_agent()
         status, data = self.httpbin_anything(conn)
         assert status == 200
@@ -947,13 +951,13 @@ class TestConnectionHttpbin:
         assert data["headers"] == {
             "Accept-Encoding": "identity",
             "Content-Type": "application/json",
-            "Host": "httpbin.org",
+            "Host": "localhost:8000",
             "User-Agent": user_agent,
         }
 
         # http_compress=False
         conn = RequestsHttpConnection(
-            "httpbin.org", port=443, use_ssl=True, http_compress=False, timeout=60
+            "localhost", port=8000, use_ssl=False, http_compress=False, timeout=60
         )
         status, data = self.httpbin_anything(conn)
         assert status == 200
@@ -961,28 +965,28 @@ class TestConnectionHttpbin:
         assert data["headers"] == {
             "Accept-Encoding": "identity",
             "Content-Type": "application/json",
-            "Host": "httpbin.org",
+            "Host": "localhost:8000",
             "User-Agent": user_agent,
         }
 
         # http_compress=True
         conn = RequestsHttpConnection(
-            "httpbin.org", port=443, use_ssl=True, http_compress=True, timeout=60
+            "localhost", port=8000, use_ssl=False, http_compress=True, timeout=60
         )
         status, data = self.httpbin_anything(conn)
         assert status == 200
         assert data["headers"] == {
             "Accept-Encoding": "gzip,deflate",
             "Content-Type": "application/json",
-            "Host": "httpbin.org",
+            "Host": "localhost:8000",
             "User-Agent": user_agent,
         }
 
         # Headers
         conn = RequestsHttpConnection(
-            "httpbin.org",
-            port=443,
-            use_ssl=True,
+            "localhost",
+            port=8000,
+            use_ssl=False,
             http_compress=True,
             headers={"header1": "value1"},
             timeout=60,
@@ -994,7 +998,7 @@ class TestConnectionHttpbin:
         assert data["headers"] == {
             "Accept-Encoding": "gzip,deflate",
             "Content-Type": "application/json",
-            "Host": "httpbin.org",
+            "Host": "localhost:8000",
             "Header1": "override!",
             "Header2": "value2",
             "User-Agent": user_agent,


### PR DESCRIPTION
### Description
Fixed flaky CI tests by adding httpbin docker container to the github workflows

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes #327 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
