### PR TITLE
Fix asyncio warnings/markers.

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.1%

--- a/test_opensearchpy/test_async/test_http_connection.py
+++ b/test_opensearchpy/test_async/test_http_connection.py
@@ -30,14 +30,11 @@ from typing import Any
 
 import mock
 import pytest
-from _pytest.mark.structures import MarkDecorator
 from multidict import CIMultiDict
 
 from opensearchpy._async._extra_imports import aiohttp  # type: ignore
 from opensearchpy._async.compat import get_running_loop
 from opensearchpy.connection.http_async import AsyncHttpConnection
-
-pytestmark: MarkDecorator = pytest.mark.asyncio
 
 
 class TestAsyncHttpConnection:
@@ -60,6 +57,7 @@ class TestAsyncHttpConnection:
         c = AsyncHttpConnection(http_auth=auth_fn)
         assert callable(c._http_auth)
 
+    @pytest.mark.asyncio  # type: ignore
     @mock.patch("aiohttp.ClientSession.request", new_callable=mock.Mock)
     async def test_basicauth_in_request_session(self, mock_request: Any) -> None:
         async def do_request(*args: Any, **kwargs: Any) -> Any:
@@ -91,6 +89,7 @@ class TestAsyncHttpConnection:
             fingerprint=None,
         )
 
+    @pytest.mark.asyncio  # type: ignore
     @mock.patch("aiohttp.ClientSession.request", new_callable=mock.Mock)
     async def test_callable_in_request_session(self, mock_request: Any) -> None:
         def auth_fn(*args: Any, **kwargs: Any) -> Any:

--- a/test_opensearchpy/test_async/test_plugins_client.py
+++ b/test_opensearchpy/test_async/test_plugins_client.py
@@ -8,18 +8,24 @@
 # Modifications Copyright OpenSearch Contributors. See
 # GitHub history for details.
 
-from unittest import TestCase
+
+import warnings
+
+import pytest
+from _pytest.mark.structures import MarkDecorator
 
 from opensearchpy._async.client import AsyncOpenSearch
 
+pytestmark: MarkDecorator = pytest.mark.asyncio
 
-class TestPluginsClient(TestCase):
+
+class TestPluginsClient:
     async def test_plugins_client(self) -> None:
-        with self.assertWarns(Warning) as w:
+        with warnings.catch_warnings(record=True) as w:
             client = AsyncOpenSearch()
             # testing double-init here
             client.plugins.__init__(client)  # type: ignore
-            self.assertEqual(
-                str(w.warnings[0].message),
-                "Cannot load `alerting` directly to AsyncOpenSearch as it already exists. Use `AsyncOpenSearch.plugin.alerting` instead.",
+            assert (
+                str(w[0].message)
+                == "Cannot load `alerting` directly to AsyncOpenSearch as it already exists. Use `AsyncOpenSearch.plugin.alerting` instead."
             )


### PR DESCRIPTION
### Description

Fixes

```
test_opensearchpy/test_async/test_http_connection.py::TestAsyncHttpConnection::test_auth_as_tuple
  test_opensearchpy/test_async/test_http_connection.py:44: PytestWarning: The test <Function test_auth_as_tuple> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove asyncio marker. If the test is not marked explicitly, check for global markers applied via 'pytestmark'.
    def test_auth_as_tuple(self) -> None:
```

and

```
test_opensearchpy/test_async/test_plugins_client.py::TestPluginsClient::test_plugins_client
  /Users/dblock/.pyenv/versions/3.9.16/lib/python3.9/unittest/case.py:550: RuntimeWarning: coroutine 'TestPluginsClient.test_plugins_client' was never awaited
    method()
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
```

I also added a codecov threshold of 0.1% to allow some minor coverage changes. In this PR there's no change in coverage, yet codecov seems to think otherwise because of some code line changes. No need to fail the build on such minor changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
