### PR TITLE
Integrated generated 'nodes' client APIs into the existing module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added point-in-time APIs (create_pit, delete_pit, delete_all_pits, get_all_pits) and Security Client APIs (health and update_audit_configuration) ([#502](https://github.com/opensearch-project/opensearch-py/pull/502))
 ### Changed
 - Integrated generated `tasks client` APIs into the existing module, ensuring alignment with the server and maintaining backward compatibility ([#508](https://github.com/opensearch-project/opensearch-py/pull/508))
+- Integrated generated `nodes client` APIs into the existing module, ensuring alignment with the server and maintaining backward compatibility ([#514](https://github.com/opensearch-project/opensearch-py/pull/514))
 ### Deprecated
 - Deprecated point-in-time APIs (list_all_point_in_time, create_point_in_time, delete_point_in_time) and Security Client APIs (health_check and update_audit_config) ([#502](https://github.com/opensearch-project/opensearch-py/pull/502))
 ### Removed

--- a/opensearchpy/_async/client/nodes.py
+++ b/opensearchpy/_async/client/nodes.py
@@ -25,6 +25,16 @@
 #  under the License.
 
 
+# ----------------------------------------------------
+# THIS CODE IS GENERATED AND MANUAL EDITS WILL BE LOST.
+#
+# To contribute, kindly make essential modifications through either the "opensearch-py client generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or the "OpenSearch API specification" available at:
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
+
 from .utils import NamespacedClient, _make_path, query_params
 
 
@@ -37,12 +47,12 @@ class NodesClient(NamespacedClient):
         Reloads secure settings.
 
 
-        :arg body: An object containing the password for the
-            opensearch keystore
-        :arg node_id: A comma-separated list of node IDs to span the
+        :arg body: An object containing the password for the opensearch
+            keystore
+        :arg node_id: Comma-separated list of node IDs to span the
             reload/reinit call. Should stay empty because reloading usually involves
             all cluster nodes.
-        :arg timeout: Explicit operation timeout
+        :arg timeout: Operation timeout.
         """
         return await self.transport.perform_request(
             "POST",
@@ -58,16 +68,16 @@ class NodesClient(NamespacedClient):
         Returns information about nodes in the cluster.
 
 
-        :arg node_id: A comma-separated list of node IDs or names to
-            limit the returned information; use `_local` to return information from
-            the node you're connecting to, leave empty to get information from all
-            nodes
-        :arg metric: A comma-separated list of metrics you wish
-            returned. Leave empty to return all.  Valid choices: settings, os,
-            process, jvm, thread_pool, transport, http, plugins, ingest
-        :arg flat_settings: Return settings in flat format (default:
+        :arg node_id: Comma-separated list of node IDs or names to limit
+            the returned information; use `_local` to return information from the
+            node you're connecting to, leave empty to get information from all
+            nodes.
+        :arg metric: Comma-separated list of metrics you wish returned.
+            Leave empty to return all.  Valid choices: settings, os, process, jvm,
+            thread_pool, transport, http, plugins, ingest
+        :arg flat_settings: Return settings in flat format. (default:
             false)
-        :arg timeout: Explicit operation timeout
+        :arg timeout: Operation timeout.
         """
         return await self.transport.perform_request(
             "GET", _make_path("_nodes", node_id, metric), params=params, headers=headers
@@ -79,7 +89,6 @@ class NodesClient(NamespacedClient):
         "fields",
         "groups",
         "include_segment_file_sizes",
-        "include_unloaded_segments",
         "level",
         "timeout",
         "types",
@@ -91,37 +100,34 @@ class NodesClient(NamespacedClient):
         Returns statistical information about nodes in the cluster.
 
 
-        :arg node_id: A comma-separated list of node IDs or names to
-            limit the returned information; use `_local` to return information from
-            the node you're connecting to, leave empty to get information from all
-            nodes
+        :arg node_id: Comma-separated list of node IDs or names to limit
+            the returned information; use `_local` to return information from the
+            node you're connecting to, leave empty to get information from all
+            nodes.
         :arg metric: Limit the information returned to the specified
-            metrics  Valid choices: _all, breaker, fs, http, indices, jvm, os,
+            metrics.  Valid choices: _all, breaker, fs, http, indices, jvm, os,
             process, thread_pool, transport, discovery, indexing_pressure
         :arg index_metric: Limit the information returned for `indices`
             metric to the specific index metrics. Isn't used if `indices` (or `all`)
-            metric isn't specified.  Valid choices: _all, completion, docs,
-            fielddata, query_cache, flush, get, indexing, merge, request_cache,
-            refresh, search, segments, store, warmer, suggest
-        :arg completion_fields: A comma-separated list of fields for
-            `fielddata` and `suggest` index metric (supports wildcards)
-        :arg fielddata_fields: A comma-separated list of fields for
-            `fielddata` index metric (supports wildcards)
-        :arg fields: A comma-separated list of fields for `fielddata`
-            and `completion` index metric (supports wildcards)
-        :arg groups: A comma-separated list of search groups for
-            `search` index metric
+            metric isn't specified.  Valid choices: _all, store, indexing, get,
+            search, merge, flush, refresh, query_cache, fielddata, docs, warmer,
+            completion, segments, translog, suggest, request_cache, recovery
+        :arg completion_fields: Comma-separated list of fields for
+            `fielddata` and `suggest` index metric (supports wildcards).
+        :arg fielddata_fields: Comma-separated list of fields for
+            `fielddata` index metric (supports wildcards).
+        :arg fields: Comma-separated list of fields for `fielddata` and
+            `completion` index metric (supports wildcards).
+        :arg groups: Comma-separated list of search groups for `search`
+            index metric.
         :arg include_segment_file_sizes: Whether to report the
             aggregated disk usage of each one of the Lucene index files (only
-            applies if segment stats are requested)
-        :arg include_unloaded_segments: If set to true segment stats
-            will include stats for segments that are not currently loaded into
-            memory
+            applies if segment stats are requested). (default: false)
         :arg level: Return indices stats aggregated at index, node or
-            shard level  Valid choices: indices, node, shards  Default: node
-        :arg timeout: Explicit operation timeout
-        :arg types: A comma-separated list of document types for the
-            `indexing` index metric
+            shard level.  Valid choices: indices, node, shards
+        :arg timeout: Operation timeout.
+        :arg types: Comma-separated list of document types for the
+            `indexing` index metric.
         """
         return await self.transport.perform_request(
             "GET",
@@ -138,21 +144,21 @@ class NodesClient(NamespacedClient):
         Returns information about hot threads on each node in the cluster.
 
 
-        :arg node_id: A comma-separated list of node IDs or names to
-            limit the returned information; use `_local` to return information from
-            the node you're connecting to, leave empty to get information from all
-            nodes
-        :arg doc_type: The type to sample (default: cpu)  Valid choices:
-            cpu, wait, block
+        :arg node_id: Comma-separated list of node IDs or names to limit
+            the returned information; use `_local` to return information from the
+            node you're connecting to, leave empty to get information from all
+            nodes.
+        :arg doc_type: The type to sample.  Valid choices: cpu, wait,
+            block
         :arg ignore_idle_threads: Don't show threads that are in known-
             idle places, such as waiting on a socket select or pulling from an empty
-            task queue (default: true)
-        :arg interval: The interval for the second sampling of threads
-        :arg snapshots: Number of samples of thread stacktrace (default:
-            10)
+            task queue. (default: True)
+        :arg interval: The interval for the second sampling of threads.
+        :arg snapshots: Number of samples of thread stacktrace.
+            (default: 10)
         :arg threads: Specify the number of threads to provide
-            information for (default: 3)
-        :arg timeout: Explicit operation timeout
+            information for. (default: 3)
+        :arg timeout: Operation timeout.
         """
         # type is a reserved word so it cannot be used, use doc_type instead
         if "doc_type" in params:
@@ -171,13 +177,13 @@ class NodesClient(NamespacedClient):
         Returns low-level information about REST actions usage on nodes.
 
 
-        :arg node_id: A comma-separated list of node IDs or names to
-            limit the returned information; use `_local` to return information from
-            the node you're connecting to, leave empty to get information from all
-            nodes
+        :arg node_id: Comma-separated list of node IDs or names to limit
+            the returned information; use `_local` to return information from the
+            node you're connecting to, leave empty to get information from all
+            nodes.
         :arg metric: Limit the information returned to the specified
-            metrics  Valid choices: _all, rest_actions
-        :arg timeout: Explicit operation timeout
+            metrics.  Valid choices: _all, rest_actions
+        :arg timeout: Operation timeout.
         """
         return await self.transport.perform_request(
             "GET",

--- a/opensearchpy/_async/client/nodes.pyi
+++ b/opensearchpy/_async/client/nodes.pyi
@@ -24,6 +24,15 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+# ----------------------------------------------------
+# THIS CODE IS GENERATED AND MANUAL EDITS WILL BE LOST.
+#
+# To contribute, kindly make essential modifications through either the "opensearch-py client generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or the "OpenSearch API specification" available at:
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
 from typing import Any, Collection, MutableMapping, Optional, Tuple, Union
 
 from .utils import NamespacedClient
@@ -79,7 +88,6 @@ class NodesClient(NamespacedClient):
         fields: Optional[Any] = ...,
         groups: Optional[Any] = ...,
         include_segment_file_sizes: Optional[Any] = ...,
-        include_unloaded_segments: Optional[Any] = ...,
         level: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         types: Optional[Any] = ...,

--- a/opensearchpy/client/nodes.py
+++ b/opensearchpy/client/nodes.py
@@ -25,6 +25,16 @@
 #  under the License.
 
 
+# ----------------------------------------------------
+# THIS CODE IS GENERATED AND MANUAL EDITS WILL BE LOST.
+#
+# To contribute, kindly make essential modifications through either the "opensearch-py client generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or the "OpenSearch API specification" available at:
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
+
 from .utils import NamespacedClient, _make_path, query_params
 
 
@@ -37,12 +47,12 @@ class NodesClient(NamespacedClient):
         Reloads secure settings.
 
 
-        :arg body: An object containing the password for the
-            opensearch keystore
-        :arg node_id: A comma-separated list of node IDs to span the
+        :arg body: An object containing the password for the opensearch
+            keystore
+        :arg node_id: Comma-separated list of node IDs to span the
             reload/reinit call. Should stay empty because reloading usually involves
             all cluster nodes.
-        :arg timeout: Explicit operation timeout
+        :arg timeout: Operation timeout.
         """
         return self.transport.perform_request(
             "POST",
@@ -58,16 +68,16 @@ class NodesClient(NamespacedClient):
         Returns information about nodes in the cluster.
 
 
-        :arg node_id: A comma-separated list of node IDs or names to
-            limit the returned information; use `_local` to return information from
-            the node you're connecting to, leave empty to get information from all
-            nodes
-        :arg metric: A comma-separated list of metrics you wish
-            returned. Leave empty to return all.  Valid choices: settings, os,
-            process, jvm, thread_pool, transport, http, plugins, ingest
-        :arg flat_settings: Return settings in flat format (default:
+        :arg node_id: Comma-separated list of node IDs or names to limit
+            the returned information; use `_local` to return information from the
+            node you're connecting to, leave empty to get information from all
+            nodes.
+        :arg metric: Comma-separated list of metrics you wish returned.
+            Leave empty to return all.  Valid choices: settings, os, process, jvm,
+            thread_pool, transport, http, plugins, ingest
+        :arg flat_settings: Return settings in flat format. (default:
             false)
-        :arg timeout: Explicit operation timeout
+        :arg timeout: Operation timeout.
         """
         return self.transport.perform_request(
             "GET", _make_path("_nodes", node_id, metric), params=params, headers=headers
@@ -79,7 +89,6 @@ class NodesClient(NamespacedClient):
         "fields",
         "groups",
         "include_segment_file_sizes",
-        "include_unloaded_segments",
         "level",
         "timeout",
         "types",
@@ -91,37 +100,34 @@ class NodesClient(NamespacedClient):
         Returns statistical information about nodes in the cluster.
 
 
-        :arg node_id: A comma-separated list of node IDs or names to
-            limit the returned information; use `_local` to return information from
-            the node you're connecting to, leave empty to get information from all
-            nodes
+        :arg node_id: Comma-separated list of node IDs or names to limit
+            the returned information; use `_local` to return information from the
+            node you're connecting to, leave empty to get information from all
+            nodes.
         :arg metric: Limit the information returned to the specified
-            metrics  Valid choices: _all, breaker, fs, http, indices, jvm, os,
+            metrics.  Valid choices: _all, breaker, fs, http, indices, jvm, os,
             process, thread_pool, transport, discovery, indexing_pressure
         :arg index_metric: Limit the information returned for `indices`
             metric to the specific index metrics. Isn't used if `indices` (or `all`)
-            metric isn't specified.  Valid choices: _all, completion, docs,
-            fielddata, query_cache, flush, get, indexing, merge, request_cache,
-            refresh, search, segments, store, warmer, suggest
-        :arg completion_fields: A comma-separated list of fields for
-            `fielddata` and `suggest` index metric (supports wildcards)
-        :arg fielddata_fields: A comma-separated list of fields for
-            `fielddata` index metric (supports wildcards)
-        :arg fields: A comma-separated list of fields for `fielddata`
-            and `completion` index metric (supports wildcards)
-        :arg groups: A comma-separated list of search groups for
-            `search` index metric
+            metric isn't specified.  Valid choices: _all, store, indexing, get,
+            search, merge, flush, refresh, query_cache, fielddata, docs, warmer,
+            completion, segments, translog, suggest, request_cache, recovery
+        :arg completion_fields: Comma-separated list of fields for
+            `fielddata` and `suggest` index metric (supports wildcards).
+        :arg fielddata_fields: Comma-separated list of fields for
+            `fielddata` index metric (supports wildcards).
+        :arg fields: Comma-separated list of fields for `fielddata` and
+            `completion` index metric (supports wildcards).
+        :arg groups: Comma-separated list of search groups for `search`
+            index metric.
         :arg include_segment_file_sizes: Whether to report the
             aggregated disk usage of each one of the Lucene index files (only
-            applies if segment stats are requested)
-        :arg include_unloaded_segments: If set to true segment stats
-            will include stats for segments that are not currently loaded into
-            memory
+            applies if segment stats are requested). (default: false)
         :arg level: Return indices stats aggregated at index, node or
-            shard level  Valid choices: indices, node, shards  Default: node
-        :arg timeout: Explicit operation timeout
-        :arg types: A comma-separated list of document types for the
-            `indexing` index metric
+            shard level.  Valid choices: indices, node, shards
+        :arg timeout: Operation timeout.
+        :arg types: Comma-separated list of document types for the
+            `indexing` index metric.
         """
         return self.transport.perform_request(
             "GET",
@@ -138,21 +144,21 @@ class NodesClient(NamespacedClient):
         Returns information about hot threads on each node in the cluster.
 
 
-        :arg node_id: A comma-separated list of node IDs or names to
-            limit the returned information; use `_local` to return information from
-            the node you're connecting to, leave empty to get information from all
-            nodes
-        :arg doc_type: The type to sample (default: cpu)  Valid choices:
-            cpu, wait, block
+        :arg node_id: Comma-separated list of node IDs or names to limit
+            the returned information; use `_local` to return information from the
+            node you're connecting to, leave empty to get information from all
+            nodes.
+        :arg doc_type: The type to sample.  Valid choices: cpu, wait,
+            block
         :arg ignore_idle_threads: Don't show threads that are in known-
             idle places, such as waiting on a socket select or pulling from an empty
-            task queue (default: true)
-        :arg interval: The interval for the second sampling of threads
-        :arg snapshots: Number of samples of thread stacktrace (default:
-            10)
+            task queue. (default: True)
+        :arg interval: The interval for the second sampling of threads.
+        :arg snapshots: Number of samples of thread stacktrace.
+            (default: 10)
         :arg threads: Specify the number of threads to provide
-            information for (default: 3)
-        :arg timeout: Explicit operation timeout
+            information for. (default: 3)
+        :arg timeout: Operation timeout.
         """
         # type is a reserved word so it cannot be used, use doc_type instead
         if "doc_type" in params:
@@ -171,13 +177,13 @@ class NodesClient(NamespacedClient):
         Returns low-level information about REST actions usage on nodes.
 
 
-        :arg node_id: A comma-separated list of node IDs or names to
-            limit the returned information; use `_local` to return information from
-            the node you're connecting to, leave empty to get information from all
-            nodes
+        :arg node_id: Comma-separated list of node IDs or names to limit
+            the returned information; use `_local` to return information from the
+            node you're connecting to, leave empty to get information from all
+            nodes.
         :arg metric: Limit the information returned to the specified
-            metrics  Valid choices: _all, rest_actions
-        :arg timeout: Explicit operation timeout
+            metrics.  Valid choices: _all, rest_actions
+        :arg timeout: Operation timeout.
         """
         return self.transport.perform_request(
             "GET",

--- a/opensearchpy/client/nodes.pyi
+++ b/opensearchpy/client/nodes.pyi
@@ -24,6 +24,15 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+# ----------------------------------------------------
+# THIS CODE IS GENERATED AND MANUAL EDITS WILL BE LOST.
+#
+# To contribute, kindly make essential modifications through either the "opensearch-py client generator":
+# https://github.com/opensearch-project/opensearch-py/blob/main/utils/generate-api.py
+# or the "OpenSearch API specification" available at:
+# https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json
+# -----------------------------------------------------
+
 from typing import Any, Collection, MutableMapping, Optional, Tuple, Union
 
 from .utils import NamespacedClient
@@ -79,7 +88,6 @@ class NodesClient(NamespacedClient):
         fields: Optional[Any] = ...,
         groups: Optional[Any] = ...,
         include_segment_file_sizes: Optional[Any] = ...,
-        include_unloaded_segments: Optional[Any] = ...,
         level: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         types: Optional[Any] = ...,


### PR DESCRIPTION
### Description
Integrated generated 'nodes' client APIs into the existing module, ensuring alignment with the server and maintaining backward compatibility

### Issues Resolved
Related to #477 

### Testing the "include_unloaded_segments" parameter in the "stats" API resulted in an error indicating that the parameter is unrecognized (Implies generated "stats" API is correct)

`get https://localhost:9200/_nodes/stats?include_unloaded_segments=true`

{
"error": {
"root_cause": [
{
"type": "illegal_argument_exception",
"reason": "request [/_nodes/stats] contains unrecognized parameter: [include_unloaded_segments]"
}
],
"type": "illegal_argument_exception",
"reason": "request [/_nodes/stats] contains unrecognized parameter: [include_unloaded_segments]"
},
"status": 400
}

### Before giving your approval, kindly double-check.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
