### PR TITLE
[#387] Do not escape the "timeout" parameter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,3 +86,4 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 [2.1.0]: https://github.com/opensearch-project/opensearch-py/compare/v2.0.1...v2.1.0
 [2.1.1]: https://github.com/opensearch-project/opensearch-py/compare/v2.1.0...v2.1.1
 [2.2.0]: https://github.com/opensearch-project/opensearch-py/compare/v2.1.1...v2.2.0
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Updates `master` to `cluster_manager` to be inclusive ([#242](https://github.com/opensearch-project/opensearch-py/pull/242))
 - Support a custom signing service name for AWS SigV4 ([#268](https://github.com/opensearch-project/opensearch-py/pull/268))
 - Updated CI tests to make them work locally ([#275](https://github.com/opensearch-project/opensearch-py/pull/275))
+- Fix bug with validation of 'timeout' parameter ([#387](Do not escape the "timeout" parameter.))
 ### Deprecated
 
 ### Removed

--- a/opensearchpy/client/utils.py
+++ b/opensearchpy/client/utils.py
@@ -165,7 +165,7 @@ def query_params(*opensearch_query_params):
             elif api_key is not None:
                 headers["authorization"] = "ApiKey %s" % (_base64_auth_header(api_key),)
 
-            # don't treat ignore, request_timeout, timeout, and opaque_id as other params to avoid escaping
+            # don't escape ignore, request_timeout, or timeout
             for p in ("ignore", "request_timeout", "timeout"):
                 if p in kwargs:
                     params[p] = kwargs.pop(p)

--- a/opensearchpy/client/utils.py
+++ b/opensearchpy/client/utils.py
@@ -165,16 +165,17 @@ def query_params(*opensearch_query_params):
             elif api_key is not None:
                 headers["authorization"] = "ApiKey %s" % (_base64_auth_header(api_key),)
 
+            # don't treat ignore, request_timeout, timeout, and opaque_id as other params to avoid escaping
+            for p in ("ignore", "request_timeout", "timeout"):
+                if p in kwargs:
+                    params[p] = kwargs.pop(p)
+
             for p in opensearch_query_params + GLOBAL_PARAMS:
                 if p in kwargs:
                     v = kwargs.pop(p)
                     if v is not None:
                         params[p] = _escape(v)
 
-            # don't treat ignore, request_timeout, and opaque_id as other params to avoid escaping
-            for p in ("ignore", "request_timeout"):
-                if p in kwargs:
-                    params[p] = kwargs.pop(p)
             return func(*args, params=params, headers=headers, **kwargs)
 
         return _wrapped

--- a/test_opensearchpy/test_client/test_utils.py
+++ b/test_opensearchpy/test_client/test_utils.py
@@ -87,12 +87,28 @@ class TestQueryParams(TestCase):
 
     def test_non_escaping_params(self):
         # the query_params decorator doesn't validate "timeout" it simply avoids escaping as it did
-        self.func_to_wrap(simple_param = "x", timeout="4s")
-        self.assertEqual(self.calls[-1], ((), {"params": { "simple_param" : b'x', "timeout" : "4s" }, "headers" : {}}))
+        self.func_to_wrap(simple_param="x", timeout="4s")
+        self.assertEqual(
+            self.calls[-1],
+            ((), {"params": {"simple_param": b"x", "timeout": "4s"}, "headers": {}}),
+        )
 
-        self.func_to_wrap(simple_param = "x", timeout=4)
-        self.assertEqual(self.calls[-1], ((), {"params": { "simple_param" : b'x', "timeout" : 4 }, "headers" : {}}))
-
+        self.func_to_wrap(simple_param="x", timeout=4, ignore=5, request_timeout=6)
+        self.assertEqual(
+            self.calls[-1],
+            (
+                (),
+                {
+                    "params": {
+                        "simple_param": b"x",
+                        "timeout": 4,
+                        "ignore": 5,
+                        "request_timeout": 6,
+                    },
+                    "headers": {},
+                },
+            ),
+        )
 
     def test_per_call_authentication(self):
         self.func_to_wrap(api_key=("name", "key"))

--- a/test_opensearchpy/test_client/test_utils.py
+++ b/test_opensearchpy/test_client/test_utils.py
@@ -85,6 +85,15 @@ class TestQueryParams(TestCase):
         self.func_to_wrap(headers={"X": "y"})
         self.assertEqual(self.calls[-1], ((), {"params": {}, "headers": {"x": "y"}}))
 
+    def test_non_escaping_params(self):
+        # the query_params decorator doesn't validate "timeout" it simply avoids escaping as it did
+        self.func_to_wrap(simple_param = "x", timeout="4s")
+        self.assertEqual(self.calls[-1], ((), {"params": { "simple_param" : b'x', "timeout" : "4s" }, "headers" : {}}))
+
+        self.func_to_wrap(simple_param = "x", timeout=4)
+        self.assertEqual(self.calls[-1], ((), {"params": { "simple_param" : b'x', "timeout" : 4 }, "headers" : {}}))
+
+
     def test_per_call_authentication(self):
         self.func_to_wrap(api_key=("name", "key"))
         self.assertEqual(

--- a/test_opensearchpy/test_server/test_helpers/test_actions.py
+++ b/test_opensearchpy/test_server/test_helpers/test_actions.py
@@ -80,7 +80,7 @@ class TestStreamingBulk(OpenSearchTestCase):
                 "settings": {"number_of_shards": 1, "number_of_replicas": 0},
             },
         )
-        self.client.cluster.health(wait_for_status="yellow")
+        self.client.cluster.health(wait_for_status="yellow", timeout=10)
 
         try:
             for ok, item in helpers.streaming_bulk(
@@ -273,7 +273,7 @@ class TestBulk(OpenSearchTestCase):
                 "settings": {"number_of_shards": 1, "number_of_replicas": 0},
             },
         )
-        self.client.cluster.health(wait_for_status="yellow")
+        self.client.cluster.health(wait_for_status="yellow", request_timeout=10)
 
         success, failed = helpers.bulk(
             self.client,

--- a/test_opensearchpy/test_server/test_helpers/test_actions.py
+++ b/test_opensearchpy/test_server/test_helpers/test_actions.py
@@ -80,7 +80,7 @@ class TestStreamingBulk(OpenSearchTestCase):
                 "settings": {"number_of_shards": 1, "number_of_replicas": 0},
             },
         )
-        self.client.cluster.health(wait_for_status="yellow", timeout=10)
+        self.client.cluster.health(wait_for_status="yellow")
 
         try:
             for ok, item in helpers.streaming_bulk(
@@ -273,7 +273,7 @@ class TestBulk(OpenSearchTestCase):
                 "settings": {"number_of_shards": 1, "number_of_replicas": 0},
             },
         )
-        self.client.cluster.health(wait_for_status="yellow", request_timeout=10)
+        self.client.cluster.health(wait_for_status="yellow")
 
         success, failed = helpers.bulk(
             self.client,


### PR DESCRIPTION
When the "timeout" parameter is escaped and turned into a string, it does not pass validation checks.
This PR ensures that timeout is passed through as-is, just like "request_timeout".
There's no explicit test for this parameter, but I included it on some existing tests just to ensure that the code is exercised.  Without the fix in place, one of the tests as modified will not pass.

### Description
With this change, using the `timeout` parameter in `cluster.health` no longer throws a validation error.  I have not checked whether the problem exists elsewhere.

### Issues Resolved
Resolves #387 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
