### PR TITLE
Bumps  urllib3 from >=1.21.1 to >=1.26.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Dependencies
 - Bumps `sphinx` from <7.1 to <7.3
 - Bumps `urllib3` from >=1.21.1, <2 to >=1.21.1 ([#466](https://github.com/opensearch-project/opensearch-py/pull/466))
+- Bumps `urllib3` from >=1.21.1 to >=1.26.9 ([#518](https://github.com/opensearch-project/opensearch-py/pull/518))
 
 ## [2.3.1]
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ packages = [
     if package == module_dir or package.startswith(module_dir + ".")
 ]
 install_requires = [
-    "urllib3>=1.21.1",
+    "urllib3>=1.26.9",
     "requests>=2.4.0, <3.0.0",
     "six",
     "python-dateutil",


### PR DESCRIPTION
### Description
Bumps  urllib3 from >=1.21.1 to >=1.26.9

### Issues Resolved
related to #516 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
