### PR TITLE
Fixed typo in CHANGELOG from merged PR #576

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Deprecated point-in-time APIs (list_all_point_in_time, create_point_in_time, delete_point_in_time) and Security Client APIs (health_check and update_audit_config) ([#502](https://github.com/opensearch-project/opensearch-py/pull/502))
 ### Removed
 - Removed leftover support for Python 2.7 ([#548](https://github.com/opensearch-project/opensearch-py/pull/548))
-- Removed leftover support for Python 3.6 ([#576](https://github.com/opensearch-project/opensearch-py/pull/576))
 ### Fixed
 - Fixed automatically built and deployed docs ([575](https://github.com/opensearch-project/opensearch-py/pull/575))
 ### Security


### PR DESCRIPTION
### Description
Fixes typo in CHANGELOG.md that was accidentally introduced in PR [#576](https://github.com/opensearch-project/opensearch-py/pull/576)

### Issues Resolved
A typo in the CHANGELOG suggests we removed leftover support for Python 3.6, which was not part of the PR. Just a typo, should be removed from CHANGELOG.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
