### PR TITLE
Fix: build and deploy docs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,22 +52,3 @@ jobs:
       - name: Check with Twine
         working-directory: dist
         run: twine check *
-
-  test-docs-build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.7
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-      - name: Check if Sphinx docs are built
-        run: |
-          pip install -e .[docs]
-          cd docs
-          make html
-          

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,5 @@
-name: Build & Deploy Doc
-on:
-  push:
-    branches: [ main ]
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+name: Build & Deploy Docs
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-and-deploy:
@@ -15,19 +10,17 @@ jobs:
       with:
         python-version: 3.7
 
-    - name: Install
+    - name: Install Dependencies
       run: |
-        python -m pip install -U pip
-        pip install --progress-bar off -U .[docs]
+        python3.7 -m pip install nox
 
     - name: Make
       run: |
-        cd docs
-        make html
-        cd ..
+        nox -rs docs
 
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
+      if: github.ref == 'refs/heads/main'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/build/html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 - Removed leftover support for Python 2.7 ([#548](https://github.com/opensearch-project/opensearch-py/pull/548))
 ### Fixed
+- Fixed automatically built and deployed docs ([575](https://github.com/opensearch-project/opensearch-py/pull/575))
 ### Security
 ### Dependencies
 - Bumps `sphinx` from <7.1 to <7.3

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ OpenSearch Python Client
 - [License](https://github.com/opensearch-project/opensearch-py#license)
 - [Copyright](https://github.com/opensearch-project/opensearch-py#copyright)
 
-## Welcome!
+# Welcome!
 
 **opensearch-py** is [a community-driven, open source fork](https://aws.amazon.com/blogs/opensource/introducing-opensearch/)
 of elasticsearch-py licensed under the [Apache v2.0 License](https://github.com/opensearch-project/opensearch-py/blob/main/LICENSE.txt). 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/opensearchpy/_async/client/__init__.py
+++ b/opensearchpy/_async/client/__init__.py
@@ -373,7 +373,7 @@ class AsyncOpenSearch(Client):
         :arg if_seq_no: only perform the operation if the last operation
             that has changed the document has the specified sequence number.
         :arg op_type: Explicit operation type. Defaults to `index` for
-            requests with an explicit document ID, and to `create`for requests
+            requests with an explicit document ID, and to `create` for requests
             without an explicit document ID. Valid choices are index, create.
         :arg pipeline: The pipeline id to preprocess incoming documents
             with.

--- a/opensearchpy/client/__init__.py
+++ b/opensearchpy/client/__init__.py
@@ -373,7 +373,7 @@ class OpenSearch(Client):
         :arg if_seq_no: only perform the operation if the last operation
             that has changed the document has the specified sequence number.
         :arg op_type: Explicit operation type. Defaults to `index` for
-            requests with an explicit document ID, and to `create`for requests
+            requests with an explicit document ID, and to `create` for requests
             without an explicit document ID. Valid choices are index, create.
         :arg pipeline: The pipeline id to preprocess incoming documents
             with.

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
     tests_require=tests_require,
     extras_require={
         "develop": tests_require + docs_require + generate_require,
-        "docs": docs_require,
+        "docs": docs_require + async_require,
         "async": async_require,
         "kerberos": ["requests_kerberos"],
     },


### PR DESCRIPTION
### Description

Imports in https://github.com/opensearch-project/opensearch-py/actions/runs/6828368821/job/18572361261 are silently failing with this:

```
WARNING: autodoc: failed to import class 'client.cat.CatClient' from module 'opensearchpy'; the following exception was raised:
No module named 'aiohttp'
```

1. Added `aiohttp` to the docs requires.
2. Turned on warnings as errors so we can catch these, and running docs in PRs in the same workflow as the site deployment.
3. Use `nox -rs docs` everywhere.
4. Ran `nox -rs generate` with https://github.com/opensearch-project/opensearch-api-specification/pull/165 was merged.

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-py/issues/558.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
