### PR TITLE
fixes: #512 Wrong return type hint in async_scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed patch versions in integration tests for OpenSearch 1.0.0 - 2.3.0 to reduce Github Action jobs ([#262](https://github.com/opensearch-project/opensearch-py/pull/262))
 ### Fixed
 - Fixed DeprecationWarning emitted from urllib3 1.26.13+ ([#246](https://github.com/opensearch-project/opensearch-py/pull/246))
+- Fixed Wrong return type hint in `async_scan` ([520](https://github.com/opensearch-project/opensearch-py/pull/520))
 ### Security
 
 [Unreleased]: https://github.com/opensearch-project/opensearch-py/compare/v2.3.1...HEAD

--- a/opensearchpy/_async/helpers/actions.pyi
+++ b/opensearchpy/_async/helpers/actions.pyi
@@ -100,7 +100,7 @@ def async_scan(
     clear_scroll: bool = ...,
     scroll_kwargs: Optional[Mapping[str, Any]] = ...,
     **kwargs: Any
-) -> AsyncGenerator[int, None]: ...
+) -> AsyncGenerator[dict[str, Any], None]: ...
 async def async_reindex(
     client: AsyncOpenSearch,
     source_index: Union[str, Collection[str]],


### PR DESCRIPTION
### Description
fixes: #512 Wrong return type hint in async_scan
Verified the same with [opensearch API](https://opensearch.org/docs/latest/search-plugins/async/index/)


### Issues Resolved
Closes #512 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
