### PR TITLE
Add permission to the release workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the team set up in https://github.com/orgs/opensearch-project/teams and include any additional contributors
-*   @VachaShah @dblock @harshavamsi @axeoman @deztructor @Shephalimittal @saimedhi @florianvazelle
+*   @VachaShah @dblock @harshavamsi @axeoman @Shephalimittal @saimedhi @florianvazelle

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   draft-a-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3


### PR DESCRIPTION
### Description
Add permission to the release workflow

### Issues Resolved
Release workflow failed to create github issue for manual approval.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
