### PR TITLE
Added Python 3.10 and 3.11 to nox.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -36,7 +36,7 @@ SOURCE_FILES = (
 )
 
 
-@nox.session(python=["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"])
 def test(session):
     session.install(".")
     session.install("-r", "dev-requirements.txt")


### PR DESCRIPTION
### Description

Closes https://github.com/opensearch-project/opensearch-py/pull/336. Just add the missing versions to nox, we already have 3.10 and 3.11 in GHA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
