### PR TITLE
Fix: assert deprecation.

### DIFF
--- a/test_opensearchpy/test_serializer.py
+++ b/test_opensearchpy/test_serializer.py
@@ -111,9 +111,7 @@ class TestJSONSerializer(TestCase):
             np.float32,
             np.float64,
         ):
-            self.assertRegexpMatches(
-                ser.dumps({"d": np_type(1.2)}), r'^\{"d":1\.2[\d]*}$'
-            )
+            self.assertRegex(ser.dumps({"d": np_type(1.2)}), r'^\{"d":1\.2[\d]*}$')
 
     def test_serializes_numpy_datetime(self) -> None:
         requires_numpy_and_pandas()


### PR DESCRIPTION
### Description

Fixes deprecation.

```
test_opensearchpy/test_serializer.py:114: DeprecationWarning: Please use assertRegex instead.
    self.assertRegexpMatches(
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
