### PR TITLE
Update the GHA release workflow with trusted publisher enabled

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -40,3 +40,23 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts.tar.gz
+      - name: upload windows dists
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - draft-a-release
+    permissions:
+      id-token: write
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v3
+        with:
+          name: release-dists
+          path: dist
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -32,14 +32,6 @@ jobs:
       - name: Build project for distribution
         run: |
           python -m build
-          tar -zvcf artifacts.tar.gz dist
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          draft: true
-          generate_release_notes: true
-          files: |
-            artifacts.tar.gz
       - name: upload windows dists
         uses: actions/upload-artifact@v3
         with:
@@ -52,11 +44,21 @@ jobs:
       - draft-a-release
     permissions:
       id-token: write
+      contents: write
     steps:
       - name: Retrieve release distributions
         uses: actions/download-artifact@v3
         with:
           name: release-dists
           path: dist
+      - name: Generate the artifacts
+        run: |
+          tar -zvcf artifacts.tar.gz dist
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          files: |
+            artifacts.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added pylint `line-too-long` and `invalid-name` ([#590](https://github.com/opensearch-project/opensearch-py/pull/590))
 - Added pylint `pointless-statement` ([#611](https://github.com/opensearch-project/opensearch-py/pull/611))
 - Added a log collection guide ([#579](https://github.com/opensearch-project/opensearch-py/pull/579))
-- - Update the GHA release workflow with trusted publisher enabled  ([#614](https://github.com/opensearch-project/opensearch-py/pull/614))
+- Added GHA release ([#614](https://github.com/opensearch-project/opensearch-py/pull/614))
 ### Changed
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Added pylint `line-too-long` and `invalid-name` ([#590](https://github.com/opensearch-project/opensearch-py/pull/590))
 - Added pylint `pointless-statement` ([#611](https://github.com/opensearch-project/opensearch-py/pull/611))
+- Update the GHA release workflow with trusted publisher enabled  ([#614](https://github.com/opensearch-project/opensearch-py/pull/614))
 ### Changed
 ### Deprecated
 ### Removed


### PR DESCRIPTION
### Description
Enable GHA release by adding trusted publisher.
This workflow will be triggered when a tag is pushed to this repository. The workflow will built the product and publish to Pypi. 
The GitHub release will be created after publishing to Pypi with `artifacts.tar.gz`. 

I will add this workflow as trusted publisher according to this. https://docs.pypi.org/trusted-publishers/adding-a-publisher/

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build-libraries/issues/222

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
