### PR TITLE
Bumps aiohttp from >=3,<4 to >=3.9.0,<4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix KeyError when scroll return no hits ([#616](https://github.com/opensearch-project/opensearch-py/pull/616))
 ### Security
 ### Dependencies
+- Bumps `aiohttp` from >=3,<4 to >=3.9.0,<4 ([#634](https://github.com/opensearch-project/opensearch-py/pull/634))
 - Bumps `pytest-asyncio` from <=0.21.1 to <=0.23.2
 
 ## [2.4.2]

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ tests_require = [
     "pytest-mock<4.0.0",
 ]
 
-async_require = ["aiohttp>=3,<4"]
+async_require = ["aiohttp>=3.9.0,<4"]
 
 docs_require = ["sphinx", "sphinx_rtd_theme", "myst_parser", "sphinx_copybutton"]
 generate_require = ["black", "jinja2"]


### PR DESCRIPTION
### Description
Bumps aiohttp from >=3,<4 to >=3.9.0,<4

### Issues Resolved
Closes #622 
Closes #621 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
