### PR TITLE
Added restore API in RemoteStoreClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Enhanced YAML test runner to use OpenSearch rest-api-spec YAML tests ([#414](https://github.com/opensearch-project/opensearch-py/pull/414)
 - Added `Search#collapse` ([#409](https://github.com/opensearch-project/opensearch-py/issues/409))
 - Added support for the ISM API ([#398](https://github.com/opensearch-project/opensearch-py/pull/398))
-- Added `trust_env` to `AIOHttpConnection` ([#398](https://github.com/opensearch-project/opensearch-py/pull/438))
+- Added `trust_env` to `AIOHttpConnection` ([#438](https://github.com/opensearch-project/opensearch-py/pull/438))
+- Added "restore" API in "RemoteStoreClient" ([#443](https://github.com/opensearch-project/opensearch-py/pull/443))
 
 ### Changed
 - Upgrading pytest-asyncio to latest version - 0.21.0 ([#339](https://github.com/opensearch-project/opensearch-py/pull/339))

--- a/opensearchpy/_async/client/remote_store.py
+++ b/opensearchpy/_async/client/remote_store.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+# ----------------------------------------------------
+# THIS CODE IS GENERATED. MANUAL EDITS WILL BE LOST.
+
+# To contribute, please make necessary modifications to either "Python generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or "OpenAPI specs":
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
+from .utils import SKIP_IN_PATH, NamespacedClient, query_params
+
+
+class RemoteStoreClient(NamespacedClient):
+    @query_params("cluster_manager_timeout", "wait_for_completion")
+    async def restore(self, body, params=None, headers=None):
+        """
+        Restores from remote store.
+
+
+        :arg body: Comma-separated list of index IDs
+        :arg cluster_manager_timeout: Operation timeout for connection
+            to cluster-manager node.
+        :arg wait_for_completion: Should this request wait until the
+            operation has completed before returning.
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+
+        return await self.transport.perform_request(
+            "POST", "/_remotestore/_restore", params=params, headers=headers, body=body
+        )

--- a/opensearchpy/_async/client/remote_store.pyi
+++ b/opensearchpy/_async/client/remote_store.pyi
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+# ----------------------------------------------------
+# THIS CODE IS GENERATED. MANUAL EDITS WILL BE LOST.
+
+# To contribute, please make necessary modifications to either "Python generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or "OpenAPI specs":
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
+from typing import Any, Collection, MutableMapping, Optional, Tuple, Union
+
+from .utils import NamespacedClient
+
+class RemoteStoreClient(NamespacedClient):
+    async def restore(
+        self,
+        *,
+        body: Any,
+        cluster_manager_timeout: Optional[Any] = ...,
+        wait_for_completion: Optional[Any] = ...,
+        pretty: Optional[bool] = ...,
+        human: Optional[bool] = ...,
+        error_trace: Optional[bool] = ...,
+        format: Optional[str] = ...,
+        filter_path: Optional[Union[str, Collection[str]]] = ...,
+        request_timeout: Optional[Union[int, float]] = ...,
+        ignore: Optional[Union[int, Collection[int]]] = ...,
+        opaque_id: Optional[str] = ...,
+        http_auth: Optional[Union[str, Tuple[str, str]]] = ...,
+        api_key: Optional[Union[str, Tuple[str, str]]] = ...,
+        params: Optional[MutableMapping[str, Any]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...,
+    ) -> Any: ...

--- a/opensearchpy/client/remote_store.py
+++ b/opensearchpy/client/remote_store.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+# ----------------------------------------------------
+# THIS CODE IS GENERATED. MANUAL EDITS WILL BE LOST.
+
+# To contribute, please make necessary modifications to either "Python generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or "OpenAPI specs":
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
+from .utils import SKIP_IN_PATH, NamespacedClient, query_params
+
+
+class RemoteStoreClient(NamespacedClient):
+    @query_params("cluster_manager_timeout", "wait_for_completion")
+    def restore(self, body, params=None, headers=None):
+        """
+        Restores from remote store.
+
+
+        :arg body: Comma-separated list of index IDs
+        :arg cluster_manager_timeout: Operation timeout for connection
+            to cluster-manager node.
+        :arg wait_for_completion: Should this request wait until the
+            operation has completed before returning.
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+
+        return self.transport.perform_request(
+            "POST", "/_remotestore/_restore", params=params, headers=headers, body=body
+        )

--- a/opensearchpy/client/remote_store.pyi
+++ b/opensearchpy/client/remote_store.pyi
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+# ----------------------------------------------------
+# THIS CODE IS GENERATED. MANUAL EDITS WILL BE LOST.
+
+# To contribute, please make necessary modifications to either "Python generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or "OpenAPI specs":
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
+from typing import Any, Collection, MutableMapping, Optional, Tuple, Union
+
+from .utils import NamespacedClient
+
+class RemoteStoreClient(NamespacedClient):
+    def restore(
+        self,
+        *,
+        body: Any,
+        cluster_manager_timeout: Optional[Any] = ...,
+        wait_for_completion: Optional[Any] = ...,
+        pretty: Optional[bool] = ...,
+        human: Optional[bool] = ...,
+        error_trace: Optional[bool] = ...,
+        format: Optional[str] = ...,
+        filter_path: Optional[Union[str, Collection[str]]] = ...,
+        request_timeout: Optional[Union[int, float]] = ...,
+        ignore: Optional[Union[int, Collection[int]]] = ...,
+        opaque_id: Optional[str] = ...,
+        http_auth: Optional[Union[str, Tuple[str, str]]] = ...,
+        api_key: Optional[Union[str, Tuple[str, str]]] = ...,
+        params: Optional[MutableMapping[str, Any]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...,
+    ) -> Any: ...


### PR DESCRIPTION
### Description
Added restore API in RemoteStoreClient. This is an experimental feature. API Code is generated using "python API generator". Tests to this feature can be added [here](https://github.com/opensearch-project/OpenSearch/tree/main/rest-api-spec/src/main/resources/rest-api-spec/test)

### Issues Resolved
Related Issue https://github.com/opensearch-project/opensearch-py/issues/435

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
