### PR TITLE
FIX: Remove HEAD -> GET request swap workaround

### DIFF
--- a/opensearchpy/_async/http_aiohttp.py
+++ b/opensearchpy/_async/http_aiohttp.py
@@ -246,12 +246,8 @@ class AIOHttpConnection(AsyncConnection):
         else:
             query_string = ""
 
-        # There is a bug in aiohttp that disables the re-use
-        # of the connection in the pool when method=HEAD.
-        # See: aio-libs/aiohttp#1769
         is_head = False
         if method == "HEAD":
-            method = "GET"
             is_head = True
 
         # Top-tier tip-toeing happening here. Basically
@@ -301,9 +297,9 @@ class AIOHttpConnection(AsyncConnection):
                 timeout=timeout,
                 fingerprint=self.ssl_assert_fingerprint,
             ) as response:
-                if is_head:  # We actually called 'GET' so throw away the data.
+                if is_head:
                     await response.release()
-                    raw_data = ""
+                    raw_data = ""  # HEAD method has no response body
                 else:
                     raw_data = await response.text()
                 duration = self.loop.time() - start

--- a/opensearchpy/connection/http_async.py
+++ b/opensearchpy/connection/http_async.py
@@ -167,12 +167,8 @@ class AsyncHttpConnection(AIOHttpConnection):
         else:
             query_string = ""
 
-        # There is a bug in aiohttp that disables the re-use
-        # of the connection in the pool when method=HEAD.
-        # See: https://github.com/aio-libs/aiohttp/issues/1769
         is_head = False
         if method == "HEAD":
-            method = "GET"
             is_head = True
 
         # Top-tier tip-toeing happening here. Basically
@@ -221,9 +217,9 @@ class AsyncHttpConnection(AIOHttpConnection):
                 timeout=timeout,
                 fingerprint=self.ssl_assert_fingerprint,
             ) as response:
-                if is_head:  # We actually called 'GET' so throw away the data.
+                if is_head:
                     await response.release()
-                    raw_data = ""
+                    raw_data = ""  # HEAD method has no response body
                 else:
                     raw_data = await response.text()
                 duration = self.loop.time() - start


### PR DESCRIPTION
### Description
Remove a workaround replacing HEAD requests with GET requests for async requests.
This workaround is no longer needed after the underlying bug was fixed in https://github.com/aio-libs/aiohttp/pull/5012

### Issues Resolved
Partially resolves https://github.com/opensearch-project/opensearch-py/issues/698
The rest of the issue is user (my) error.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
