### PR TITLE
Reusable async client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added a log collection guide ([#579](https://github.com/opensearch-project/opensearch-py/pull/579))
 - Added GHA release ([#614](https://github.com/opensearch-project/opensearch-py/pull/614))
 ### Changed
-- `AsyncOpensearch` can now be re-used after calling `close()` ([#639](https://github.com/opensearch-project/opensearch-py/pull/639))
 ### Deprecated
 ### Removed
 - Removed unnecessary `# -*- coding: utf-8 -*-` headers from .py files ([#615](https://github.com/opensearch-project/opensearch-py/pull/615), [#617](https://github.com/opensearch-project/opensearch-py/pull/617))
 ### Fixed
 - Fix KeyError when scroll return no hits ([#616](https://github.com/opensearch-project/opensearch-py/pull/616))
+- Fix reuse of `AsyncOpenSearch` after calling `close` ([#639](https://github.com/opensearch-project/opensearch-py/pull/639))
 ### Security
 ### Dependencies
 - Bumps `pytest-asyncio` from <=0.21.1 to <=0.23.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added a log collection guide ([#579](https://github.com/opensearch-project/opensearch-py/pull/579))
 - Added GHA release ([#614](https://github.com/opensearch-project/opensearch-py/pull/614))
 ### Changed
+- `AsyncOpensearch` can now be re-used after calling `close()` ([#635](https://github.com/opensearch-project/opensearch-py/pull/635))
 ### Deprecated
 ### Removed
 - Removed unnecessary `# -*- coding: utf-8 -*-` headers from .py files ([#615](https://github.com/opensearch-project/opensearch-py/pull/615), [#617](https://github.com/opensearch-project/opensearch-py/pull/617))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added a log collection guide ([#579](https://github.com/opensearch-project/opensearch-py/pull/579))
 - Added GHA release ([#614](https://github.com/opensearch-project/opensearch-py/pull/614))
 ### Changed
-- `AsyncOpensearch` can now be re-used after calling `close()` ([#635](https://github.com/opensearch-project/opensearch-py/pull/635))
+- `AsyncOpensearch` can now be re-used after calling `close()` ([#639](https://github.com/opensearch-project/opensearch-py/pull/639))
 ### Deprecated
 ### Removed
 - Removed unnecessary `# -*- coding: utf-8 -*-` headers from .py files ([#615](https://github.com/opensearch-project/opensearch-py/pull/615), [#617](https://github.com/opensearch-project/opensearch-py/pull/617))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed unnecessary `# -*- coding: utf-8 -*-` headers from .py files ([#615](https://github.com/opensearch-project/opensearch-py/pull/615), [#617](https://github.com/opensearch-project/opensearch-py/pull/617))
 ### Fixed
 - Fix KeyError when scroll return no hits ([#616](https://github.com/opensearch-project/opensearch-py/pull/616))
-- Fix reuse of `AsyncOpenSearch` after calling `close` ([#639](https://github.com/opensearch-project/opensearch-py/pull/639))
+- Fix reuse of `OpenSearch` using `Urllib3HttpConnection` and `AsyncOpenSearch` after calling `close` ([#639](https://github.com/opensearch-project/opensearch-py/pull/639))
 ### Security
 ### Dependencies
 - Bumps `pytest-asyncio` from <=0.21.1 to <=0.23.2

--- a/opensearchpy/_async/http_aiohttp.py
+++ b/opensearchpy/_async/http_aiohttp.py
@@ -361,6 +361,7 @@ class AIOHttpConnection(AsyncConnection):
         """
         if self.session:
             await self.session.close()
+            self.session = None
 
     async def _create_aiohttp_session(self) -> Any:
         """Creates an aiohttp.ClientSession(). This is delayed until

--- a/opensearchpy/connection/http_async.py
+++ b/opensearchpy/connection/http_async.py
@@ -277,6 +277,7 @@ class AsyncHttpConnection(AIOHttpConnection):
         """
         if self.session:
             await self.session.close()
+            self.session = None
 
     async def _create_aiohttp_session(self) -> Any:
         """Creates an aiohttp.ClientSession(). This is delayed until

--- a/opensearchpy/connection/http_urllib3.py
+++ b/opensearchpy/connection/http_urllib3.py
@@ -214,14 +214,13 @@ class Urllib3HttpConnection(Connection):
         if pool_maxsize and isinstance(pool_maxsize, int):
             kw["maxsize"] = pool_maxsize
 
-        def urllib3_pool_factory() -> Any:
-            return pool_class(self.hostname, port=self.port, timeout=self.timeout, **kw)
-
-        self._urllib3_pool_factory = urllib3_pool_factory
+        self._urllib3_pool_factory = lambda: pool_class(
+            self.hostname, port=self.port, timeout=self.timeout, **kw
+        )
         self._create_urllib3_pool()
 
     def _create_urllib3_pool(self) -> None:
-        self.pool = self._urllib3_pool_factory()
+        self.pool = self._urllib3_pool_factory()  # type: ignore
 
     def perform_request(
         self,

--- a/test_opensearchpy/test_async/test_server/test_clients.py
+++ b/test_opensearchpy/test_async/test_server/test_clients.py
@@ -71,10 +71,11 @@ class TestYarlMissing:
 
 class TestClose:
     async def test_close_doesnt_break_client(self, async_client: Any) -> None:
+        await async_client.cluster.health()
         await async_client.close()
         await async_client.cluster.health()
 
-        async with async_client:
-            await async_client.cluster.health()
-        async with async_client:
-            await async_client.cluster.health()
+    async def test_with_doesnt_break_client(self, async_client: Any) -> None:
+        for _ in range(2):
+            async with async_client as client:
+                await client.cluster.health()

--- a/test_opensearchpy/test_async/test_server/test_clients.py
+++ b/test_opensearchpy/test_async/test_server/test_clients.py
@@ -67,3 +67,8 @@ class TestYarlMissing:
 
         resp = await async_client.info(pretty=True)
         assert isinstance(resp, dict)
+
+class TestClose:
+    async def test_close_doesnt_break_client(self, async_client: Any) -> None:
+        await async_client.close()
+        await async_client.cluster.health()

--- a/test_opensearchpy/test_async/test_server/test_clients.py
+++ b/test_opensearchpy/test_async/test_server/test_clients.py
@@ -68,6 +68,7 @@ class TestYarlMissing:
         resp = await async_client.info(pretty=True)
         assert isinstance(resp, dict)
 
+
 class TestClose:
     async def test_close_doesnt_break_client(self, async_client: Any) -> None:
         await async_client.close()

--- a/test_opensearchpy/test_async/test_server/test_clients.py
+++ b/test_opensearchpy/test_async/test_server/test_clients.py
@@ -73,3 +73,8 @@ class TestClose:
     async def test_close_doesnt_break_client(self, async_client: Any) -> None:
         await async_client.close()
         await async_client.cluster.health()
+
+        async with async_client:
+            await async_client.cluster.health()
+        async with async_client:
+            await async_client.cluster.health()

--- a/test_opensearchpy/test_server/test_clients.py
+++ b/test_opensearchpy/test_server/test_clients.py
@@ -49,3 +49,15 @@ class TestBulk(OpenSearchTestCase):
 
         self.assertFalse(response["errors"])
         self.assertEqual(1, len(response["items"]))
+
+
+class TestClose(OpenSearchTestCase):
+    def test_close_doesnt_break_client(self) -> None:
+        self.client.cluster.health()
+        self.client.close()
+        self.client.cluster.health()
+
+        with self.client as client:
+            client.cluster.health()
+        with self.client as client:
+            client.cluster.health()

--- a/test_opensearchpy/test_server/test_clients.py
+++ b/test_opensearchpy/test_server/test_clients.py
@@ -57,7 +57,7 @@ class TestClose(OpenSearchTestCase):
         self.client.close()
         self.client.cluster.health()
 
-        with self.client as client:
-            client.cluster.health()
-        with self.client as client:
-            client.cluster.health()
+    def test_with_doesnt_break_client(self) -> None:
+        for _ in range(2):
+            with self.client as client:
+                client.cluster.health()


### PR DESCRIPTION
### Description
Clears out the `session` attribute of `AsyncHttpConnection` and `AIOHttpConnection` when calling `close()`, which allow re-using a previously closed `AsyncOpensearch` instance.

### Issues Resolved
Closes #637

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
