### PR TITLE
feat: allow to set a signature port for tunnel usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed allow AWSV4SignerAuth to work with a tunnel ([[#184](https://github.com/opensearch-project/opensearch-py/issues/184)
 ### Security
 ### Dependencies
 - Bumps `sphinx` from <7.1 to <7.3

--- a/test_opensearchpy/test_helpers/test_signer.py
+++ b/test_opensearchpy/test_helpers/test_signer.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+from unittest import TestCase
+
+from opensearchpy.helpers.signer import derive_signature_url
+
+
+class TestUrllib3Connection(TestCase):
+    def test_derive_signature_url(self):
+        assert (
+            derive_signature_url("http://localhost:10552/", singing_port=443)
+            == "http://localhost:443/"
+        )
+        assert (
+            derive_signature_url("http://localhost:10552/foo/bar", singing_port=443)
+            == "http://localhost:443/foo/bar"
+        )
+        assert (
+            derive_signature_url("http://localhost/", singing_port=443)
+            == "http://localhost:443/"
+        )
+        assert (
+            derive_signature_url("http://localhost/foo/bar", singing_port=443)
+            == "http://localhost:443/foo/bar"
+        )
+
+    def test_derive_signature_url_no_hostname(self):
+        self.assertRaises(RuntimeError, derive_signature_url, "http://", 23)


### PR DESCRIPTION
### Description
Allows to change the port used to sign the AWS request which is causing an issue if accessing an AWS Opensearch instance via a tunnel

If you have an ssh tunnel created this works now (while it would not without `signature_port`):
```
host = 'localhost'
port = 10012
region = 'eu-west-1'
service = 'es'
credentials = boto3.Session().get_credentials()
auth = AWSV4SignerAuth(credentials, region, service, signature_port=443)

client = OpenSearch(
    hosts = [{'host': host, 'port': port}],
    http_auth = auth,
    use_ssl = True,
    verify_certs = False,
    ssl_assert_hostname = False,
    ssl_show_warn = False,
    connection_class = RequestsHttpConnection,
    pool_maxsize = 20
)
```


### Issues Resolved
https://github.com/opensearch-project/opensearch-py/issues/184

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
