### PR TITLE
Bumps aiohttp from >=3.9.2,<4 to >=3.9.4,<4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `black` to >=24.3.0 ([#717](https://github.com/opensearch-project/opensearch-py/pull/717))
 - Bumps `pytest-asyncio` from <=0.23.5 to <=0.23.7
 - Bumps `sphinx` from <7.3 to <7.4
+- Bumps `aiohttp` from >=3.9.2,<4 to >=3.9.4,<4 ([#751](https://github.com/opensearch-project/opensearch-py/pull/751))
 
 ## [2.5.0]
 ### Added

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,6 +22,6 @@ black>=24.3.0
 twine
 
 # Requirements for testing [async] extra
-aiohttp>=3.9.2, <4
+aiohttp>=3.9.4, <4
 pytest-asyncio<=0.23.7
 unasync

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ tests_require = [
     "pytest-mock<4.0.0",
 ]
 
-async_require = ["aiohttp>=3.9.2,<4"]
+async_require = ["aiohttp>=3.9.4,<4"]
 
 docs_require = ["sphinx", "sphinx_rtd_theme", "myst_parser", "sphinx_copybutton"]
 generate_require = ["black>=24.3.0", "jinja2"]


### PR DESCRIPTION
### Description
Bumps aiohttp from >=3.9.2,<4 to >=3.9.4,<4 to fix high severity vulnerability.

### Issues Resolved
Closes #745, #728 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
