### PR TITLE
Add MultiTerms Aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added a log collection guide ([#579](https://github.com/opensearch-project/opensearch-py/pull/579))
 - Added GHA release ([#614](https://github.com/opensearch-project/opensearch-py/pull/614))
 - Incorporated API generation into CI workflow and fixed 'generate' nox session ([#660](https://github.com/opensearch-project/opensearch-py/pull/660))
+- Added support for the `multi_terms` bucket aggregation
 ### Changed
 - Updated the `get_policy` API in the index_management plugin to allow the policy_id argument as optional ([#633](https://github.com/opensearch-project/opensearch-py/pull/633))
 - Updated the `point_in_time.md` guide with examples demonstrating the usage of the new APIs as alternatives to the deprecated ones. ([#661](https://github.com/opensearch-project/opensearch-py/pull/661))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added a log collection guide ([#579](https://github.com/opensearch-project/opensearch-py/pull/579))
 - Added GHA release ([#614](https://github.com/opensearch-project/opensearch-py/pull/614))
 - Incorporated API generation into CI workflow and fixed 'generate' nox session ([#660](https://github.com/opensearch-project/opensearch-py/pull/660))
-- Added support for the `multi_terms` bucket aggregation
+- Added support for the `multi_terms` bucket aggregation ([#663](https://github.com/opensearch-project/opensearch-py/pull/663))
 ### Changed
 - Updated the `get_policy` API in the index_management plugin to allow the policy_id argument as optional ([#633](https://github.com/opensearch-project/opensearch-py/pull/633))
 - Updated the `point_in_time.md` guide with examples demonstrating the usage of the new APIs as alternatives to the deprecated ones. ([#661](https://github.com/opensearch-project/opensearch-py/pull/661))

--- a/opensearchpy/helpers/aggs.py
+++ b/opensearchpy/helpers/aggs.py
@@ -308,6 +308,10 @@ class VariableWidthHistogram(Bucket):
         return FieldBucketData(self, search, data)
 
 
+class MultiTerms(Bucket):
+    name = "multi_terms"
+
+
 # metric aggregations
 class TopHits(Agg):
     name = "top_hits"

--- a/test_opensearchpy/test_helpers/test_aggs.py
+++ b/test_opensearchpy/test_helpers/test_aggs.py
@@ -309,6 +309,18 @@ def test_variable_width_histogram_aggregation() -> None:
     assert {"variable_width_histogram": {"buckets": 2, "field": "price"}} == a.to_dict()
 
 
+def test_multi_terms_aggregation() -> None:
+    a = aggs.MultiTerms(terms=[{"field": "tags"}, {"field": "author.row"}])
+    assert {
+        "multi_terms": {
+            "terms": [
+                {"field": "tags"},
+                {"field": "author.row"},
+            ]
+        }
+    } == a.to_dict()
+
+
 def test_median_absolute_deviation_aggregation() -> None:
     a = aggs.MedianAbsoluteDeviation(field="rating")
 


### PR DESCRIPTION
### Description
This change makes it possible to use the `multi_terms` bucket aggregation, using the syntax
```python
aggs.MultiTerms(terms=[{"field": "tags"}, {"field": "author.row"}])
```

It is similar to [PR#1543](https://github.com/elastic/elasticsearch-dsl-py/pull/1543) from the `elasticsearch-dsl-py` repo.
I hope that is okay, since that project is also licensed under Apache 2.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).