### PR TITLE
Remove unnecessary utf-8 header in license_headers.py (follow-up to #615)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 ### Deprecated
 ### Removed
-- Removed unnecessary `# -*- coding: utf-8 -*-` headers from .py files ([#615](https://github.com/opensearch-project/opensearch-py/pull/615))
+- Removed unnecessary `# -*- coding: utf-8 -*-` headers from .py files ([#615](https://github.com/opensearch-project/opensearch-py/pull/615), [#617](https://github.com/opensearch-project/opensearch-py/pull/617))
 ### Fixed
 ### Security
 

--- a/utils/license_headers.py
+++ b/utils/license_headers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/utils/license_headers.py
+++ b/utils/license_headers.py
@@ -18,7 +18,7 @@ import re
 import sys
 from typing import Iterator, List
 
-LINES_TO_KEEP = ["# -*- coding: utf-8 -*-", "#!/usr/bin/env python"]
+LINES_TO_KEEP = ["#!/usr/bin/env python"]
 
 LICENSE_HEADER = """
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
### Description
This is a small followup to @samuelorji's cleanup in #615.  It applies the same cleanup (removal of a redundant/default `coding` declaration of `utf-8` in source files) to the `license_headers.py` check script itself.

This pull request also removes that line from the list of `LINES_TO_KEEP` - lines of source code that aren't checked by the license check script - since it shouldn't appear anymore.

### Issues Resolved
#613

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).