### PR TITLE
Enhanced the generator to omit generating default parameter values when already present in param description.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Updated code generator to use native OpenAPI specification ([#721](https://github.com/opensearch-project/opensearch-py/pull/721))
 ### Updated APIs
+- Updated opensearch-py APIs to reflect [opensearch-api-specification@61f8a38](https://github.com/opensearch-project/opensearch-api-specification/commit/61f8a382c6abc7d9bb0504a097b52323809095be)
 - Updated opensearch-py APIs to reflect [opensearch-api-specification@e02c076](https://github.com/opensearch-project/opensearch-api-specification/commit/e02c076ef63f7a9b650ca1416380120cc640620a)
 - Updated opensearch-py APIs to reflect [opensearch-api-specification@fe6f977](https://github.com/opensearch-project/opensearch-api-specification/commit/fe6f977bcae4e27a2b261fb9599884df5606c0bc)
 - Updated opensearch-py APIs to reflect [opensearch-api-specification@29faff0](https://github.com/opensearch-project/opensearch-api-specification/commit/29faff0709b2557acfd4c3c7e053a2c313413633)

--- a/opensearchpy/_async/client/__init__.py
+++ b/opensearchpy/_async/client/__init__.py
@@ -846,7 +846,7 @@ class AsyncOpenSearch(Client):
             `open`, `closed`, `hidden`, `none`.
         :arg filter_path: Comma-separated list of filters used to reduce
             the response.
-        :arg from_: Starting offset (default: 0) Default is 0.
+        :arg from_: Starting offset (default: 0)
         :arg human: Whether to return human readable values for
             statistics.
         :arg ignore_unavailable: If `false`, the request returns an
@@ -2765,7 +2765,7 @@ class AsyncOpenSearch(Client):
             `closed`, `hidden`, `none`.
         :arg filter_path: Comma-separated list of filters used to reduce
             the response.
-        :arg from_: Starting offset (default: 0) Default is 0.
+        :arg from_: Starting offset (default: 0)
         :arg human: Whether to return human readable values for
             statistics.
         :arg ignore_unavailable: If `false`, the request returns an

--- a/opensearchpy/_async/client/cluster.py
+++ b/opensearchpy/_async/client/cluster.py
@@ -223,13 +223,13 @@ class ClusterClient(NamespacedClient):
         :arg filter_path: Comma-separated list of filters used to reduce
             the response.
         :arg flat_settings: Return settings in flat format (default:
-            false) Default is false.
+            false)
         :arg human: Whether to return human readable values for
             statistics.
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg local: Return local information, do not retrieve the state
-            from cluster-manager node (default: false) Default is false.
+            from cluster-manager node (default: false)
         :arg master_timeout (Deprecated: To promote inclusive language,
             use 'cluster_manager_timeout' instead.): Specify timeout for connection
             to master
@@ -438,7 +438,7 @@ class ClusterClient(NamespacedClient):
         :arg filter_path: Comma-separated list of filters used to reduce
             the response.
         :arg flat_settings: Return settings in flat format (default:
-            false) Default is false.
+            false)
         :arg human: Whether to return human readable values for
             statistics.
         :arg master_timeout (Deprecated: To promote inclusive language,

--- a/opensearchpy/_async/client/indices.py
+++ b/opensearchpy/_async/client/indices.py
@@ -1214,11 +1214,11 @@ class IndicesClient(NamespacedClient):
         :arg filter_path: Comma-separated list of filters used to reduce
             the response.
         :arg flat_settings: Return settings in flat format (default:
-            false) Default is false.
+            false)
         :arg human: Whether to return human readable values for
             statistics.
         :arg local: Return local information, do not retrieve the state
-            from cluster-manager node (default: false) Default is false.
+            from cluster-manager node (default: false)
         :arg master_timeout (Deprecated: To promote inclusive language,
             use 'cluster_manager_timeout' instead.): Explicit operation timeout for
             connection to master node
@@ -1970,7 +1970,7 @@ class IndicesClient(NamespacedClient):
         :arg filter_path: Comma-separated list of filters used to reduce
             the response.
         :arg flush: Specify whether the index should be flushed after
-            performing the operation (default: true) Default is True.
+            performing the operation (default: true)
         :arg human: Whether to return human readable values for
             statistics.
         :arg ignore_unavailable: Whether specified concrete indices

--- a/opensearchpy/_async/client/snapshot.py
+++ b/opensearchpy/_async/client/snapshot.py
@@ -289,7 +289,7 @@ class SnapshotClient(NamespacedClient):
         :arg human: Whether to return human readable values for
             statistics.
         :arg local: Return local information, do not retrieve the state
-            from cluster-manager node (default: false) Default is false.
+            from cluster-manager node (default: false)
         :arg master_timeout (Deprecated: To promote inclusive language,
             use 'cluster_manager_timeout' instead.): Explicit operation timeout for
             connection to master node

--- a/opensearchpy/client/__init__.py
+++ b/opensearchpy/client/__init__.py
@@ -846,7 +846,7 @@ class OpenSearch(Client):
             `open`, `closed`, `hidden`, `none`.
         :arg filter_path: Comma-separated list of filters used to reduce
             the response.
-        :arg from_: Starting offset (default: 0) Default is 0.
+        :arg from_: Starting offset (default: 0)
         :arg human: Whether to return human readable values for
             statistics.
         :arg ignore_unavailable: If `false`, the request returns an
@@ -2765,7 +2765,7 @@ class OpenSearch(Client):
             `closed`, `hidden`, `none`.
         :arg filter_path: Comma-separated list of filters used to reduce
             the response.
-        :arg from_: Starting offset (default: 0) Default is 0.
+        :arg from_: Starting offset (default: 0)
         :arg human: Whether to return human readable values for
             statistics.
         :arg ignore_unavailable: If `false`, the request returns an

--- a/opensearchpy/client/cluster.py
+++ b/opensearchpy/client/cluster.py
@@ -223,13 +223,13 @@ class ClusterClient(NamespacedClient):
         :arg filter_path: Comma-separated list of filters used to reduce
             the response.
         :arg flat_settings: Return settings in flat format (default:
-            false) Default is false.
+            false)
         :arg human: Whether to return human readable values for
             statistics.
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg local: Return local information, do not retrieve the state
-            from cluster-manager node (default: false) Default is false.
+            from cluster-manager node (default: false)
         :arg master_timeout (Deprecated: To promote inclusive language,
             use 'cluster_manager_timeout' instead.): Specify timeout for connection
             to master
@@ -438,7 +438,7 @@ class ClusterClient(NamespacedClient):
         :arg filter_path: Comma-separated list of filters used to reduce
             the response.
         :arg flat_settings: Return settings in flat format (default:
-            false) Default is false.
+            false)
         :arg human: Whether to return human readable values for
             statistics.
         :arg master_timeout (Deprecated: To promote inclusive language,

--- a/opensearchpy/client/indices.py
+++ b/opensearchpy/client/indices.py
@@ -1214,11 +1214,11 @@ class IndicesClient(NamespacedClient):
         :arg filter_path: Comma-separated list of filters used to reduce
             the response.
         :arg flat_settings: Return settings in flat format (default:
-            false) Default is false.
+            false)
         :arg human: Whether to return human readable values for
             statistics.
         :arg local: Return local information, do not retrieve the state
-            from cluster-manager node (default: false) Default is false.
+            from cluster-manager node (default: false)
         :arg master_timeout (Deprecated: To promote inclusive language,
             use 'cluster_manager_timeout' instead.): Explicit operation timeout for
             connection to master node
@@ -1970,7 +1970,7 @@ class IndicesClient(NamespacedClient):
         :arg filter_path: Comma-separated list of filters used to reduce
             the response.
         :arg flush: Specify whether the index should be flushed after
-            performing the operation (default: true) Default is True.
+            performing the operation (default: true)
         :arg human: Whether to return human readable values for
             statistics.
         :arg ignore_unavailable: Whether specified concrete indices

--- a/opensearchpy/client/snapshot.py
+++ b/opensearchpy/client/snapshot.py
@@ -289,7 +289,7 @@ class SnapshotClient(NamespacedClient):
         :arg human: Whether to return human readable values for
             statistics.
         :arg local: Return local information, do not retrieve the state
-            from cluster-manager node (default: false) Default is false.
+            from cluster-manager node (default: false)
         :arg master_timeout (Deprecated: To promote inclusive language,
             use 'cluster_manager_timeout' instead.): Explicit operation timeout for
             connection to master node

--- a/utils/templates/base
+++ b/utils/templates/base
@@ -23,7 +23,7 @@
         {% if info.description %}
         {% filter wordwrap(72, wrapstring="\n            ") %}
         :arg {{ p }}{% if info.deprecated and info.deprecation_message is defined %} (Deprecated: {{ info['deprecation_message'][:-1] }}.){% endif %}: {{ info.description }} {% if info.options and "Valid values" not in info.description %}Valid choices are {{ info.options|join(", ") }}.{% endif %}
-        {% if info.default is defined %}{% if info.default is not none %}{% if info.default is sameas(false) %}Default is false.{% else %}Default is {{ info.default }}.{% endif %}{% endif %}{% endif %}
+        {% if info.default is defined %}{% if info.default is not none and "default:" not in info.description%}{% if info.default is sameas(false) %}Default is false.{% else %}Default is {{ info.default }}.{% endif %}{% endif %}{% endif %}
         {% endfilter %}
 
         {% endif %}


### PR DESCRIPTION
### Description

- Enhanced the generator to omit generating default parameter values when they are already specified in the parameter description.

### Issues Resolved
 Closes https://github.com/opensearch-project/opensearch-py/pull/727#discussion_r1573170642

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
