### PR TITLE
Added fix for key error because of missing 'hits' key.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 - Removed unnecessary `# -*- coding: utf-8 -*-` headers from .py files ([#615](https://github.com/opensearch-project/opensearch-py/pull/615))
 ### Fixed
+- Fix KeyError when scroll return no hits ([#616](https://github.com/opensearch-project/opensearch-py/pull/616))
 ### Security
 
 ## [2.4.2]

--- a/opensearchpy/_async/helpers/actions.py
+++ b/opensearchpy/_async/helpers/actions.py
@@ -390,14 +390,17 @@ async def async_scan(
     scroll_id = resp.get("_scroll_id")
 
     try:
-        while scroll_id and resp["hits"]["hits"]:
-            for hit in resp["hits"]["hits"]:
+        while scroll_id and resp.get("hits", {}).get("hits"):
+            for hit in resp.get("hits", {}).get("hits", []):
                 yield hit
 
-            # Default to 0 if the value isn't included in the response
-            shards_successful = resp["_shards"].get("successful", 0)
-            shards_skipped = resp["_shards"].get("skipped", 0)
-            shards_total = resp["_shards"].get("total", 0)
+            _shards = resp.get("_shards")
+
+            if _shards:
+                # Default to 0 if the value isn't included in the response
+                shards_successful = _shards.get("successful", 0)
+                shards_skipped = _shards.get("skipped", 0)
+                shards_total = _shards.get("total", 0)
 
             # check if we have any errors
             if (shards_successful + shards_skipped) < shards_total:

--- a/opensearchpy/helpers/actions.py
+++ b/opensearchpy/helpers/actions.py
@@ -586,14 +586,17 @@ def scan(
     scroll_id = resp.get("_scroll_id")
 
     try:
-        while scroll_id and resp["hits"]["hits"]:
-            for hit in resp["hits"]["hits"]:
+        while scroll_id and resp.get("hits", {}).get("hits"):
+            for hit in resp.get("hits", {}).get("hits", []):
                 yield hit
 
-            # Default to 0 if the value isn't included in the response
-            shards_successful = resp["_shards"].get("successful", 0)
-            shards_skipped = resp["_shards"].get("skipped", 0)
-            shards_total = resp["_shards"].get("total", 0)
+            _shards = resp.get("_shards")
+
+            if _shards:
+                # Default to 0 if the value isn't included in the response
+                shards_successful = _shards.get("successful", 0)
+                shards_skipped = _shards.get("skipped", 0)
+                shards_total = _shards.get("total", 0)
 
             # check if we have any errors
             if (shards_successful + shards_skipped) < shards_total:
@@ -614,6 +617,7 @@ def scan(
                             shards_total,
                         ),
                     )
+
             resp = client.scroll(
                 body={"scroll_id": scroll_id, "scroll": scroll}, **scroll_kwargs
             )


### PR DESCRIPTION
### Description
Adds graceful/defensive code for handling case of missing "hits" key in scan response.

### Issues Resolved
Resolves issue [#313](https://github.com/opensearch-project/opensearch-py/issues/313)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
