### PR TITLE
`Service Time` measurement Trail_Approach_1

### DIFF
--- a/opensearchpy/connection/http_requests.py
+++ b/opensearchpy/connection/http_requests.py
@@ -163,7 +163,6 @@ class RequestsHttpConnection(Connection):
         body: Optional[bytes] = None,
         timeout: Optional[Union[int, float]] = None,
         allow_redirects: Optional[bool] = True,
-        calculate_service_time: Optional[bool] = False,
         ignore: Collection[int] = (),
         headers: Optional[Mapping[str, str]] = None,
     ) -> Any:

--- a/opensearchpy/connection/http_requests.py
+++ b/opensearchpy/connection/http_requests.py
@@ -166,6 +166,10 @@ class RequestsHttpConnection(Connection):
         ignore: Collection[int] = (),
         headers: Optional[Mapping[str, str]] = None,
     ) -> Any:
+        
+        calculate_service_time=False
+        if "calculate_service_time" in self.kwargs:
+            calculate_service_time=self.kwargs["calculate_service_time"]
         url = self.base_url + url
         headers = headers or {}
         if params:

--- a/opensearchpy/connection/http_requests.py
+++ b/opensearchpy/connection/http_requests.py
@@ -88,6 +88,7 @@ class RequestsHttpConnection(Connection):
         pool_maxsize: Any = None,
         **kwargs: Any
     ) -> None:
+        self.kwargs=kwargs
         if not REQUESTS_AVAILABLE:
             raise ImproperlyConfigured(
                 "Please install requests to use RequestsHttpConnection."

--- a/opensearchpy/connection/http_requests.py
+++ b/opensearchpy/connection/http_requests.py
@@ -188,7 +188,9 @@ class RequestsHttpConnection(Connection):
         }
         send_kwargs.update(settings)
         try:
+            request_start = time.perf_counter()
             response = self.session.send(prepared_request, **send_kwargs)
+            request_duration=time.perf_counter()-request_start
             duration = time.time() - start
             raw_data = response.content.decode("utf-8", "surrogatepass")
         except reraise_exceptions:

--- a/opensearchpy/connection/http_requests.py
+++ b/opensearchpy/connection/http_requests.py
@@ -216,7 +216,7 @@ class RequestsHttpConnection(Connection):
         
         # Add the service time to the response headers
         if calculate_service_time:
-            response.headers["X-Service-Time"] = str(duration)
+            raw_data["__client"] = {"Service_Time": str(duration)}
 
         # raise warnings if any from the 'Warnings' header.
         warnings_headers = (

--- a/opensearchpy/connection/http_requests.py
+++ b/opensearchpy/connection/http_requests.py
@@ -176,7 +176,6 @@ class RequestsHttpConnection(Connection):
             body = self._gzip_compress(body)
             headers["content-encoding"] = "gzip"  # type: ignore
 
-        start = time.time()
         request = requests.Request(method=method, headers=headers, url=url, data=body)
         prepared_request = self.session.prepare_request(request)
         settings = self.session.merge_environment_settings(
@@ -188,9 +187,8 @@ class RequestsHttpConnection(Connection):
         }
         send_kwargs.update(settings)
         try:
-            request_start = time.perf_counter()
+            start = time.time()
             response = self.session.send(prepared_request, **send_kwargs)
-            request_duration=time.perf_counter()-request_start
             duration = time.time() - start
             raw_data = response.content.decode("utf-8", "surrogatepass")
         except reraise_exceptions:

--- a/opensearchpy/connection/http_requests.py
+++ b/opensearchpy/connection/http_requests.py
@@ -186,14 +186,15 @@ class RequestsHttpConnection(Connection):
             "allow_redirects": allow_redirects,
         }
         send_kwargs.update(settings)
+        start = time.time()
         try:
-            start = time.time()
             response = self.session.send(prepared_request, **send_kwargs)
             duration = time.time() - start
             raw_data = response.content.decode("utf-8", "surrogatepass")
         except reraise_exceptions:
             raise
         except Exception as e:
