### PR TITLE
Fix integration tests workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Integ OpenSearch secured=${{ matrix.secured }} version=${{matrix.entry.opensearch_version}}
-        run: "./.ci/run-tests ${{ matrix.secured }} ${{ matrix.entry.opensearch_version }}"
+      - name: Integ OpenSearch secured=${{ matrix.secured }} version=${{ matrix.opensearch_version }}
+        run: "./.ci/run-tests ${{ matrix.secured }} ${{ matrix.opensearch_version }}"


### PR DESCRIPTION
### Description
The CI always seems to be using the latest version of opensearch rather than the one specified in the matrix.

![image](https://github.com/opensearch-project/opensearch-py/assets/23208753/f1d0628d-1a33-4e49-b566-7e71f720925f)

### Issues Resolved
Fix integration tests that always use the latest version of opensearch rather than the one specified in the matrix.

