### PR TITLE
Fixed YAML test runner for failing search/highlight/30_max_analyzed_offset[5] test

### DIFF
--- a/test_opensearchpy/test_server/test_rest_api_spec.py
+++ b/test_opensearchpy/test_server/test_rest_api_spec.py
@@ -371,10 +371,10 @@ class YamlRunner:
 
             if (
                 isinstance(expected, str)
-                and expected.startswith("/")
-                and expected.endswith("/")
+                and expected.strip().startswith("/")
+                and expected.strip().endswith("/")
             ):
-                expected = re.compile(expected[1:-1], re.VERBOSE | re.MULTILINE)
+                expected = re.compile(expected.strip()[1:-1], re.VERBOSE | re.MULTILINE)
                 assert expected.search(value), "%r does not match %r" % (
                     value,
                     expected,
@@ -417,9 +417,7 @@ class YamlRunner:
                         value = value.replace(key_replace, v)
                         break
 
-        if isinstance(value, string_types):
-            value = value.strip()
-        elif isinstance(value, dict):
+        if isinstance(value, dict):
             value = dict((k, self._resolve(v)) for (k, v) in value.items())
         elif isinstance(value, list):
             value = list(map(self._resolve, value))


### PR DESCRIPTION
### Description
Fixed YAML test runner for failing search/highlight/30_max_analyzed_offset[5] test in integration tests against an **unreleased** versions [2.x](https://github.com/opensearch-project/opensearch-py/actions/runs/8246216987/job/22551786241#step:10:2051), [main](https://github.com/opensearch-project/opensearch-py/actions/runs/8246216987/job/22551788126#step:10:2159) of OpenSearch.

- Note: This test is failing in several **released** opensearch versions as well. To address the failing tests in those versions, I'll correct the skipped versions in the [opensearch main branch](https://github.com/opensearch-project/OpenSearch/blob/main/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml#L85). Skip version should be version: " - 2.12.99"


### Issues Resolved
Related to https://github.com/opensearch-project/opensearch-py/issues/686

### Additional context 

- This [test case](https://github.com/opensearch-project/OpenSearch/blob/main/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml#L83) asserts 

  ` match: {hits.hits.0.highlight.field1.0: "The <em>quick</em> "}`
  

-   Yaml test runner is considering it as 
` match: {hits.hits.0.highlight.field1.0: "The <em>quick</em>"}` without space at the end because of value.strip() [here](https://github.com/opensearch-project/opensearch-py/blob/main/test_opensearchpy/test_server/test_rest_api_spec.py#L421).

  
  




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
