### PR TITLE
Removed EOL Python3.5 & bumped urllib3 ver to patch security vulnerability.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       matrix:
         entry:
-          - { os: 'ubuntu-20.04', python-version: "3.5" }
           - { os: 'ubuntu-20.04', python-version: "3.6" }
           - { os: 'ubuntu-latest', python-version: "3.7" }
           - { os: 'ubuntu-latest', python-version: "3.8" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed race condition in AWSV4SignerAuth & AWSV4SignerAsyncAuth when using refreshable credentials ([#470](https://github.com/opensearch-project/opensearch-py/pull/470))
 ### Security
 ### Dependencies
+- Bumps `urllib3` from >= 1.26.9 to >= 1.26.17 [#533](https://github.com/opensearch-project/opensearch-py/pull/533)
 
 ## [2.3.0]
 ### Added
@@ -66,6 +67,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 - Removed support for Python 2.7 ([#421](https://github.com/opensearch-project/opensearch-py/pull/421))
+- Removed support for Python 3.5 ([#533](https://github.com/opensearch-project/opensearch-py/pull/533))
 ### Fixed
 - Fixed flaky CI tests by replacing httpbin with a simple http_server ([#395](https://github.com/opensearch-project/opensearch-py/pull/395))
 - Fixed import cycle when importing async helpers ([#311](https://github.com/opensearch-project/opensearch-py/pull/311))

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,7 +36,7 @@ SOURCE_FILES = (
 )
 
 
-@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"])
+@nox.session(python=["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"])
 def test(session):
     session.install(".")
     session.install("-r", "dev-requirements.txt")

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ packages = [
     if package == module_dir or package.startswith(module_dir + ".")
 ]
 install_requires = [
-    "urllib3>=1.26.9",
+    "urllib3>=1.26.17",
     "requests>=2.4.0, <3.0.0",
     "six",
     "python-dateutil",


### PR DESCRIPTION
### Description
The security vulnerability was detected in the package `urllib3`, and the fix necessitates an upgrade to `urllib3` version **1.26.17**. However, this upgrade is not compatible with Python version 3.5. As a consequence, this PR removes Python 3.5 references from ﻿`noxfile.py` and ﻿.`github/workflows/test.yml`.
The primary reason for removing Python 3.5, an End-of-Life version which can be referenced [here](https://github.com/opensearch-project/opensearch-py/issues/430), is to ensure the application's security and accommodate the updated urllib3 version. 


### Issues Resolved
This PR addresses high severity security vulnerability issue #532
This PR also meets one of the items in issue #430

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
