### PR TITLE
Add a nox session for client generator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added guide on making raw JSON REST requests ([#542](https://github.com/opensearch-project/opensearch-py/pull/542))
 - Added support for AWS SigV4 for urllib3 ([#547](https://github.com/opensearch-project/opensearch-py/pull/547))
 - Added `remote store` client APIs ([#552](https://github.com/opensearch-project/opensearch-py/pull/552))
+- Added `nox -rs generate` ([#554](https://github.com/opensearch-project/opensearch-py/pull/554))
 ### Changed
 - Generate `tasks` client from API specs ([#508](https://github.com/opensearch-project/opensearch-py/pull/508))
 - Generate `ingest` client from API specs ([#513](https://github.com/opensearch-project/opensearch-py/pull/513))

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,10 +1,10 @@
 - [Developer Guide](#developer-guide)
   - [Prerequisites](#prerequisites)
-  - [Docker Image Installation](#docker-setup)
+  - [Install Docker Image](#install-docker-image)
   - [Running Tests](#running-tests)
-  - [Integration Tests](#integration-tests)
+  - [Linter](#linter)
   - [Documentation](#documentation)
-  - [Running Python Client Generator](#running-python-client-generator)
+  - [Client Code Generator](#client-code-generator)
 
 # Developer Guide
 
@@ -115,12 +115,10 @@ make html
 
 Open `opensearch-py/docs/build/html/index.html` to see results.
 
-## Running Python Client Generator
+## Client Code Generator
 
-The following code executes a python client generator that updates the client by utilizing the [openapi specifications](https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json) found in the "opensearch-api-specification" repository. This process allows for the automatic generation and synchronization of the client code with the latest API specifications.
+OpenSearch publishes an [OpenAPI specification](https://github.com/opensearch-project/opensearch-api-specification/blob/main/OpenSearch.openapi.json) in the [opensearch-api-specification](https://github.com/opensearch-project/opensearch-api-specification) repository, which is used to auto-generate the less interesting parts of the client.
 
 ```
-cd opensearch-py
-python utils/generate-api.py
-nox -rs format
+nox -rs generate
 ```

--- a/noxfile.py
+++ b/noxfile.py
@@ -87,3 +87,10 @@ def docs(session):
         "-rdev-requirements.txt", "sphinx-rtd-theme", "sphinx-autodoc-typehints"
     )
     session.run("python", "-m", "pip", "install", "sphinx-autodoc-typehints")
+
+
+@nox.session()
+def generate(session):
+    session.install("-rdev-requirements.txt")
+    session.run("python", "utils/generate-api.py")
+    format(session)


### PR DESCRIPTION
### Description

Add a nox session for client generator.

Run `nox -rs generate` and stop dealing with missing dependencies.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
