### PR TITLE
Bumps urllib3 from >=1.26.18 to >=1.26.18, <2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Security
 ### Dependencies
 - Bumps `pytest-asyncio` from <=0.21.1 to <=0.23.2
+- Bumps `urllib3` from >=1.26.18 to >=1.26.18, <2 ([#632](https://github.com/opensearch-project/opensearch-py/pull/632))
 
 ## [2.4.2]
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ packages = [
     if package == MODULE_DIR or package.startswith(MODULE_DIR + ".")
 ]
 install_requires = [
-    "urllib3>=1.26.18",
+    "urllib3>=1.26.18, <2",
     "requests>=2.4.0, <3.0.0",
     "six",
     "python-dateutil",


### PR DESCRIPTION
### Description
Bumps urllib3 from >=1.26.18 to >=1.26.18, <2

### Issues Resolved
Closes #628 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
