### PR TITLE
remove unnecessary utf-8 header in .py files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 ### Deprecated
 ### Removed
+- Removed Unnecessary `# -*- coding: utf-8 -*-` headers from .py files
 ### Fixed
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 ### Deprecated
 ### Removed
-- Removed Unnecessary `# -*- coding: utf-8 -*-` headers from .py files
+- Removed unnecessary `# -*- coding: utf-8 -*-` headers from .py files ([#615](https://github.com/opensearch-project/opensearch-py/pull/615))
 ### Fixed
 ### Security
 

--- a/benchmarks/bench_async.py
+++ b/benchmarks/bench_async.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/benchmarks/bench_info_sync.py
+++ b/benchmarks/bench_info_sync.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/benchmarks/bench_sync.py
+++ b/benchmarks/bench_sync.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/benchmarks/bench_sync_async.py
+++ b/benchmarks/bench_sync_async.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/benchmarks/thread_with_return_value.py
+++ b/benchmarks/thread_with_return_value.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/__init__.py
+++ b/opensearchpy/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/__init__.py
+++ b/opensearchpy/_async/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/_extra_imports.py
+++ b/opensearchpy/_async/_extra_imports.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/__init__.py
+++ b/opensearchpy/_async/client/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/_patch.py
+++ b/opensearchpy/_async/client/_patch.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/cat.py
+++ b/opensearchpy/_async/client/cat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/client.py
+++ b/opensearchpy/_async/client/client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/cluster.py
+++ b/opensearchpy/_async/client/cluster.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/dangling_indices.py
+++ b/opensearchpy/_async/client/dangling_indices.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/features.py
+++ b/opensearchpy/_async/client/features.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/http.py
+++ b/opensearchpy/_async/client/http.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/indices.py
+++ b/opensearchpy/_async/client/indices.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/ingest.py
+++ b/opensearchpy/_async/client/ingest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/nodes.py
+++ b/opensearchpy/_async/client/nodes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/plugins.py
+++ b/opensearchpy/_async/client/plugins.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/remote.py
+++ b/opensearchpy/_async/client/remote.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/remote_store.py
+++ b/opensearchpy/_async/client/remote_store.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/security.py
+++ b/opensearchpy/_async/client/security.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/snapshot.py
+++ b/opensearchpy/_async/client/snapshot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/tasks.py
+++ b/opensearchpy/_async/client/tasks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/client/utils.py
+++ b/opensearchpy/_async/client/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/compat.py
+++ b/opensearchpy/_async/compat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/helpers/__init__.py
+++ b/opensearchpy/_async/helpers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/helpers/actions.py
+++ b/opensearchpy/_async/helpers/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/helpers/document.py
+++ b/opensearchpy/_async/helpers/document.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/helpers/faceted_search.py
+++ b/opensearchpy/_async/helpers/faceted_search.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/helpers/index.py
+++ b/opensearchpy/_async/helpers/index.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/helpers/mapping.py
+++ b/opensearchpy/_async/helpers/mapping.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/helpers/search.py
+++ b/opensearchpy/_async/helpers/search.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/helpers/test.py
+++ b/opensearchpy/_async/helpers/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/helpers/update_by_query.py
+++ b/opensearchpy/_async/helpers/update_by_query.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/http_aiohttp.py
+++ b/opensearchpy/_async/http_aiohttp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/plugins/__init__.py
+++ b/opensearchpy/_async/plugins/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/plugins/alerting.py
+++ b/opensearchpy/_async/plugins/alerting.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/plugins/index_management.py
+++ b/opensearchpy/_async/plugins/index_management.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_async/transport.py
+++ b/opensearchpy/_async/transport.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/_version.py
+++ b/opensearchpy/_version.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/__init__.py
+++ b/opensearchpy/client/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/_patch.py
+++ b/opensearchpy/client/_patch.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/cat.py
+++ b/opensearchpy/client/cat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/client.py
+++ b/opensearchpy/client/client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/cluster.py
+++ b/opensearchpy/client/cluster.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/dangling_indices.py
+++ b/opensearchpy/client/dangling_indices.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/features.py
+++ b/opensearchpy/client/features.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/http.py
+++ b/opensearchpy/client/http.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/indices.py
+++ b/opensearchpy/client/indices.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/ingest.py
+++ b/opensearchpy/client/ingest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/nodes.py
+++ b/opensearchpy/client/nodes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/plugins.py
+++ b/opensearchpy/client/plugins.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/remote.py
+++ b/opensearchpy/client/remote.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/remote_store.py
+++ b/opensearchpy/client/remote_store.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/security.py
+++ b/opensearchpy/client/security.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/snapshot.py
+++ b/opensearchpy/client/snapshot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/tasks.py
+++ b/opensearchpy/client/tasks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/client/utils.py
+++ b/opensearchpy/client/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/compat.py
+++ b/opensearchpy/compat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/connection/__init__.py
+++ b/opensearchpy/connection/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/connection/async_connections.py
+++ b/opensearchpy/connection/async_connections.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/connection/base.py
+++ b/opensearchpy/connection/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/connection/connections.py
+++ b/opensearchpy/connection/connections.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/connection/http_async.py
+++ b/opensearchpy/connection/http_async.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/connection/http_requests.py
+++ b/opensearchpy/connection/http_requests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/connection/http_urllib3.py
+++ b/opensearchpy/connection/http_urllib3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/connection/pooling.py
+++ b/opensearchpy/connection/pooling.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/connection_pool.py
+++ b/opensearchpy/connection_pool.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/exceptions.py
+++ b/opensearchpy/exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/__init__.py
+++ b/opensearchpy/helpers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/actions.py
+++ b/opensearchpy/helpers/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/aggs.py
+++ b/opensearchpy/helpers/aggs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/analysis.py
+++ b/opensearchpy/helpers/analysis.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/asyncsigner.py
+++ b/opensearchpy/helpers/asyncsigner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/document.py
+++ b/opensearchpy/helpers/document.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/errors.py
+++ b/opensearchpy/helpers/errors.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/faceted_search.py
+++ b/opensearchpy/helpers/faceted_search.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/field.py
+++ b/opensearchpy/helpers/field.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/function.py
+++ b/opensearchpy/helpers/function.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/index.py
+++ b/opensearchpy/helpers/index.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/mapping.py
+++ b/opensearchpy/helpers/mapping.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/query.py
+++ b/opensearchpy/helpers/query.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/response/__init__.py
+++ b/opensearchpy/helpers/response/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/response/aggs.py
+++ b/opensearchpy/helpers/response/aggs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/response/hit.py
+++ b/opensearchpy/helpers/response/hit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/search.py
+++ b/opensearchpy/helpers/search.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/signer.py
+++ b/opensearchpy/helpers/signer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/test.py
+++ b/opensearchpy/helpers/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/update_by_query.py
+++ b/opensearchpy/helpers/update_by_query.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/utils.py
+++ b/opensearchpy/helpers/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/helpers/wrappers.py
+++ b/opensearchpy/helpers/wrappers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/plugins/__init__.py
+++ b/opensearchpy/plugins/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/plugins/alerting.py
+++ b/opensearchpy/plugins/alerting.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/plugins/index_management.py
+++ b/opensearchpy/plugins/index_management.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/serializer.py
+++ b/opensearchpy/serializer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/opensearchpy/transport.py
+++ b/opensearchpy/transport.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/advanced_index_actions/advanced_index_actions_sample.py
+++ b/samples/advanced_index_actions/advanced_index_actions_sample.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/aws/search_requests.py
+++ b/samples/aws/search_requests.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/aws/search_urllib3.py
+++ b/samples/aws/search_urllib3.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/bulk/bulk_array.py
+++ b/samples/bulk/bulk_array.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/bulk/bulk_helpers.py
+++ b/samples/bulk/bulk_helpers.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/bulk/bulk_ld.py
+++ b/samples/bulk/bulk_ld.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/document_lifecycle/document_lifecycle_sample.py
+++ b/samples/document_lifecycle/document_lifecycle_sample.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/hello/hello.py
+++ b/samples/hello/hello.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/hello/hello_async.py
+++ b/samples/hello/hello_async.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/index_template/index_template_sample.py
+++ b/samples/index_template/index_template_sample.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/json/json_hello.py
+++ b/samples/json/json_hello.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/json/json_hello_async.py
+++ b/samples/json/json_hello_async.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/knn/knn_async_basics.py
+++ b/samples/knn/knn_async_basics.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/knn/knn_basics.py
+++ b/samples/knn/knn_basics.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/knn/knn_boolean_filter.py
+++ b/samples/knn/knn_boolean_filter.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/knn/knn_efficient_filter.py
+++ b/samples/knn/knn_efficient_filter.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/logging/log_collection_sample.py
+++ b/samples/logging/log_collection_sample.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/security/roles.py
+++ b/samples/security/roles.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/samples/security/users.py
+++ b/samples/security/users.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/__init__.py
+++ b/test_opensearchpy/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/__init__.py
+++ b/test_opensearchpy/test_async/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_client.py
+++ b/test_opensearchpy/test_async/test_client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_connection.py
+++ b/test_opensearchpy/test_async/test_connection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_helpers/__init__.py
+++ b/test_opensearchpy/test_async/test_helpers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_helpers/conftest.py
+++ b/test_opensearchpy/test_async/test_helpers/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_helpers/test_document.py
+++ b/test_opensearchpy/test_async/test_helpers/test_document.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_helpers/test_faceted_search.py
+++ b/test_opensearchpy/test_async/test_helpers/test_faceted_search.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_helpers/test_index.py
+++ b/test_opensearchpy/test_async/test_helpers/test_index.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_helpers/test_mapping.py
+++ b/test_opensearchpy/test_async/test_helpers/test_mapping.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_helpers/test_search.py
+++ b/test_opensearchpy/test_async/test_helpers/test_search.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_helpers/test_update_by_query.py
+++ b/test_opensearchpy/test_async/test_helpers/test_update_by_query.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_http.py
+++ b/test_opensearchpy/test_async/test_http.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_http_connection.py
+++ b/test_opensearchpy/test_async/test_http_connection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_plugins_client.py
+++ b/test_opensearchpy/test_async/test_plugins_client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/__init__.py
+++ b/test_opensearchpy/test_async/test_server/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/conftest.py
+++ b/test_opensearchpy/test_async/test_server/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/test_clients.py
+++ b/test_opensearchpy/test_async/test_server/test_clients.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/test_helpers/__init__.py
+++ b/test_opensearchpy/test_async/test_server/test_helpers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/test_helpers/conftest.py
+++ b/test_opensearchpy/test_async/test_server/test_helpers/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/test_helpers/test_actions.py
+++ b/test_opensearchpy/test_async/test_server/test_helpers/test_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/test_helpers/test_data.py
+++ b/test_opensearchpy/test_async/test_server/test_helpers/test_data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/test_helpers/test_document.py
+++ b/test_opensearchpy/test_async/test_server/test_helpers/test_document.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/test_helpers/test_faceted_search.py
+++ b/test_opensearchpy/test_async/test_server/test_helpers/test_faceted_search.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/test_helpers/test_index.py
+++ b/test_opensearchpy/test_async/test_server/test_helpers/test_index.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/test_helpers/test_mapping.py
+++ b/test_opensearchpy/test_async/test_server/test_helpers/test_mapping.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/test_helpers/test_search.py
+++ b/test_opensearchpy/test_async/test_server/test_helpers/test_search.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/test_helpers/test_update_by_query.py
+++ b/test_opensearchpy/test_async/test_server/test_helpers/test_update_by_query.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/test_plugins/__init__.py
+++ b/test_opensearchpy/test_async/test_server/test_plugins/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/test_plugins/test_alerting.py
+++ b/test_opensearchpy/test_async/test_server/test_plugins/test_alerting.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/test_plugins/test_index_management.py
+++ b/test_opensearchpy/test_async/test_server/test_plugins/test_index_management.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server/test_rest_api_spec.py
+++ b/test_opensearchpy/test_async/test_server/test_rest_api_spec.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server_secured/__init__.py
+++ b/test_opensearchpy/test_async/test_server_secured/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_server_secured/test_security_plugin.py
+++ b/test_opensearchpy/test_async/test_server_secured/test_security_plugin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_signer.py
+++ b/test_opensearchpy/test_async/test_signer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_async/test_transport.py
+++ b/test_opensearchpy/test_async/test_transport.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_cases.py
+++ b/test_opensearchpy/test_cases.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_client/__init__.py
+++ b/test_opensearchpy/test_client/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_client/test_cluster.py
+++ b/test_opensearchpy/test_client/test_cluster.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_client/test_http.py
+++ b/test_opensearchpy/test_client/test_http.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_client/test_indices.py
+++ b/test_opensearchpy/test_client/test_indices.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_client/test_overrides.py
+++ b/test_opensearchpy/test_client/test_overrides.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_client/test_plugins/__init__.py
+++ b/test_opensearchpy/test_client/test_plugins/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_client/test_plugins/test_alerting.py
+++ b/test_opensearchpy/test_client/test_plugins/test_alerting.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_client/test_plugins/test_index_management.py
+++ b/test_opensearchpy/test_client/test_plugins/test_index_management.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_client/test_plugins/test_plugins_client.py
+++ b/test_opensearchpy/test_client/test_plugins/test_plugins_client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_client/test_point_in_time.py
+++ b/test_opensearchpy/test_client/test_point_in_time.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_client/test_remote_store.py
+++ b/test_opensearchpy/test_client/test_remote_store.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_client/test_requests.py
+++ b/test_opensearchpy/test_client/test_requests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_client/test_urllib3.py
+++ b/test_opensearchpy/test_client/test_urllib3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_client/test_utils.py
+++ b/test_opensearchpy/test_client/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_connection/__init__.py
+++ b/test_opensearchpy/test_connection/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_connection/test_base_connection.py
+++ b/test_opensearchpy/test_connection/test_base_connection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_connection/test_requests_http_connection.py
+++ b/test_opensearchpy/test_connection/test_requests_http_connection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_connection/test_urllib3_http_connection.py
+++ b/test_opensearchpy/test_connection/test_urllib3_http_connection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_connection_pool.py
+++ b/test_opensearchpy/test_connection_pool.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_exceptions.py
+++ b/test_opensearchpy/test_exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/__init__.py
+++ b/test_opensearchpy/test_helpers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/conftest.py
+++ b/test_opensearchpy/test_helpers/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/test_actions.py
+++ b/test_opensearchpy/test_helpers/test_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/test_aggs.py
+++ b/test_opensearchpy/test_helpers/test_aggs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/test_analysis.py
+++ b/test_opensearchpy/test_helpers/test_analysis.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/test_document.py
+++ b/test_opensearchpy/test_helpers/test_document.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/test_faceted_search.py
+++ b/test_opensearchpy/test_helpers/test_faceted_search.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/test_field.py
+++ b/test_opensearchpy/test_helpers/test_field.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/test_index.py
+++ b/test_opensearchpy/test_helpers/test_index.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/test_mapping.py
+++ b/test_opensearchpy/test_helpers/test_mapping.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/test_query.py
+++ b/test_opensearchpy/test_helpers/test_query.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/test_result.py
+++ b/test_opensearchpy/test_helpers/test_result.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/test_search.py
+++ b/test_opensearchpy/test_helpers/test_search.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/test_update_by_query.py
+++ b/test_opensearchpy/test_helpers/test_update_by_query.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/test_utils.py
+++ b/test_opensearchpy/test_helpers/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/test_validation.py
+++ b/test_opensearchpy/test_helpers/test_validation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_helpers/test_wrappers.py
+++ b/test_opensearchpy/test_helpers/test_wrappers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_http_server.py
+++ b/test_opensearchpy/test_http_server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_serializer.py
+++ b/test_opensearchpy/test_serializer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/__init__.py
+++ b/test_opensearchpy/test_server/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/conftest.py
+++ b/test_opensearchpy/test_server/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_clients.py
+++ b/test_opensearchpy/test_server/test_clients.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_helpers/__init__.py
+++ b/test_opensearchpy/test_server/test_helpers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_helpers/conftest.py
+++ b/test_opensearchpy/test_server/test_helpers/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_helpers/test_actions.py
+++ b/test_opensearchpy/test_server/test_helpers/test_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_helpers/test_analysis.py
+++ b/test_opensearchpy/test_server/test_helpers/test_analysis.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_helpers/test_count.py
+++ b/test_opensearchpy/test_server/test_helpers/test_count.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_helpers/test_data.py
+++ b/test_opensearchpy/test_server/test_helpers/test_data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_helpers/test_document.py
+++ b/test_opensearchpy/test_server/test_helpers/test_document.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_helpers/test_faceted_search.py
+++ b/test_opensearchpy/test_server/test_helpers/test_faceted_search.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_helpers/test_index.py
+++ b/test_opensearchpy/test_server/test_helpers/test_index.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_helpers/test_mapping.py
+++ b/test_opensearchpy/test_server/test_helpers/test_mapping.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_helpers/test_search.py
+++ b/test_opensearchpy/test_server/test_helpers/test_search.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_helpers/test_update_by_query.py
+++ b/test_opensearchpy/test_server/test_helpers/test_update_by_query.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_plugins/__init__.py
+++ b/test_opensearchpy/test_server/test_plugins/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_plugins/test_alerting.py
+++ b/test_opensearchpy/test_server/test_plugins/test_alerting.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_plugins/test_index_management.py
+++ b/test_opensearchpy/test_server/test_plugins/test_index_management.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server/test_rest_api_spec.py
+++ b/test_opensearchpy/test_server/test_rest_api_spec.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server_secured/__init__.py
+++ b/test_opensearchpy/test_server_secured/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server_secured/test_clients.py
+++ b/test_opensearchpy/test_server_secured/test_clients.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_server_secured/test_security_plugin.py
+++ b/test_opensearchpy/test_server_secured/test_security_plugin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_transport.py
+++ b/test_opensearchpy/test_transport.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_types/aliased_types.py
+++ b/test_opensearchpy/test_types/aliased_types.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_types/async_types.py
+++ b/test_opensearchpy/test_types/async_types.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/test_types/sync_types.py
+++ b/test_opensearchpy/test_types/sync_types.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/test_opensearchpy/utils.py
+++ b/test_opensearchpy/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/utils/build_dists.py
+++ b/utils/build_dists.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to


### PR DESCRIPTION
### Description
Remove Unnecessary `# -*- coding: utf-8 -*-`  headers from .py files

### Issues Resolved
https://github.com/opensearch-project/opensearch-py/issues/613

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
