### PR TITLE
[draft] Use a git submodule to include the OpenSearch.openapi.json file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "specifications/opensearch-api-specification"]
+	path = specifications/opensearch-api-specification
+	url = https://github.com/opensearch-project/opensearch-api-specification.git/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added a log collection guide ([#579](https://github.com/opensearch-project/opensearch-py/pull/579))
 - Added GHA release ([#614](https://github.com/opensearch-project/opensearch-py/pull/614))
 ### Changed
+- Read the `OpenSearch.openapi.json` API specification file from a `git` submodule checkout instead of making an HTTP request. ([#627](https://github.com/opensearch-project/opensearch-py/pull/627))
 ### Deprecated
 ### Removed
 - Removed unnecessary `# -*- coding: utf-8 -*-` headers from .py files ([#615](https://github.com/opensearch-project/opensearch-py/pull/615), [#617](https://github.com/opensearch-project/opensearch-py/pull/617))

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-requests>=2, <3
 pytest
 pytest-cov
 coverage

--- a/noxfile.py
+++ b/noxfile.py
@@ -118,6 +118,8 @@ def docs(session: Any) -> None:
 
 @nox.session()  # type: ignore
 def generate(session: Any) -> None:
+    session.run("git", "submodule", "init", external=True)
+    session.run("git", "submodule", "update", external=True)
     session.install("-rdev-requirements.txt")
     session.run("python", "utils/generate_api.py")
     format(session)

--- a/utils/generate_api.py
+++ b/utils/generate_api.py
@@ -41,7 +41,6 @@ from typing import Any, Dict
 
 import black
 import deepmerge
-import requests
 import unasync
 import urllib3
 from click.testing import CliRunner
@@ -429,10 +428,9 @@ def read_modules() -> Any:
     modules = {}
 
     # Load the OpenAPI specification file
-    response = requests.get(
-        "https://raw.githubusercontent.com/opensearch-project/opensearch-api-specification/main/OpenSearch.openapi.json"
-    )
-    data = response.json()
+    path = "specifications/opensearch-api-specification/OpenSearch.openapi.json"
+    with open(path) as f:
+        data = json.loads(f.read())
 
     list_of_dicts = []
 


### PR DESCRIPTION
### Description
Instead of using an HTTP(S) request to retrieve the latest `main` OpenSearch.openapi.json spec from `opensearch-api-specification.git`, reference it as a `git` submodule and read the contents from file.

### Issues Resolved
Resolves #626.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).