### PR TITLE
Bumps `urllib3` from >=1.26.17 to >=1.26.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Deprecated point-in-time APIs (list_all_point_in_time, create_point_in_time, delete_point_in_time) and Security Client APIs (health_check and update_audit_config) ([#502](https://github.com/opensearch-project/opensearch-py/pull/502))
 ### Removed
 - Removed leftover support for Python 2.7 ([#548](https://github.com/opensearch-project/opensearch-py/pull/548))
+- Removed leftover support for Python 3.6 ([#576](https://github.com/opensearch-project/opensearch-py/pull/576))
 ### Fixed
 - Fixed automatically built and deployed docs ([575](https://github.com/opensearch-project/opensearch-py/pull/575))
 ### Security
@@ -47,6 +48,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Security
 ### Dependencies
 - Bumps `urllib3` from >=1.21.1, <2 to >=1.26.9 ([#518](https://github.com/opensearch-project/opensearch-py/pull/518))
+- Bumps `urllib3` from >=1.26.17 to >=1.26.18 ([#576](https://github.com/opensearch-project/opensearch-py/pull/576))
 
 ## [2.3.1]
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ packages = [
     if package == module_dir or package.startswith(module_dir + ".")
 ]
 install_requires = [
-    "urllib3>=1.26.17",
+    "urllib3>=1.26.18",
     "requests>=2.4.0, <3.0.0",
     "six",
     "python-dateutil",


### PR DESCRIPTION
The security vulnerability was detected in the package urllib3, and the fix necessitates an upgrade to urllib3 version 1.26.18. 

Issues Resolved
This PR addresses medium severity security vulnerability [#565](https://github.com/opensearch-project/opensearch-py/issues/565)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).