### PR TITLE
Adding changelog update in API generator

### DIFF
--- a/.github/workflows/update_api.yml
+++ b/.github/workflows/update_api.yml
@@ -26,12 +26,6 @@ jobs:
           python3.7 -m pip install nox
       - name: Generate API
         run: nox -s generate
-      - name: Update CHANGELOG
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "- Your contribution here."
-          replace: "- Updated opensearch-py to reflect the latest OpenSearch API spec.\n- Your contribution here."
-          include: "**CHANGELOG.md"
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fix KeyError when scroll return no hits ([#616](https://github.com/opensearch-project/opensearch-py/pull/616))
 - Fix reuse of `OpenSearch` using `Urllib3HttpConnection` and `AsyncOpenSearch` after calling `close` ([#639](https://github.com/opensearch-project/opensearch-py/pull/639))
-### Automated API Update
-- Your contribution here.
+### Updated APIs
 ### Security
 ### Dependencies
 - Bumps `pytest-asyncio` from <=0.21.1 to <=0.23.4

--- a/utils/generate_api.py
+++ b/utils/generate_api.py
@@ -773,27 +773,23 @@ def dump_modules(modules: Any) -> None:
         commit_url = commit_info["html_url"]
         latest_commit_sha = commit_info.get("sha")
     else:
-        print("Failed to fetch opensearch-api-specification commit information.")
-        print("Status code:", response.status_code)
-        latest_commit_sha = None
+        raise Exception(
+            f"Failed to fetch opensearch-api-specification commit information. Status code: {response.status_code}"
+        )
 
-    file_content = ""
-    with open("CHANGELOG.md", "r", encoding="utf-8") as file:
+    with open("CHANGELOG.md", "r+", encoding="utf-8") as file:
         content = file.read()
         if "### Updated APIs" in content:
             file_content = content.replace(
                 "### Updated APIs",
-                "### Updated APIs\n- Updated opensearch-py APIs to reflect OpenSearch API spec"
-                + (
-                    f"[@{latest_commit_sha[:7]}]({commit_url})"
-                    if latest_commit_sha is not None
-                    else ""
-                ),
+                f"### Updated APIs\n- Updated opensearch-py APIs to reflect [opensearch-api-specification@{latest_commit_sha[:7]}]({commit_url})",
                 1,
             )
-
-    with open("CHANGELOG.md", "w", encoding="utf-8") as file:
-        file.write(file_content)
+            file.seek(0)
+            file.write(file_content)
+            file.truncate()
+        else:
+            raise Exception("'Updated APIs' section is not present in CHANGELOG.md")
 
 
 if __name__ == "__main__":

--- a/utils/generate_api.py
+++ b/utils/generate_api.py
@@ -764,6 +764,37 @@ def dump_modules(modules: Any) -> None:
     unasync.unasync_files(filepaths, rules)
     blacken(CODE_ROOT / "opensearchpy")
 
+    # Updating the CHANGELOG.md
+    response = requests.get(
+        "https://api.github.com/repos/opensearch-project/opensearch-api-specification/commits"
+    )
+    if response.ok:
+        commit_info = response.json()[0]
+        commit_url = commit_info["html_url"]
+        latest_commit_sha = commit_info.get("sha")
+    else:
+        print("Failed to fetch opensearch-api-specification commit information.")
+        print("Status code:", response.status_code)
+        latest_commit_sha = None
+
+    file_content = ""
+    with open("CHANGELOG.md", "r", encoding="utf-8") as file:
+        content = file.read()
+        if "### Updated APIs" in content:
+            file_content = content.replace(
+                "### Updated APIs",
+                "### Updated APIs\n- Updated opensearch-py APIs to reflect OpenSearch API spec"
+                + (
+                    f"[@{latest_commit_sha[:7]}]({commit_url})"
+                    if latest_commit_sha is not None
+                    else ""
+                ),
+                1,
+            )
+
+    with open("CHANGELOG.md", "w", encoding="utf-8") as file:
+        file.write(file_content)
+
 
 if __name__ == "__main__":
     dump_modules(read_modules())


### PR DESCRIPTION
### Description

- Fixed failing [update_api](https://github.com/opensearch-project/opensearch-py/actions/runs/7809558928) action by adding changelog update directly in the API generator, incorporating opensearch API spec commit details.
- Changelog updates now occur only at the first occurrence of '### Updated APIs'.
- Sample PR created: https://github.com/saimedhi/opensearch-py/pull/35/files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
