### PR TITLE
Integrated generated `tasks client` APIs into the existing module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Added generating imports and headers to API generator ([#467](https://github.com/opensearch-project/opensearch-py/pull/467))
 ### Changed
+- Integrated generated `tasks client` APIs into the existing module, ensuring alignment with the server and maintaining backward compatibility ([#508](https://github.com/opensearch-project/opensearch-py/pull/508))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/opensearchpy/_async/client/tasks.py
+++ b/opensearchpy/_async/client/tasks.py
@@ -25,6 +25,16 @@
 #  under the License.
 
 
+# ----------------------------------------------------
+# THIS CODE IS GENERATED AND MANUAL EDITS WILL BE LOST.
+#
+# To contribute, kindly make essential modifications through either the "opensearch-py client generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or the "OpenSearch API specification" available at:
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
+
 import warnings
 
 from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
@@ -45,24 +55,20 @@ class TasksClient(NamespacedClient):
         Returns a list of tasks.
 
 
-        .. warning::
-
-            This API is **experimental** so may include breaking changes
-            or be removed in a future version
-
-        :arg actions: A comma-separated list of actions that should be
+        :arg actions: Comma-separated list of actions that should be
             returned. Leave empty to return all.
-        :arg detailed: Return detailed task information (default: false)
+        :arg detailed: Return detailed task information.
         :arg group_by: Group tasks by nodes or parent/child
-            relationships  Valid choices: nodes, parents, none  Default: nodes
-        :arg nodes: A comma-separated list of node IDs or names to limit
+            relationships.  Valid choices: nodes, parents, none
+        :arg nodes: Comma-separated list of node IDs or names to limit
             the returned information; use `_local` to return information from the
-            node you're connecting to, leave empty to get information from all nodes
+            node you're connecting to, leave empty to get information from all
+            nodes.
         :arg parent_task_id: Return tasks with specified parent task id
             (node_id:task_number). Set to -1 to return all.
-        :arg timeout: Explicit operation timeout
-        :arg wait_for_completion: Wait for the matching tasks to
-            complete (default: false)
+        :arg timeout: Operation timeout.
+        :arg wait_for_completion: Should this request wait until the
+            operation has completed before returning.
         """
         return await self.transport.perform_request(
             "GET", "/_tasks", params=params, headers=headers
@@ -74,23 +80,18 @@ class TasksClient(NamespacedClient):
         Cancels a task, if it can be cancelled through an API.
 
 
-        .. warning::
-
-            This API is **experimental** so may include breaking changes
-            or be removed in a future version
-
         :arg task_id: Cancel the task with specified task id
-            (node_id:task_number)
-        :arg actions: A comma-separated list of actions that should be
+            (node_id:task_number).
+        :arg actions: Comma-separated list of actions that should be
             cancelled. Leave empty to cancel all.
-        :arg nodes: A comma-separated list of node IDs or names to limit
+        :arg nodes: Comma-separated list of node IDs or names to limit
             the returned information; use `_local` to return information from the
-            node you're connecting to, leave empty to get information from all nodes
+            node you're connecting to, leave empty to get information from all
+            nodes.
         :arg parent_task_id: Cancel tasks with specified parent task id
             (node_id:task_number). Set to -1 to cancel all.
-        :arg wait_for_completion: Should the request block until the
-            cancellation of the task and its descendant tasks is completed. Defaults
-            to false
+        :arg wait_for_completion: Should this request wait until the
+            operation has completed before returning.
         """
         return await self.transport.perform_request(
             "POST",
@@ -105,16 +106,11 @@ class TasksClient(NamespacedClient):
         Returns information about a task.
 
 
-        .. warning::
-
-            This API is **experimental** so may include breaking changes
-            or be removed in a future version
-
         :arg task_id: Return the task with specified id
-            (node_id:task_number)
-        :arg timeout: Explicit operation timeout
-        :arg wait_for_completion: Wait for the matching tasks to
-            complete (default: false)
+            (node_id:task_number).
+        :arg timeout: Operation timeout.
+        :arg wait_for_completion: Should this request wait until the
+            operation has completed before returning.
         """
         if task_id in SKIP_IN_PATH:
             warnings.warn(

--- a/opensearchpy/_async/client/tasks.pyi
+++ b/opensearchpy/_async/client/tasks.pyi
@@ -24,6 +24,15 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+# ----------------------------------------------------
+# THIS CODE IS GENERATED AND MANUAL EDITS WILL BE LOST.
+#
+# To contribute, kindly make essential modifications through either the "opensearch-py client generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or the "OpenSearch API specification" available at:
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
 from typing import Any, Collection, MutableMapping, Optional, Tuple, Union
 
 from .utils import NamespacedClient

--- a/opensearchpy/client/tasks.py
+++ b/opensearchpy/client/tasks.py
@@ -25,6 +25,16 @@
 #  under the License.
 
 
+# ----------------------------------------------------
+# THIS CODE IS GENERATED AND MANUAL EDITS WILL BE LOST.
+#
+# To contribute, kindly make essential modifications through either the "opensearch-py client generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or the "OpenSearch API specification" available at:
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
+
 import warnings
 
 from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
@@ -45,24 +55,20 @@ class TasksClient(NamespacedClient):
         Returns a list of tasks.
 
 
-        .. warning::
-
-            This API is **experimental** so may include breaking changes
-            or be removed in a future version
-
-        :arg actions: A comma-separated list of actions that should be
+        :arg actions: Comma-separated list of actions that should be
             returned. Leave empty to return all.
-        :arg detailed: Return detailed task information (default: false)
+        :arg detailed: Return detailed task information.
         :arg group_by: Group tasks by nodes or parent/child
-            relationships  Valid choices: nodes, parents, none  Default: nodes
-        :arg nodes: A comma-separated list of node IDs or names to limit
+            relationships.  Valid choices: nodes, parents, none
+        :arg nodes: Comma-separated list of node IDs or names to limit
             the returned information; use `_local` to return information from the
-            node you're connecting to, leave empty to get information from all nodes
+            node you're connecting to, leave empty to get information from all
+            nodes.
         :arg parent_task_id: Return tasks with specified parent task id
             (node_id:task_number). Set to -1 to return all.
-        :arg timeout: Explicit operation timeout
-        :arg wait_for_completion: Wait for the matching tasks to
-            complete (default: false)
+        :arg timeout: Operation timeout.
+        :arg wait_for_completion: Should this request wait until the
+            operation has completed before returning.
         """
         return self.transport.perform_request(
             "GET", "/_tasks", params=params, headers=headers
@@ -74,23 +80,18 @@ class TasksClient(NamespacedClient):
         Cancels a task, if it can be cancelled through an API.
 
 
-        .. warning::
-
-            This API is **experimental** so may include breaking changes
-            or be removed in a future version
-
         :arg task_id: Cancel the task with specified task id
-            (node_id:task_number)
-        :arg actions: A comma-separated list of actions that should be
+            (node_id:task_number).
+        :arg actions: Comma-separated list of actions that should be
             cancelled. Leave empty to cancel all.
-        :arg nodes: A comma-separated list of node IDs or names to limit
+        :arg nodes: Comma-separated list of node IDs or names to limit
             the returned information; use `_local` to return information from the
-            node you're connecting to, leave empty to get information from all nodes
+            node you're connecting to, leave empty to get information from all
+            nodes.
         :arg parent_task_id: Cancel tasks with specified parent task id
             (node_id:task_number). Set to -1 to cancel all.
-        :arg wait_for_completion: Should the request block until the
-            cancellation of the task and its descendant tasks is completed. Defaults
-            to false
+        :arg wait_for_completion: Should this request wait until the
+            operation has completed before returning.
         """
         return self.transport.perform_request(
             "POST",
@@ -105,16 +106,11 @@ class TasksClient(NamespacedClient):
         Returns information about a task.
 
 
-        .. warning::
-
-            This API is **experimental** so may include breaking changes
-            or be removed in a future version
-
         :arg task_id: Return the task with specified id
-            (node_id:task_number)
-        :arg timeout: Explicit operation timeout
-        :arg wait_for_completion: Wait for the matching tasks to
-            complete (default: false)
+            (node_id:task_number).
+        :arg timeout: Operation timeout.
+        :arg wait_for_completion: Should this request wait until the
+            operation has completed before returning.
         """
         if task_id in SKIP_IN_PATH:
             warnings.warn(

--- a/opensearchpy/client/tasks.pyi
+++ b/opensearchpy/client/tasks.pyi
@@ -24,6 +24,15 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+# ----------------------------------------------------
+# THIS CODE IS GENERATED AND MANUAL EDITS WILL BE LOST.
+#
+# To contribute, kindly make essential modifications through either the "opensearch-py client generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or the "OpenSearch API specification" available at:
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
 from typing import Any, Collection, MutableMapping, Optional, Tuple, Union
 
 from .utils import NamespacedClient

--- a/utils/generated_file_headers.txt
+++ b/utils/generated_file_headers.txt
@@ -1,8 +1,8 @@
 # ----------------------------------------------------
-# THIS CODE IS GENERATED. MANUAL EDITS WILL BE LOST. 
-# 
-# To contribute, please make necessary modifications to either "Python generator":
+# THIS CODE IS GENERATED AND MANUAL EDITS WILL BE LOST.
+#
+# To contribute, kindly make essential modifications through either the "opensearch-py client generator":
 # https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
-# or "OpenAPI specs":
+# or the "OpenSearch API specification" available at:
 # https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
 # -----------------------------------------------------


### PR DESCRIPTION

### Description

- Integrated generated `tasks client` APIs into the existing module, ensuring alignment with the server and maintaining backward compatibility.
- The experimental APIs warning is not generated, and if necessary, I can include it using overrides. However, it's worth noting that the [documentation](https://opensearch.org/docs/latest/api-reference/tasks) no longer references these APIs as experimental."

### Issues Resolved
Related to #477 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
