### PR TITLE
unnecessary-dunder-call for pylint; exception caught in run_tests.py

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,7 +1,13 @@
 [MESSAGES CONTROL]
 disable=all
-enable=line-too-long,invalid-name,pointless-statement,unspecified-encoding,
-    missing-function-docstring,missing-param-doc,differing-param-doc
+enable=line-too-long,
+    invalid-name,
+    pointless-statement,
+    unspecified-encoding,
+    missing-function-docstring,
+    missing-param-doc,
+    differing-param-doc,
+    unnecessary-dunder-call
 max-line-length=240
 good-names-rgxs=^[_a-z][_a-z0-9]?$
 

--- a/opensearchpy/.pylintrc
+++ b/opensearchpy/.pylintrc
@@ -1,5 +1,9 @@
 [MESSAGES CONTROL]
 disable=all
-enable=line-too-long,invalid-name,pointless-statement,unspecified-encoding
+enable=line-too-long,
+    invalid-name,
+    pointless-statement,
+    unspecified-encoding,
+    unnecessary-dunder-call
 max-line-length=240
 good-names-rgxs=^[_a-z][_a-z0-9]?$

--- a/opensearchpy/helpers/utils.py
+++ b/opensearchpy/helpers/utils.py
@@ -174,7 +174,7 @@ class AttrDict(object):
 
     def get(self, key: Any, default: Any = None) -> Any:
         try:
-            return self.__getattr__(key)
+            return self.__getattr__(key)  # pylint: disable=unnecessary-dunder-call
         except AttributeError:
             if default is not None:
                 return default

--- a/test_opensearchpy/.pylintrc
+++ b/test_opensearchpy/.pylintrc
@@ -5,6 +5,7 @@ enable=line-too-long,
         pointless-statement,
         unspecified-encoding,
         missing-param-doc,
-        differing-param-doc
+        differing-param-doc,
+        unnecessary-dunder-call
 max-line-length=240
 good-names-rgxs=^[_a-z][_a-z0-9]?$

--- a/test_opensearchpy/test_async/test_plugins_client.py
+++ b/test_opensearchpy/test_async/test_plugins_client.py
@@ -23,7 +23,7 @@ class TestPluginsClient:
         with warnings.catch_warnings(record=True) as w:
             client = AsyncOpenSearch()
             # testing double-init here
-            client.plugins.__init__(client)  # type: ignore
+            client.plugins.__init__(client)  # type: ignore # pylint: disable=unnecessary-dunder-call
             assert (
                 str(w[0].message)
                 == "Cannot load `alerting` directly to AsyncOpenSearch as it already exists. Use "

--- a/test_opensearchpy/test_async/test_server/test_helpers/test_document.py
+++ b/test_opensearchpy/test_async/test_server/test_helpers/test_document.py
@@ -275,22 +275,22 @@ async def test_save_and_update_return_doc_meta(write_client: Any) -> None:
     resp = await w.save(return_doc_meta=True)
     assert resp["_index"] == "test-wiki"
     assert resp["result"] == "created"
-    assert resp.keys().__contains__("_id")
-    assert resp.keys().__contains__("_primary_term")
-    assert resp.keys().__contains__("_seq_no")
-    assert resp.keys().__contains__("_shards")
-    assert resp.keys().__contains__("_version")
+    assert "_id" in resp.keys()
+    assert "_primary_term" in resp.keys()
+    assert "_seq_no" in resp.keys()
+    assert "_shards" in resp.keys()
+    assert "_version" in resp.keys()
 
     resp = await w.update(
         script="ctx._source.views += params.inc", inc=5, return_doc_meta=True
     )
     assert resp["_index"] == "test-wiki"
     assert resp["result"] == "updated"
-    assert resp.keys().__contains__("_id")
-    assert resp.keys().__contains__("_primary_term")
-    assert resp.keys().__contains__("_seq_no")
-    assert resp.keys().__contains__("_shards")
-    assert resp.keys().__contains__("_version")
+    assert "_id" in resp.keys()
+    assert "_primary_term" in resp.keys()
+    assert "_seq_no" in resp.keys()
+    assert "_shards" in resp.keys()
+    assert "_version" in resp.keys()
 
 
 async def test_init(write_client: Any) -> None:

--- a/test_opensearchpy/test_client/test_plugins/test_plugins_client.py
+++ b/test_opensearchpy/test_client/test_plugins/test_plugins_client.py
@@ -17,7 +17,7 @@ class TestPluginsClient(TestCase):
         with self.assertWarns(Warning) as w:
             client = OpenSearch()
             # double-init
-            client.plugins.__init__(client)  # type: ignore
+            client.plugins.__init__(client)  # type: ignore # pylint: disable=unnecessary-dunder-call
             self.assertEqual(
                 str(w.warnings[0].message),
                 "Cannot load `alerting` directly to OpenSearch as "

--- a/test_opensearchpy/test_server/test_helpers/test_document.py
+++ b/test_opensearchpy/test_server/test_helpers/test_document.py
@@ -284,22 +284,22 @@ def test_save_and_update_return_doc_meta(write_client: Any) -> None:
     resp = w.save(return_doc_meta=True)
     assert resp["_index"] == "test-wiki"
     assert resp["result"] == "created"
-    assert resp.keys().__contains__("_id")
-    assert resp.keys().__contains__("_primary_term")
-    assert resp.keys().__contains__("_seq_no")
-    assert resp.keys().__contains__("_shards")
-    assert resp.keys().__contains__("_version")
+    assert "_id" in resp.keys()
+    assert "_primary_term" in resp.keys()
+    assert "_seq_no" in resp.keys()
+    assert "_shards" in resp.keys()
+    assert "_version" in resp.keys()
 
     resp = w.update(
         script="ctx._source.views += params.inc", inc=5, return_doc_meta=True
     )
     assert resp["_index"] == "test-wiki"
     assert resp["result"] == "updated"
-    assert resp.keys().__contains__("_id")
-    assert resp.keys().__contains__("_primary_term")
-    assert resp.keys().__contains__("_seq_no")
-    assert resp.keys().__contains__("_shards")
-    assert resp.keys().__contains__("_version")
+    assert "_id" in resp.keys()
+    assert "_primary_term" in resp.keys()
+    assert "_seq_no" in resp.keys()
+    assert "_shards" in resp.keys()
+    assert "_version" in resp.keys()
 
 
 def test_init(write_client: Any) -> None:


### PR DESCRIPTION
added unnecessary-dunder-call to pylintrc files lines

in run_tests.py, exception thrown by 'git remote add origin' when the remote already exists will not exit

### Description
* unnecessary-dunder-call is a lint that finds any calls to magic or "dunder" functions ( __*__) that could be replaced by the operator or non-dunder function higher level call 
* also run_tests.py catches an exception thrown by git remote add origin when the remote already exists instead of exiting

### Issues Resolved
Progress on #610 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
