### PR TITLE
Removed deprecated numpy.float_ and update NumPy/Pandas imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 ### Changed
+- Removed deprecated `numpy.float_` and update NumPy/Pandas imports ([#762](https://github.com/opensearch-project/opensearch-py/pull/762))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,9 +11,8 @@ deepmerge
 Events
 setuptools
 
-# No wheels for Python 3.10 yet!
-numpy; python_version<"3.10"
-pandas; python_version<"3.10"
+numpy; python_version<="3.12"
+pandas; python_version<="3.12"
 
 pyyaml>=5.4
 

--- a/opensearchpy/serializer.py
+++ b/opensearchpy/serializer.py
@@ -111,7 +111,6 @@ class JSONSerializer(Serializer):
             elif isinstance(
                 data,
                 (
-                    np.float_,
                     np.float16,
                     np.float32,
                     np.float64,

--- a/test_opensearchpy/test_serializer.py
+++ b/test_opensearchpy/test_serializer.py
@@ -106,7 +106,6 @@ class TestJSONSerializer(TestCase):
 
         ser = JSONSerializer()
         for np_type in (
-            np.float_,
             np.float32,
             np.float64,
         ):


### PR DESCRIPTION
### Description
- Removed the deprecated usage of `numpy.float_`.
- Updated NumPy and Pandas import statements for compatibility with latest Python versions.

### Issues Resolved
https://github.com/opensearch-project/opensearch-py/pull/761#issuecomment-2168018284

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
