### PR TITLE
Integrated generated "ingest" client APIs into the existing module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added point-in-time APIs (create_pit, delete_pit, delete_all_pits, get_all_pits) and Security Client APIs (health and update_audit_configuration) ([#502](https://github.com/opensearch-project/opensearch-py/pull/502))
 ### Changed
 - Integrated generated `tasks client` APIs into the existing module, ensuring alignment with the server and maintaining backward compatibility ([#508](https://github.com/opensearch-project/opensearch-py/pull/508))
+- Integrated generated `ingest client` APIs into the existing module, ensuring alignment with the server and maintaining backward compatibility ([#513](https://github.com/opensearch-project/opensearch-py/pull/513))
 ### Deprecated
 - Deprecated point-in-time APIs (list_all_point_in_time, create_point_in_time, delete_point_in_time) and Security Client APIs (health_check and update_audit_config) ([#502](https://github.com/opensearch-project/opensearch-py/pull/502))
 ### Removed

--- a/opensearchpy/_async/client/ingest.py
+++ b/opensearchpy/_async/client/ingest.py
@@ -25,42 +25,52 @@
 #  under the License.
 
 
+# ----------------------------------------------------
+# THIS CODE IS GENERATED AND MANUAL EDITS WILL BE LOST.
+#
+# To contribute, kindly make essential modifications through either the "opensearch-py client generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or the "OpenSearch API specification" available at:
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
+
 from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class IngestClient(NamespacedClient):
-    @query_params("master_timeout", "cluster_manager_timeout", "summary")
+    @query_params("cluster_manager_timeout", "master_timeout")
     async def get_pipeline(self, id=None, params=None, headers=None):
         """
         Returns a pipeline.
 
 
-        :arg id: Comma separated list of pipeline ids. Wildcards
-            supported
-        :arg master_timeout (Deprecated: use cluster_manager_timeout): Explicit operation timeout for connection
-            to master node
-        :arg cluster_manager_timeout: Explicit operation timeout for connection
-            to cluster_manager node
-        :arg summary: Return pipelines without their definitions
-            (default: false)
+        :arg id: Comma-separated list of pipeline ids. Wildcards
+            supported.
+        :arg cluster_manager_timeout: Operation timeout for connection
+            to cluster-manager node.
+        :arg master_timeout (Deprecated: To promote inclusive language,
+            use 'cluster_manager_timeout' instead): Operation timeout for connection
+            to master node.
         """
         return await self.transport.perform_request(
             "GET", _make_path("_ingest", "pipeline", id), params=params, headers=headers
         )
 
-    @query_params("master_timeout", "cluster_manager_timeout", "timeout")
+    @query_params("cluster_manager_timeout", "master_timeout", "timeout")
     async def put_pipeline(self, id, body, params=None, headers=None):
         """
         Creates or updates a pipeline.
 
 
-        :arg id: Pipeline ID
+        :arg id: Pipeline ID.
         :arg body: The ingest definition
-        :arg master_timeout (Deprecated: use cluster_manager_timeout): Explicit operation timeout for connection
-            to master node
-        :arg cluster_manager_timeout: Explicit operation timeout for connection
-            to cluster_manager node
-        :arg timeout: Explicit operation timeout
+        :arg cluster_manager_timeout: Operation timeout for connection
+            to cluster-manager node.
+        :arg master_timeout (Deprecated: To promote inclusive language,
+            use 'cluster_manager_timeout' instead): Operation timeout for connection
+            to master node.
+        :arg timeout: Operation timeout.
         """
         for param in (id, body):
             if param in SKIP_IN_PATH:
@@ -74,18 +84,19 @@ class IngestClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("master_timeout", "cluster_manager_timeout", "timeout")
+    @query_params("cluster_manager_timeout", "master_timeout", "timeout")
     async def delete_pipeline(self, id, params=None, headers=None):
         """
         Deletes a pipeline.
 
 
-        :arg id: Pipeline ID
-        :arg master_timeout (Deprecated: use cluster_manager_timeout): Explicit operation timeout for connection
-            to master node
-        :arg cluster_manager_timeout: Explicit operation timeout for connection
-            to cluster_manager node
-        :arg timeout: Explicit operation timeout
+        :arg id: Pipeline ID.
+        :arg cluster_manager_timeout: Operation timeout for connection
+            to cluster-manager node.
+        :arg master_timeout (Deprecated: To promote inclusive language,
+            use 'cluster_manager_timeout' instead): Operation timeout for connection
+            to master node.
+        :arg timeout: Operation timeout.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'id'.")
@@ -104,9 +115,9 @@ class IngestClient(NamespacedClient):
 
 
         :arg body: The simulate definition
-        :arg id: Pipeline ID
+        :arg id: Pipeline ID.
         :arg verbose: Verbose mode. Display data output for each
-            processor in executed pipeline
+            processor in executed pipeline.
         """
         if body in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'body'.")
@@ -127,14 +138,4 @@ class IngestClient(NamespacedClient):
         """
         return await self.transport.perform_request(
             "GET", "/_ingest/processor/grok", params=params, headers=headers
-        )
-
-    @query_params()
-    async def geo_ip_stats(self, params=None, headers=None):
-        """
-        Returns statistical information about geoip databases
-
-        """
-        return await self.transport.perform_request(
-            "GET", "/_ingest/geoip/stats", params=params, headers=headers
         )

--- a/opensearchpy/_async/client/ingest.pyi
+++ b/opensearchpy/_async/client/ingest.pyi
@@ -24,6 +24,15 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+# ----------------------------------------------------
+# THIS CODE IS GENERATED AND MANUAL EDITS WILL BE LOST.
+#
+# To contribute, kindly make essential modifications through either the "opensearch-py client generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or the "OpenSearch API specification" available at:
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
 from typing import Any, Collection, MutableMapping, Optional, Tuple, Union
 
 from .utils import NamespacedClient
@@ -33,9 +42,8 @@ class IngestClient(NamespacedClient):
         self,
         *,
         id: Optional[Any] = ...,
-        master_timeout: Optional[Any] = ...,
         cluster_manager_timeout: Optional[Any] = ...,
-        summary: Optional[Any] = ...,
+        master_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -54,8 +62,8 @@ class IngestClient(NamespacedClient):
         id: Any,
         *,
         body: Any,
-        master_timeout: Optional[Any] = ...,
         cluster_manager_timeout: Optional[Any] = ...,
+        master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -74,8 +82,8 @@ class IngestClient(NamespacedClient):
         self,
         id: Any,
         *,
-        master_timeout: Optional[Any] = ...,
         cluster_manager_timeout: Optional[Any] = ...,
+        master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -110,22 +118,6 @@ class IngestClient(NamespacedClient):
         headers: Optional[MutableMapping[str, str]] = ...,
     ) -> Any: ...
     async def processor_grok(
-        self,
-        *,
-        pretty: Optional[bool] = ...,
-        human: Optional[bool] = ...,
-        error_trace: Optional[bool] = ...,
-        format: Optional[str] = ...,
-        filter_path: Optional[Union[str, Collection[str]]] = ...,
-        request_timeout: Optional[Union[int, float]] = ...,
-        ignore: Optional[Union[int, Collection[int]]] = ...,
-        opaque_id: Optional[str] = ...,
-        http_auth: Optional[Union[str, Tuple[str, str]]] = ...,
-        api_key: Optional[Union[str, Tuple[str, str]]] = ...,
-        params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
-    ) -> Any: ...
-    async def geo_ip_stats(
         self,
         *,
         pretty: Optional[bool] = ...,

--- a/opensearchpy/client/ingest.py
+++ b/opensearchpy/client/ingest.py
@@ -25,42 +25,52 @@
 #  under the License.
 
 
+# ----------------------------------------------------
+# THIS CODE IS GENERATED AND MANUAL EDITS WILL BE LOST.
+#
+# To contribute, kindly make essential modifications through either the "opensearch-py client generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or the "OpenSearch API specification" available at:
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
+
 from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class IngestClient(NamespacedClient):
-    @query_params("master_timeout", "cluster_manager_timeout", "summary")
+    @query_params("cluster_manager_timeout", "master_timeout")
     def get_pipeline(self, id=None, params=None, headers=None):
         """
         Returns a pipeline.
 
 
-        :arg id: Comma separated list of pipeline ids. Wildcards
-            supported
-        :arg master_timeout (Deprecated: use cluster_manager_timeout): Explicit operation timeout for connection
-            to master node
-        :arg cluster_manager_timeout: Explicit operation timeout for connection
-            to cluster_manager node
-        :arg summary: Return pipelines without their definitions
-            (default: false)
+        :arg id: Comma-separated list of pipeline ids. Wildcards
+            supported.
+        :arg cluster_manager_timeout: Operation timeout for connection
+            to cluster-manager node.
+        :arg master_timeout (Deprecated: To promote inclusive language,
+            use 'cluster_manager_timeout' instead): Operation timeout for connection
+            to master node.
         """
         return self.transport.perform_request(
             "GET", _make_path("_ingest", "pipeline", id), params=params, headers=headers
         )
 
-    @query_params("master_timeout", "cluster_manager_timeout", "timeout")
+    @query_params("cluster_manager_timeout", "master_timeout", "timeout")
     def put_pipeline(self, id, body, params=None, headers=None):
         """
         Creates or updates a pipeline.
 
 
-        :arg id: Pipeline ID
+        :arg id: Pipeline ID.
         :arg body: The ingest definition
-        :arg master_timeout (Deprecated: use cluster_manager_timeout): Explicit operation timeout for connection
-            to master node
-        :arg cluster_manager_timeout: Explicit operation timeout for connection
-            to cluster_manager node
-        :arg timeout: Explicit operation timeout
+        :arg cluster_manager_timeout: Operation timeout for connection
+            to cluster-manager node.
+        :arg master_timeout (Deprecated: To promote inclusive language,
+            use 'cluster_manager_timeout' instead): Operation timeout for connection
+            to master node.
+        :arg timeout: Operation timeout.
         """
         for param in (id, body):
             if param in SKIP_IN_PATH:
@@ -74,18 +84,19 @@ class IngestClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("master_timeout", "cluster_manager_timeout", "timeout")
+    @query_params("cluster_manager_timeout", "master_timeout", "timeout")
     def delete_pipeline(self, id, params=None, headers=None):
         """
         Deletes a pipeline.
 
 
-        :arg id: Pipeline ID
-        :arg master_timeout (Deprecated: use cluster_manager_timeout): Explicit operation timeout for connection
-            to master node
-        :arg cluster_manager_timeout: Explicit operation timeout for connection
-            to cluster_manager node
-        :arg timeout: Explicit operation timeout
+        :arg id: Pipeline ID.
+        :arg cluster_manager_timeout: Operation timeout for connection
+            to cluster-manager node.
+        :arg master_timeout (Deprecated: To promote inclusive language,
+            use 'cluster_manager_timeout' instead): Operation timeout for connection
+            to master node.
+        :arg timeout: Operation timeout.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'id'.")
@@ -104,9 +115,9 @@ class IngestClient(NamespacedClient):
 
 
         :arg body: The simulate definition
-        :arg id: Pipeline ID
+        :arg id: Pipeline ID.
         :arg verbose: Verbose mode. Display data output for each
-            processor in executed pipeline
+            processor in executed pipeline.
         """
         if body in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'body'.")
@@ -127,14 +138,4 @@ class IngestClient(NamespacedClient):
         """
         return self.transport.perform_request(
             "GET", "/_ingest/processor/grok", params=params, headers=headers
-        )
-
-    @query_params()
-    def geo_ip_stats(self, params=None, headers=None):
-        """
-        Returns statistical information about geoip databases
-
-        """
-        return self.transport.perform_request(
-            "GET", "/_ingest/geoip/stats", params=params, headers=headers
         )

--- a/opensearchpy/client/ingest.pyi
+++ b/opensearchpy/client/ingest.pyi
@@ -24,6 +24,15 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+# ----------------------------------------------------
+# THIS CODE IS GENERATED AND MANUAL EDITS WILL BE LOST.
+#
+# To contribute, kindly make essential modifications through either the "opensearch-py client generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or the "OpenSearch API specification" available at:
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
 from typing import Any, Collection, MutableMapping, Optional, Tuple, Union
 
 from .utils import NamespacedClient
@@ -33,9 +42,8 @@ class IngestClient(NamespacedClient):
         self,
         *,
         id: Optional[Any] = ...,
-        master_timeout: Optional[Any] = ...,
         cluster_manager_timeout: Optional[Any] = ...,
-        summary: Optional[Any] = ...,
+        master_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -54,8 +62,8 @@ class IngestClient(NamespacedClient):
         id: Any,
         *,
         body: Any,
-        master_timeout: Optional[Any] = ...,
         cluster_manager_timeout: Optional[Any] = ...,
+        master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -74,8 +82,8 @@ class IngestClient(NamespacedClient):
         self,
         id: Any,
         *,
-        master_timeout: Optional[Any] = ...,
         cluster_manager_timeout: Optional[Any] = ...,
+        master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -110,22 +118,6 @@ class IngestClient(NamespacedClient):
         headers: Optional[MutableMapping[str, str]] = ...,
     ) -> Any: ...
     def processor_grok(
-        self,
-        *,
-        pretty: Optional[bool] = ...,
-        human: Optional[bool] = ...,
-        error_trace: Optional[bool] = ...,
-        format: Optional[str] = ...,
-        filter_path: Optional[Union[str, Collection[str]]] = ...,
-        request_timeout: Optional[Union[int, float]] = ...,
-        ignore: Optional[Union[int, Collection[int]]] = ...,
-        opaque_id: Optional[str] = ...,
-        http_auth: Optional[Union[str, Tuple[str, str]]] = ...,
-        api_key: Optional[Union[str, Tuple[str, str]]] = ...,
-        params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
-    ) -> Any: ...
-    def geo_ip_stats(
         self,
         *,
         pretty: Optional[bool] = ...,

--- a/utils/generate-api.py
+++ b/utils/generate-api.py
@@ -448,9 +448,11 @@ def read_modules():
 
     for path in data["paths"]:
         for x in data["paths"][path]:
-            if "deprecated" not in data["paths"][path][x]:
-                data["paths"][path][x].update({"path": path, "method": x})
-                list_of_dicts.append(data["paths"][path][x])
+            if data["paths"][path][x]["x-operation-group"] == "nodes.hot_threads":
+                if "deprecated" in data["paths"][path][x]:
+                    continue
+            data["paths"][path][x].update({"path": path, "method": x})
+            list_of_dicts.append(data["paths"][path][x])
 
     # Update parameters  in each endpoint
     for p in list_of_dicts:
@@ -484,12 +486,15 @@ def read_modules():
                     A.update({"type": "enum"})
                     A.update({"options": m["schema"]["enum"]})
 
-                if "deprecated" in m:
-                    A.update({"deprecated": m["deprecated"]})
+                if "deprecated" in m["schema"]:
+                    A.update({"deprecated": m["schema"]["deprecated"]})
+                    A.update(
+                        {"deprecation_message": m["schema"]["x-deprecation-message"]}
+                    )
                 params_new.update({m["name"]: A})
 
             # Removing the deprecated "type"
-            if "type" in params_new:
+            if p["x-operation-group"] != "nodes.hot_threads" and "type" in params_new:
                 params_new.pop("type")
 
             if bool(params_new):

--- a/utils/templates/base
+++ b/utils/templates/base
@@ -21,7 +21,7 @@
 
         {% for p, info in api.params %}
         {% filter wordwrap(72, wrapstring="\n            ") %}
-        :arg {{ p }}: {{ info.description }}{% if info.options %}  Valid choices: {{ info.options|join(", ") }}{% endif %}{% if info.default %}  Default: {{ info.default }}{% endif %}
+        :arg {{ p }}{% if info.deprecated %} (Deprecated: {{ info['deprecation_message'][:-1] }}){% endif %}: {{ info.description }}{% if info.options %}  Valid choices: {{ info.options|join(", ") }}{% endif %}{% if info.default %}  Default: {{ info.default }}{% endif %}
         {% endfilter %}
 
         {% endfor %}


### PR DESCRIPTION
### Description
Integrated generated ingest client APIs into the existing module, ensuring alignment with the server and maintaining backward compatibility

### Issues Resolved
Related to #477 



### Testing the "summary" parameter in the "get_pipeline" API resulted in an error indicating that the parameter is unrecognized (Implies generated "get_pipeline" is correct)
```
put https://localhost:9200/_ingest/pipeline/pipelineid123

{
  "description": "This pipeline processes student data",
  "processors": [
    {
      "set": {
        "description": "Sets the graduation year to 2023",
        "field": "grad_year",
        "value": 2023
      }
    },
    {
      "set": {
        "description": "Sets graduated to true",
        "field": "graduated",
        "value": true
      }
    },
    {
      "uppercase": {
        "field": "name"
      }
    }
  ]
}
```
{
"acknowledged": true
}

`get https://localhost:9200/_ingest/pipeline/pipelineid123?summary=true`
{
"error": {
"root_cause": [
{
"type": "illegal_argument_exception",
"reason": "request [/_ingest/pipeline/pipelineid123] contains unrecognized parameter: [summary]"
}
],
"type": "illegal_argument_exception",
"reason": "request [/_ingest/pipeline/pipelineid123] contains unrecognized parameter: [summary]"
},
"status": 400
}

### Ingest.geo_ip_stats should be removed from client(Generator is correct)

`client.ingest.geo_ip_stats() `
RequestError: RequestError(400, 'no handler found for uri [/_ingest/geoip/stats] and method [GET]', 'no handler found for uri [/_ingest/geoip/stats] and method [GET]')


### Before giving your approval, kindly double-check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
