### PR TITLE
Enabled pylint:pointless-statement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
-- Added pylint, enforcing `line-too-long` and `invalid-name` ([#590](https://github.com/opensearch-project/opensearch-py/pull/590))
+- Added pylint `line-too-long` and `invalid-name` ([#590](https://github.com/opensearch-project/opensearch-py/pull/590))
+- Added pylint `pointless-statement` ([#611](https://github.com/opensearch-project/opensearch-py/pull/611))
 ### Changed
 ### Deprecated
 ### Removed

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,4 +28,4 @@ good-names-rgxs = ^[_a-z][_a-z0-9]?$  # allow for 1-character variable names
 
 [pylint.MESSAGE CONTROL]
 disable = all
-enable = line-too-long, invalid-name
+enable = line-too-long, invalid-name, pointless-statement

--- a/test_opensearchpy/test_async/test_helpers/test_document.py
+++ b/test_opensearchpy/test_async/test_helpers/test_document.py
@@ -343,10 +343,10 @@ async def test_doc_type_can_be_correctly_pickled() -> None:
 
 async def test_meta_is_accessible_even_on_empty_doc() -> None:
     d = MyDoc()
-    d.meta
+    assert d.meta == {}
 
     d = MyDoc(title="aaa")
-    d.meta
+    assert d.meta == {}
 
 
 async def test_meta_field_mapping() -> None:
@@ -404,7 +404,7 @@ async def test_docs_with_properties() -> None:
     assert u.check_password(b"not-secret")
 
     with raises(AttributeError):
-        u.password
+        assert u.password
 
 
 async def test_nested_can_be_assigned_to() -> None:

--- a/test_opensearchpy/test_helpers/test_document.py
+++ b/test_opensearchpy/test_helpers/test_document.py
@@ -353,10 +353,10 @@ def test_doc_type_can_be_correctly_pickled() -> None:
 
 def test_meta_is_accessible_even_on_empty_doc() -> None:
     d1: Any = MyDoc()
-    d1.meta
+    assert d1.meta == {}
 
     d2: Any = MyDoc(title="aaa")
-    d2.meta
+    assert d2.meta == {}
 
 
 def test_meta_field_mapping() -> None:
@@ -414,7 +414,7 @@ def test_docs_with_properties() -> None:
     assert u.check_password(b"not-secret")
 
     with raises(AttributeError):
-        u.password
+        assert u.password
 
 
 def test_nested_can_be_assigned_to() -> None:

--- a/test_opensearchpy/test_helpers/test_result.py
+++ b/test_opensearchpy/test_helpers/test_result.py
@@ -43,7 +43,7 @@ def agg_response(aggs_search: Any, aggs_data: Any) -> Any:
 
 
 def test_agg_response_is_pickleable(agg_response: Any) -> None:
-    agg_response.hits
+    assert agg_response.hits == []
     r = pickle.loads(pickle.dumps(agg_response))
 
     assert r == agg_response
@@ -53,7 +53,7 @@ def test_agg_response_is_pickleable(agg_response: Any) -> None:
 
 def test_response_is_pickleable(dummy_response: Any) -> None:
     res = response.Response(Search(), dummy_response)
-    res.hits
+    assert res.hits
     r = pickle.loads(pickle.dumps(res))
 
     assert r == res
@@ -146,10 +146,10 @@ def test_hits_provide_dot_and_bracket_access_to_attrs(dummy_response: Any) -> No
     assert "Honza" == res.hits[2].name.first
 
     with raises(KeyError):
-        h["not_there"]
+        assert h["not_there"]
 
     with raises(AttributeError):
-        h.not_there
+        assert h.not_there
 
 
 def test_slicing_on_response_slices_on_hits(dummy_response: Any) -> None:


### PR DESCRIPTION
### Description

Enabled pylint:pointless-statement.

### Issues Resolved

Part of https://github.com/opensearch-project/opensearch-py/issues/610.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
