### PR TITLE
Updated the get_policy API in the index_management plugin 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added a log collection guide ([#579](https://github.com/opensearch-project/opensearch-py/pull/579))
 - Added GHA release ([#614](https://github.com/opensearch-project/opensearch-py/pull/614))
 ### Changed
+- Updated the `get_policy` API in the index_management plugin to allow the policy_id argument as optional ([#633](https://github.com/opensearch-project/opensearch-py/pull/633))
 ### Deprecated
 ### Removed
 - Removed unnecessary `# -*- coding: utf-8 -*-` headers from .py files ([#615](https://github.com/opensearch-project/opensearch-py/pull/615), [#617](https://github.com/opensearch-project/opensearch-py/pull/617))

--- a/opensearchpy/_async/plugins/index_management.py
+++ b/opensearchpy/_async/plugins/index_management.py
@@ -56,15 +56,13 @@ class IndexManagementClient(NamespacedClient):
 
     @query_params()
     async def get_policy(
-        self, policy: Any, params: Any = None, headers: Any = None
+        self, policy: Any = None, params: Any = None, headers: Any = None
     ) -> Any:
         """
-        Gets the policy by `policy_id`.
+        Gets the policy by `policy_id`; returns all policies if no policy_id is provided.
 
         :arg policy: The name of the policy
         """
-        if policy in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'policy'.")
 
         return await self.transport.perform_request(
             "GET",

--- a/opensearchpy/plugins/index_management.py
+++ b/opensearchpy/plugins/index_management.py
@@ -55,14 +55,14 @@ class IndexManagementClient(NamespacedClient):
         )
 
     @query_params()
-    def get_policy(self, policy: Any, params: Any = None, headers: Any = None) -> Any:
+    def get_policy(
+        self, policy: Any = None, params: Any = None, headers: Any = None
+    ) -> Any:
         """
-        Gets the policy by `policy_id`.
+        Gets the policy by `policy_id`; returns all policies if no policy_id is provided.
 
         :arg policy: The name of the policy
         """
-        if policy in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'policy'.")
 
         return self.transport.perform_request(
             "GET",


### PR DESCRIPTION

### Description
Updated the `get_policy` API in the index_management plugin to allow the policy_id argument as optional

### Issues Resolved
Closes #629 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
