### PR TITLE
fix: retry_on_conflict is int not bool

### DIFF
--- a/opensearchpy/_async/helpers/document.py
+++ b/opensearchpy/_async/helpers/document.py
@@ -318,7 +318,7 @@ class AsyncDocument(ObjectBase):
         detect_noop: Optional[bool] = True,
         doc_as_upsert: Optional[bool] = False,
         refresh: Optional[bool] = False,
-        retry_on_conflict: Optional[bool] = None,
+        retry_on_conflict: Optional[int] = None,
         script: Any = None,
         script_id: Optional[str] = None,
         scripted_upsert: Optional[bool] = False,

--- a/opensearchpy/helpers/document.py
+++ b/opensearchpy/helpers/document.py
@@ -374,7 +374,7 @@ class Document(ObjectBase):
         detect_noop: bool = True,
         doc_as_upsert: bool = False,
         refresh: bool = False,
-        retry_on_conflict: Any = None,
+        retry_on_conflict: int = None,
         script: Any = None,
         script_id: Any = None,
         scripted_upsert: bool = False,

--- a/test_opensearchpy/test_async/test_server/test_helpers/test_document.py
+++ b/test_opensearchpy/test_async/test_server/test_helpers/test_document.py
@@ -251,7 +251,7 @@ async def test_update_retry_on_conflict(write_client: Any) -> None:
 
 @pytest.mark.parametrize("retry_on_conflict", [None, 0])  # type: ignore
 async def test_update_conflicting_version(
-    write_client: Any, retry_on_conflict: bool
+    write_client: Any, retry_on_conflict: int
 ) -> None:
     await Wiki.init()
     w = Wiki(owner=User(name="Honza Kral"), _id="opensearch-py", views=42)

--- a/test_opensearchpy/test_server/test_helpers/test_document.py
+++ b/test_opensearchpy/test_server/test_helpers/test_document.py
@@ -261,7 +261,7 @@ def test_update_retry_on_conflict(write_client: Any) -> None:
 
 
 @pytest.mark.parametrize("retry_on_conflict", [None, 0])  # type: ignore
-def test_update_conflicting_version(write_client: Any, retry_on_conflict: Any) -> None:
+def test_update_conflicting_version(write_client: Any, retry_on_conflict: int) -> None:
     Wiki.init()
     w = Wiki(owner=User(name="Honza Kral"), _id="opensearch-py", views=42)
     w.save()


### PR DESCRIPTION
### Description
retry_on_conflict appears to be typed incorrectly in select locations. The documentation points to the value for this being an integer.
https://opensearch.org/docs/1.0/opensearch/rest-api/document-apis/update-document/

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
