### PR TITLE
Remove support for local client in testing.

### DIFF
--- a/test_opensearchpy/test_server/__init__.py
+++ b/test_opensearchpy/test_server/__init__.py
@@ -32,7 +32,7 @@ from unittest import SkipTest
 from opensearchpy.helpers import test
 from opensearchpy.helpers.test import OpenSearchTestCase as BaseTestCase
 
-client = None
+client: Any = None
 
 
 def get_client(**kwargs: Any) -> Any:
@@ -42,18 +42,11 @@ def get_client(**kwargs: Any) -> Any:
     if client is not None and not kwargs:
         return client
 
-    # try and locate manual override in the local environment
     try:
-        from test_opensearchpy.local import get_client as local_get_client
-
-        new_client = local_get_client(**kwargs)
-    except ImportError:
-        # fallback to using vanilla client
-        try:
-            new_client = test.get_test_client(**kwargs)
-        except SkipTest:
-            client = False
-            raise
+        new_client = test.get_test_client(**kwargs)
+    except SkipTest:
+        client = False
+        raise
 
     if not kwargs:
         client = new_client


### PR DESCRIPTION
### Description

This looks like an unnecessary and undocumented test feature that allows potentially to create a local file that returns a custom client. I can't imagine why this would be a good idea.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