+             duration = time.time() - start
             self.log_request_fail(
                 method,
                 url,
@@ -207,6 +208,7 @@ class RequestsHttpConnection(Connection):
             if isinstance(e, requests.Timeout):
                 raise ConnectionTimeout("TIMEOUT", str(e), e)
             raise ConnectionError("N/A", str(e), e)
+            
 
         # raise warnings if any from the 'Warnings' header.
         warnings_headers = (

--- a/opensearchpy/connection/http_requests.py
+++ b/opensearchpy/connection/http_requests.py
@@ -194,7 +194,7 @@ class RequestsHttpConnection(Connection):
         except reraise_exceptions:
             raise
         except Exception as e:
-             duration = time.time() - start
+            duration = time.time() - start
             self.log_request_fail(
                 method,
                 url,

--- a/opensearchpy/connection/http_requests.py
+++ b/opensearchpy/connection/http_requests.py
@@ -208,6 +208,10 @@ class RequestsHttpConnection(Connection):
             if isinstance(e, requests.Timeout):
                 raise ConnectionTimeout("TIMEOUT", str(e), e)
             raise ConnectionError("N/A", str(e), e)
+        
+        # Add the service time to the response headers
+        response.headers["X-Service-Time"] = str(duration)
+
             
 
         # raise warnings if any from the 'Warnings' header.

--- a/opensearchpy/connection/http_requests.py
+++ b/opensearchpy/connection/http_requests.py
@@ -214,10 +214,10 @@ class RequestsHttpConnection(Connection):
                 raise ConnectionTimeout("TIMEOUT", str(e), e)
             raise ConnectionError("N/A", str(e), e)
         
-        # Add the service time to the response headers
+        # Add the service time to the raw_data
         if calculate_service_time:
-            raw_data["__client"] = {"Service_Time": str(duration)}
-
+            raw_data = raw_data.rstrip()[:-1] + f', "__client": {{"Service_Time": "{duration}"}}' + '}'
+            
         # raise warnings if any from the 'Warnings' header.
         warnings_headers = (
             (response.headers["warning"],) if "warning" in response.headers else ()

--- a/opensearchpy/connection/http_requests.py
+++ b/opensearchpy/connection/http_requests.py
@@ -163,6 +163,7 @@ class RequestsHttpConnection(Connection):
         body: Optional[bytes] = None,
         timeout: Optional[Union[int, float]] = None,
         allow_redirects: Optional[bool] = True,
+        calculate_service_time: Optional[bool] = False,
         ignore: Collection[int] = (),
         headers: Optional[Mapping[str, str]] = None,
     ) -> Any:
@@ -210,9 +211,8 @@ class RequestsHttpConnection(Connection):
             raise ConnectionError("N/A", str(e), e)
         
         # Add the service time to the response headers
-        response.headers["X-Service-Time"] = str(duration)
-
-            
+        if calculate_service_time:
+            response.headers["X-Service-Time"] = str(duration)
 
         # raise warnings if any from the 'Warnings' header.
         warnings_headers = (

--- a/opensearchpy/transport.py
+++ b/opensearchpy/transport.py
@@ -419,6 +419,7 @@ class Transport(object):
                 headers_response = {
                     header.lower(): value for header, value in headers_response.items()
                 }
+                print("headers_response", headers_response)
 
             except TransportError as e:
                 if method == "HEAD" and e.status_code == 404:
@@ -457,7 +458,10 @@ class Transport(object):
                     data = self.deserializer.loads(
                         data, headers_response.get("content-type")
                     )
+                if self.kwargs["calculate_service_time"] is True:
+                    data.update({"x-service-time": headers_response["x-service-time"]})
                 return data
+                    
 
     def close(self) -> Any:
         """

--- a/opensearchpy/transport.py
+++ b/opensearchpy/transport.py
@@ -419,7 +419,6 @@ class Transport(object):
                 headers_response = {
                     header.lower(): value for header, value in headers_response.items()
                 }
-                print("headers_response", headers_response)
 
             except TransportError as e:
                 if method == "HEAD" and e.status_code == 404:
@@ -458,10 +457,7 @@ class Transport(object):
                     data = self.deserializer.loads(
                         data, headers_response.get("content-type")
                     )
-                if self.kwargs["calculate_service_time"] is True:
-                    data.update({"x-service-time": headers_response["x-service-time"]})
                 return data
-                    
 
     def close(self) -> Any:
         """


### PR DESCRIPTION
### Description

- Service time is calculated within the perform_request function of the Connection class ( This draft uses RequestsHttpConnection) at the point where the server call is made.

- The calculated service time is added to the response or data in the connection. 

- I understand that this method is not ideal for returning service time and am exploring alternative options for improvement.

### Issues Resolved
Related to #678 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
