### PR TITLE
Add support for urllib3 v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Added support for urllib3 2+ in Python 3.10+ ([#719](https://github.com/opensearch-project/opensearch-py/pull/719))
 - Added support for Python 3.12 ([#717](https://github.com/opensearch-project/opensearch-py/pull/717))
 - Added service time metrics ([#716](https://github.com/opensearch-project/opensearch-py/pull/716))
 - Added `search_pipeline` APIs and `notifications` plugin APIs ([#724](https://github.com/opensearch-project/opensearch-py/pull/724))

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ packages = [
     if package == MODULE_DIR or package.startswith(MODULE_DIR + ".")
 ]
 install_requires = [
-    "urllib3>=1.26.18, <2",
+    'urllib3>=1.26.18,<1.27 ; python_version < "3.10"',
+    'urllib3>=1.26.18,!=2.2.0,<3 ; python_version >= "3.10"',
     "requests>=2.4.0, <3.0.0",
     "six",
     "python-dateutil",


### PR DESCRIPTION
### Description

Allows using urllib3 v2 if Python version is >= 3.10. The same technique is applied in https://github.com/boto/botocore/pull/3141/files.

### Issues Resolved

https://github.com/opensearch-project/opensearch-py/issues/628

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
