### PR TITLE
Fix: don't hardcode client class name.

### DIFF
--- a/opensearchpy/_async/client/plugins.py
+++ b/opensearchpy/_async/client/plugins.py
@@ -44,7 +44,7 @@ class PluginsClient(NamespacedClient):
                 setattr(client, plugin, getattr(self, plugin))
             else:
                 warnings.warn(
-                    f"Cannot load `{plugin}` directly to AsyncOpenSearch. `{plugin}` already exists in AsyncOpenSearch. Please use `AsyncOpenSearch.plugin.{plugin}` instead.",
+                    f"Cannot load `{plugin}` directly to {self.client.__class__.__name__} as it already exists. Use `{self.client.__class__.__name__}.plugin.{plugin}` instead.",
                     category=RuntimeWarning,
                     stacklevel=2,
                 )

--- a/opensearchpy/client/plugins.py
+++ b/opensearchpy/client/plugins.py
@@ -7,7 +7,6 @@
 # Modifications Copyright OpenSearch Contributors. See
 # GitHub history for details.
 
-
 import warnings
 
 from ..plugins.alerting import AlertingClient
@@ -45,9 +44,7 @@ class PluginsClient(NamespacedClient):
                 setattr(client, plugin, getattr(self, plugin))
             else:
                 warnings.warn(
-                    "Cannot load `{plugin}` directly to OpenSearch. `{plugin}` already exists in OpenSearch. Please use `OpenSearch.plugin.{plugin}` instead.".format(
-                        plugin=plugin
-                    ),
+                    f"Cannot load `{plugin}` directly to {self.client.__class__.__name__} as it already exists. Use `{self.client.__class__.__name__}.plugin.{plugin}` instead.",
                     category=RuntimeWarning,
                     stacklevel=2,
                 )

--- a/test_opensearchpy/test_async/test_plugins_client.py
+++ b/test_opensearchpy/test_async/test_plugins_client.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+from unittest import TestCase
+
+from opensearchpy._async.client import AsyncOpenSearch
+
+
+class TestPluginsClient(TestCase):
+    async def test_plugins_client(self):
+        with self.assertWarns(Warning) as w:
+            client = AsyncOpenSearch()
+            client.plugins.__init__(client)  # double-init
+            self.assertEqual(
+                str(w.warnings[0].message),
+                "Cannot load `alerting` directly to AsyncOpenSearch as it already exists. Use `AsyncOpenSearch.plugin.alerting` instead.",
+            )

--- a/test_opensearchpy/test_client/test_plugins/test_plugins_client.py
+++ b/test_opensearchpy/test_client/test_plugins/test_plugins_client.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+from opensearchpy.client import OpenSearch
+
+from ...test_cases import TestCase
+
+
+class TestPluginsClient(TestCase):
+    def test_plugins_client(self):
+        with self.assertWarns(Warning) as w:
+            client = OpenSearch()
+            client.plugins.__init__(client)  # double-init
+            self.assertEqual(
+                str(w.warnings[0].message),
+                "Cannot load `alerting` directly to OpenSearch as it already exists. Use `OpenSearch.plugin.alerting` instead.",
+            )


### PR DESCRIPTION
### Description

The generator copies then patches all async class names to be sync, but it doesn't know how to patch a string inside a warning message. This avoids the problem and adds a test for the correct warning message.

### Issues Resolved

https://github.com/opensearch-project/opensearch-py/pull/553/files#r1373341397

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
