### PR TITLE
Updated to the latest 'peter-evans/create-pull-request@v6' version in Update API Workflow

### DIFF
--- a/.github/workflows/update_api.yml
+++ b/.github/workflows/update_api.yml
@@ -38,7 +38,7 @@ jobs:
           installation_id: 22958780
       - name: Create pull request
         id: cpr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ steps.github_app_token.outputs.token }}
           commit-message: Updated opensearch-py to reflect the latest OpenSearch API spec (${{ steps.date.outputs.date }})


### PR DESCRIPTION
### Description
Updated **Update API** Workflow to use the latest version of 'peter-evans/create-pull-request@v6'. The update addresses failures caused by an upstream [issue](https://github.com/peter-evans/create-pull-request/issues/2790).

### Issues Resolved

https://github.com/opensearch-project/opensearch-py/actions/workflows/update_api.yml


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
