### PR TITLE
Added Windows CI.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
           - { os: 'ubuntu-latest', python-version: "3.10" }
           - { os: 'ubuntu-latest', python-version: "3.11" }
           - { os: 'macos-latest', python-version: "3.11" }
+          - { os: 'windows-latest', python-version: "3.11" }
           
     name: test (os=${{ matrix.entry.os }}, python=${{ matrix.entry.python-version }})
     continue-on-error: ${{ matrix.entry.experimental || false }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added a utf-8 header to all .py files ([#557](https://github.com/opensearch-project/opensearch-py/pull/557))
 - Added `samples`, `benchmarks` and `docs` to `nox -rs format` ([#556](https://github.com/opensearch-project/opensearch-py/pull/556))
 - Added guide on the document lifecycle API(s) ([#559](https://github.com/opensearch-project/opensearch-py/pull/559))
+- Added Windows CI ([#569](https://github.com/opensearch-project/opensearch-py/pull/569))
 ### Changed
 - Generate `tasks` client from API specs ([#508](https://github.com/opensearch-project/opensearch-py/pull/508))
 - Generate `ingest` client from API specs ([#513](https://github.com/opensearch-project/opensearch-py/pull/513))

--- a/opensearchpy/_async/http_aiohttp.py
+++ b/opensearchpy/_async/http_aiohttp.py
@@ -183,7 +183,9 @@ class AIOHttpConnection(AsyncConnection):
                 ssl_context.check_hostname = False
                 ssl_context.verify_mode = ssl.CERT_NONE
 
-            ca_certs = self.default_ca_certs() if ca_certs is None else ca_certs
+            if ca_certs is None:
+                ca_certs = self.default_ca_certs()
+
             if verify_certs:
                 if not ca_certs:
                     raise ImproperlyConfigured(

--- a/opensearchpy/connection/base.py
+++ b/opensearchpy/connection/base.py
@@ -138,6 +138,11 @@ class Connection(object):
             raise TypeError("Unsupported equality check for %s and %s" % (self, other))
         return self.__hash__() == other.__hash__()
 
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, Connection):
+            raise TypeError("Unsupported lt check for %s and %s" % (self, other))
+        return self.__hash__() < other.__hash__()
+
     def __hash__(self) -> int:
         return id(self)
 

--- a/test_opensearchpy/test_async/test_transport.py
+++ b/test_opensearchpy/test_async/test_transport.py
@@ -272,7 +272,7 @@ class TestTransport:
 
     async def test_request_will_fail_after_X_retries(self) -> None:
         t: Any = AsyncTransport(
-            [{"exception": ConnectionError("abandon ship")}],
+            [{"exception": ConnectionError(None, "abandon ship", Exception())}],
             connection_class=DummyConnection,
         )
 
@@ -287,7 +287,7 @@ class TestTransport:
 
     async def test_failed_connection_will_be_marked_as_dead(self) -> None:
         t: Any = AsyncTransport(
-            [{"exception": ConnectionError("abandon ship")}] * 2,
+            [{"exception": ConnectionError(None, "abandon ship", Exception())}] * 2,
             connection_class=DummyConnection,
         )
 
@@ -381,7 +381,10 @@ class TestTransport:
 
     async def test_sniff_on_fail_triggers_sniffing_on_fail(self) -> None:
         t: Any = AsyncTransport(
-            [{"exception": ConnectionError("abandon ship")}, {"data": CLUSTER_NODES}],
+            [
+                {"exception": ConnectionError(None, "abandon ship", Exception())},
+                {"data": CLUSTER_NODES},
+            ],
             connection_class=DummyConnection,
             sniff_on_connection_fail=True,
             max_retries=0,
@@ -407,7 +410,10 @@ class TestTransport:
     ) -> None:
         sniff_hosts.side_effect = [TransportError("sniff failed")]
         t: Any = AsyncTransport(
-            [{"exception": ConnectionError("abandon ship")}, {"data": CLUSTER_NODES}],
+            [
+                {"exception": ConnectionError(None, "abandon ship", Exception())},
+                {"data": CLUSTER_NODES},
+            ],
             connection_class=DummyConnection,
             sniff_on_connection_fail=True,
             max_retries=3,

--- a/test_opensearchpy/test_transport.py
+++ b/test_opensearchpy/test_transport.py
@@ -266,7 +266,7 @@ class TestTransport(TestCase):
 
     def test_request_will_fail_after_X_retries(self) -> None:
         t: Any = Transport(
-            [{"exception": ConnectionError("abandon ship")}],
+            [{"exception": ConnectionError(None, "abandon ship", Exception())}],
             connection_class=DummyConnection,
         )
 
@@ -275,7 +275,7 @@ class TestTransport(TestCase):
 
     def test_failed_connection_will_be_marked_as_dead(self) -> None:
         t: Any = Transport(
-            [{"exception": ConnectionError("abandon ship")}] * 2,
+            [{"exception": ConnectionError(None, "abandon ship", Exception())}] * 2,
             connection_class=DummyConnection,
         )
 
@@ -349,7 +349,10 @@ class TestTransport(TestCase):
 
     def test_sniff_on_fail_triggers_sniffing_on_fail(self) -> None:
         t: Any = Transport(
-            [{"exception": ConnectionError("abandon ship")}, {"data": CLUSTER_NODES}],
+            [
+                {"exception": ConnectionError(None, "abandon ship", Exception())},
+                {"data": CLUSTER_NODES},
+            ],
             connection_class=DummyConnection,
             sniff_on_connection_fail=True,
             max_retries=0,
@@ -366,7 +369,10 @@ class TestTransport(TestCase):
     ) -> None:
         sniff_hosts.side_effect = [TransportError("sniff failed")]
         t: Any = Transport(
-            [{"exception": ConnectionError("abandon ship")}, {"data": CLUSTER_NODES}],
+            [
+                {"exception": ConnectionError(None, "abandon ship", Exception())},
+                {"data": CLUSTER_NODES},
+            ],
             connection_class=DummyConnection,
             sniff_on_connection_fail=True,
             max_retries=3,


### PR DESCRIPTION
### Description

Added Windows CI. 

Fixed failing tests:

```
2023-11-09T22:09:24.7178027Z _________ TestTransport.test_failed_connection_will_be_marked_as_dead _________
2023-11-09T22:09:24.7178656Z 
2023-11-09T22:09:24.7179274Z self = <DummyConnection: http://localhost:9200>, args = ('GET', '/', None, None)
2023-11-09T22:09:24.7180399Z kwargs = {'headers': None, 'ignore': (), 'timeout': None}
2023-11-09T22:09:24.7180874Z 
2023-11-09T22:09:24.7181305Z     def perform_request(self, *args: Any, **kwargs: Any) -> Any:
2023-11-09T22:09:24.7181986Z         self.calls.append((args, kwargs))
2023-11-09T22:09:24.7182516Z         if self.exception:
2023-11-09T22:09:24.7182927Z >           raise self.exception
2023-11-09T22:09:24.7183252Z 
2023-11-09T22:09:24.7183475Z test_opensearchpy\test_transport.py:56: 
2023-11-09T22:09:24.7184204Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
2023-11-09T22:09:24.7184976Z opensearchpy\transport.py:409: in perform_request
2023-11-09T22:09:24.7185728Z     status, headers_response, data = connection.perform_request(
2023-11-09T22:09:24.7186585Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
2023-11-09T22:09:24.7187167Z 
2023-11-09T22:09:24.7187803Z self = <DummyConnection: http://localhost:9200>, args = ('GET', '/', None, None)
2023-11-09T22:09:24.7188542Z kwargs = {'headers': None, 'ignore': (), 'timeout': None}
2023-11-09T22:09:24.7188833Z 
2023-11-09T22:09:24.7189083Z     def perform_request(self, *args: Any, **kwargs: Any) -> Any:
2023-11-09T22:09:24.7189510Z         self.calls.append((args, kwargs))
2023-11-09T22:09:24.7189829Z         if self.exception:
2023-11-09T22:09:24.7190097Z >           raise self.exception
2023-11-09T22:09:24.7190739Z E           opensearchpy.exceptions.ConnectionError: <exception str() failed>
2023-11-09T22:09:24.7191126Z 
```

The constructor `ConnectionError("abandon ship")` had wrong arguments (it takes 3), so as written `str(ConnectionError("abandon ship"))` will fail.  On *nix it seems to re-raise the object as an exception as is, but on Windows it re-raises `str(error)` and fails with `exception str() failed`.


```

2023-11-09T22:09:24.7192548Z self = <test_opensearchpy.test_transport.TestTransport testMethod=test_failed_connection_will_be_marked_as_dead>
2023-11-09T22:09:24.7193065Z 
2023-11-09T22:09:24.7193457Z     def test_failed_connection_will_be_marked_as_dead(self) -> None:
2023-11-09T22:09:24.7193870Z         t: Any = Transport(
2023-11-09T22:09:24.7194214Z             [{"exception": ConnectionError("abandon ship")}] * 2,
2023-11-09T22:09:24.7194656Z             connection_class=DummyConnection,
2023-11-09T22:09:24.7194962Z         )
2023-11-09T22:09:24.7195128Z     
2023-11-09T22:09:24.7195451Z >       self.assertRaises(ConnectionError, t.perform_request, "GET", "/")
2023-11-09T22:09:24.7195790Z 
2023-11-09T22:09:24.7195909Z test_opensearchpy\test_transport.py:282: 
2023-11-09T22:09:24.7196306Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
2023-11-09T22:09:24.7196752Z opensearchpy\transport.py:439: in perform_request
2023-11-09T22:09:24.7197106Z     self.mark_dead(connection)
2023-11-09T22:09:24.7197399Z opensearchpy\transport.py:367: in mark_dead
2023-11-09T22:09:24.7197764Z     self.connection_pool.mark_dead(connection)
2023-11-09T22:09:24.7198151Z opensearchpy\connection_pool.py:198: in mark_dead
2023-11-09T22:09:24.7198520Z     self.dead.put((now + timeout, connection))
2023-11-09T22:09:24.7198993Z C:\hostedtoolcache\windows\Python\3.11.6\x64\Lib\queue.py:150: in put
2023-11-09T22:09:24.7199416Z     self._put(item)
2023-11-09T22:09:24.7199722Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
2023-11-09T22:09:24.7200031Z 
2023-11-09T22:09:24.7200117Z     def _put(self, item):
2023-11-09T22:09:24.7200375Z >       heappush(self.queue, item)
2023-11-09T22:09:24.7200974Z E       TypeError: '<' not supported between instances of 'DummyConnection' and 'DummyConnection'
```

This `DummyConnection` object is being compared to another in a heap. Not sure why it only hits `lt` on Windows, but if these objects are to be compared, they should have `lt` implemented. Probably a real bug that only shows up on Windows.

```
2023-11-09T22:09:24.7217026Z _______________ TestAIOHttpConnection.test_uses_given_ca_certs ________________
2023-11-09T22:09:24.7217385Z 
2023-11-09T22:09:24.7217754Z self = <test_opensearchpy.test_async.test_connection.TestAIOHttpConnection object at 0x00000204C20F63D0>
2023-11-09T22:09:24.7218578Z load_verify_locations = <MagicMock name='load_verify_locations' id='2219462067920'>
2023-11-09T22:09:24.7219510Z tmp_path = WindowsPath('C:/Users/runneradmin/AppData/Local/Temp/pytest-of-runneradmin/pytest-0/test_uses_given_ca_certs0')
2023-11-09T22:09:24.7220102Z 
2023-11-09T22:09:24.7220242Z     @patch("ssl.SSLContext.load_verify_locations")
2023-11-09T22:09:24.7220606Z     async def test_uses_given_ca_certs(
2023-11-09T22:09:24.7220966Z         self, load_verify_locations: Any, tmp_path: Any
2023-11-09T22:09:24.7221324Z     ) -> None:
2023-11-09T22:09:24.7221555Z         path = tmp_path / "ca_certs.pem"
2023-11-09T22:09:24.7221857Z         path.touch()
2023-11-09T22:09:24.7222157Z         AIOHttpConnection(use_ssl=True, ca_certs=str(path))
2023-11-09T22:09:24.7222638Z >       load_verify_locations.assert_called_once_with(cafile=str(path))
2023-11-09T22:09:24.7222966Z 
2023-11-09T22:09:24.7223124Z test_opensearchpy\test_async\test_connection.py:264: 
2023-11-09T22:09:24.7223577Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
2023-11-09T22:09:24.7223876Z 
2023-11-09T22:09:24.7224151Z _mock_self = <MagicMock name='load_verify_locations' id='2219462067920'>
2023-11-09T22:09:24.7224559Z args = ()
2023-11-09T22:09:24.7225290Z kwargs = {'cafile': 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-runneradmin\\pytest-0\\test_uses_given_ca_certs0\\ca_certs.pem'}
2023-11-09T22:09:24.7226183Z self = <MagicMock name='load_verify_locations' id='2219462067920'>
2023-11-09T22:09:24.7227581Z msg = "Expected 'load_verify_locations' to be called once. Called 3 times.\nCalls: [call(cadata=bytearray(b'0\\x82\\x01\\xca...dmin\\\\AppData\\\\Local\\\\Temp\\\\pytest-of-runneradmin\\\\pytest-0\\\\test_uses_given_ca_certs0\\\\ca_certs.pem')]."
2023-11-09T22:09:24.7228728Z 
2023-11-09T22:09:24.7228898Z     def assert_called_once_with(_mock_self, *args, **kwargs):
2023-11-09T22:09:24.7229410Z         """assert that the mock was called exactly once and that that call was
2023-11-09T22:09:24.7229865Z         with the specified arguments."""
2023-11-09T22:09:24.7230163Z         self = _mock_self
2023-11-09T22:09:24.7230414Z         if not self.call_count == 1:
2023-11-09T22:09:24.7230873Z             msg = ("Expected '%s' to be called once. Called %s times.%s"
2023-11-09T22:09:24.7231346Z                    % (self._mock_name or 'mock',
2023-11-09T22:09:24.7231687Z                       self.call_count,
2023-11-09T22:09:24.7231997Z                       self._calls_repr()))
2023-11-09T22:09:24.7232307Z >           raise AssertionError(msg)
2023-11-09T22:09:24.7232965Z E           AssertionError: Expected 'load_verify_locations' to be called once. Called 3 times.
```

Looks like the SSL context is being created somewhere else than in `AIOHttpConnection` as a side-effect, causing the number of calls to `load_verify_locations` to be different. To fix I used a mock SSL context instead of patching the global method, therefore only counting the calls we makle.

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-py/issues/347.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
