### PR TITLE
skipping failing integ test that is newly added

### DIFF
--- a/test_opensearchpy/test_server/test_rest_api_spec.py
+++ b/test_opensearchpy/test_server/test_rest_api_spec.py
@@ -90,6 +90,8 @@ SKIP_TESTS = {
     "OpenSearch-main/rest-api-spec/src/main/resources/rest-api-spec/test/tasks/list/10_basic[0]",
     "OpenSearch-main/rest-api-spec/src/main/resources/rest-api-spec/test/index/90_unsigned_long[1]",
     "OpenSearch-main/rest-api-spec/src/main/resources/rest-api-spec/test/indices/stats/50_noop_update[0]",
+    "OpenSearch-main/rest-api-spec/src/main/resources/rest-api-spec/test/search/340_doc_values_field[0]",
+    "OpenSearch-main/rest-api-spec/src/main/resources/rest-api-spec/test/search/340_doc_values_field[1]",
     "search/aggregation/250_moving_fn[1]",
     # body: null
     "indices/simulate_index_template/10_basic[2]",
@@ -131,7 +133,6 @@ SKIP_TESTS = {
     # unique usage of 'set'
     "indices/stats/50_disk_usage[0]",
     "indices/stats/60_field_usage[0]",
-    "OpenSearch-main/rest-api-spec/src/main/resources/rest-api-spec/test/indices/stats/50_noop_update[0]",
 }
 
 

--- a/test_opensearchpy/test_server/test_rest_api_spec.py
+++ b/test_opensearchpy/test_server/test_rest_api_spec.py
@@ -130,6 +130,7 @@ SKIP_TESTS = {
     # unique usage of 'set'
     "indices/stats/50_disk_usage[0]",
     "indices/stats/60_field_usage[0]",
+    "OpenSearch-main/rest-api-spec/src/main/resources/rest-api-spec/test/indices/stats/50_noop_update[0]",
 }
 
 


### PR DESCRIPTION
### Description
A recently added rest-api-spec [test](https://github.com/opensearch-project/OpenSearch/blame/main/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/50_noop_update.yml) is failing. Added it to the skip list [here](https://github.com/opensearch-project/opensearch-py/blob/main/test_opensearchpy/test_server/test_rest_api_spec.py#L73). 

I will raise an issue to make all the skipping [tests](https://github.com/opensearch-project/opensearch-py/blob/main/test_opensearchpy/test_server/test_rest_api_spec.py#L73) work.

closes #653 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
