### PR TITLE
Fixes a suspicious setattr that should be taking an Any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fix `TypeError` on `parallel_bulk` ([#601](https://github.com/opensearch-project/opensearch-py/pull/601))
 - Fix Amazon OpenSearch Serverless integration with LangChain ([#603](https://github.com/opensearch-project/opensearch-py/pull/603))
+- Fix type of `Field.__setattr__` ([604](https://github.com/opensearch-project/opensearch-py/pull/604))
 ### Security
 
 ## [2.4.1]

--- a/opensearchpy/helpers/utils.py
+++ b/opensearchpy/helpers/utils.py
@@ -309,7 +309,7 @@ class DslBase(object):
     def __ne__(self, other: Any) -> bool:
         return not self == other
 
-    def __setattr__(self, name: str, value: Optional[bool]) -> None:
+    def __setattr__(self, name: str, value: Any) -> None:
         if name.startswith("_"):
             return super(DslBase, self).__setattr__(name, value)
         return self._setattr(name, value)

--- a/test_opensearchpy/test_helpers/test_document.py
+++ b/test_opensearchpy/test_helpers/test_document.py
@@ -32,7 +32,7 @@ import ipaddress
 import pickle
 from datetime import datetime
 from hashlib import sha256
-from typing import Any
+from typing import Any, Union
 
 from pytest import raises
 
@@ -648,3 +648,28 @@ def test_nested_and_object_inner_doc() -> None:
         },
         "title": {"type": "keyword"},
     }
+
+
+def test_save_double(mock_client: Any) -> None:
+    class MyDocumentWithDouble(MyDoc):
+        a_double: Union[float, field.Double] = field.Double()
+
+        def save(
+            self,
+            using: Any = None,
+            index: Any = None,
+            validate: bool = True,
+            skip_empty: bool = True,
+            return_doc_meta: bool = False,
+            **kwargs: Any,
+        ) -> Any:
+            if not self.a_double:
+                self.a_double = 3.14159265359
+            return super().save(
+                using, index, validate, skip_empty, return_doc_meta, **kwargs
+            )
+
+    md: Any = MyDocumentWithDouble()
+    with raises(ValidationException):
+        md.save(using="mock")
+    assert md.a_double == 3.14159265359


### PR DESCRIPTION
### Description

Fixes a suspicious `setattr` that should be taking an `Any`.

The `Double` supports `__setattr__` assignment with a float, but I am not sure how to express that in the actual `Double` class.

### Issues Resolved

Related to #602.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
