### PR TITLE
Adding @florianvazelle as maintainer and codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the team set up in https://github.com/orgs/opensearch-project/teams and include any additional contributors
-*   @VachaShah @dblock @harshavamsi @axeoman @deztructor @Shephalimittal @saimedhi
+*   @VachaShah @dblock @harshavamsi @axeoman @deztructor @Shephalimittal @saimedhi @florianvazelle

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,6 +13,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Denis Zalevskiy           | [deztructor](https://github.com/deztructor)         | Aiven       |
 | Shephali Mittal           | [Shephalimittal](https://github.com/Shephalimittal) | Amazon      |
 | Sai Medhini Reddy Maryada | [saimedhi](https://github.com/saimedhi)             | Amazon      |
+| Florian Vazelle           | [florianvazelle](https://github.com/florianvazelle) | harfanglab  |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description
Adding @florianvazelle as maintainer and codeowner


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
