### PR TITLE
Fixed issue 769:Collapse not preserved when chaining a search instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed Collapse not preserved when chaining a search instance (update-PR#)
 ### Updated APIs
 - Updated opensearch-py APIs to reflect [opensearch-api-specification@7452827](https://github.com/opensearch-project/opensearch-api-specification/commit/745282767026703ea27967d2705633c3e2661c97)
 - Updated opensearch-py APIs to reflect [opensearch-api-specification@f2afd71](https://github.com/opensearch-project/opensearch-api-specification/commit/f2afd7171406c7477fbd644d74087bb0e2948c75)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
-- Fixed issue 769:Collapse not preserved when chaining a search instance ([#771](https://github.com/opensearch-project/opensearch-py/pull/771))
+- Fixed issue 769: Collapse not preserved when chaining a search instance ([#771](https://github.com/opensearch-project/opensearch-py/pull/771))
 ### Updated APIs
 - Updated opensearch-py APIs to reflect [opensearch-api-specification@7452827](https://github.com/opensearch-project/opensearch-api-specification/commit/745282767026703ea27967d2705633c3e2661c97)
 - Updated opensearch-py APIs to reflect [opensearch-api-specification@f2afd71](https://github.com/opensearch-project/opensearch-api-specification/commit/f2afd7171406c7477fbd644d74087bb0e2948c75)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
-- Fixed Collapse not preserved when chaining a search instance (update-PR#)
+- Fixed issue 769:Collapse not preserved when chaining a search instance ([#771](https://github.com/opensearch-project/opensearch-py/pull/771))
 ### Updated APIs
 - Updated opensearch-py APIs to reflect [opensearch-api-specification@7452827](https://github.com/opensearch-project/opensearch-api-specification/commit/745282767026703ea27967d2705633c3e2661c97)
 - Updated opensearch-py APIs to reflect [opensearch-api-specification@f2afd71](https://github.com/opensearch-project/opensearch-api-specification/commit/f2afd7171406c7477fbd644d74087bb0e2948c75)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
-- Fixed issue 769: Collapse not preserved when chaining a search instance ([#771](https://github.com/opensearch-project/opensearch-py/pull/771))
+- Fixed Search helper to ensure proper retention of the _collapse attribute in chained operations. ([#771](https://github.com/opensearch-project/opensearch-py/pull/771))
 ### Updated APIs
 - Updated opensearch-py APIs to reflect [opensearch-api-specification@7452827](https://github.com/opensearch-project/opensearch-api-specification/commit/745282767026703ea27967d2705633c3e2661c97)
 - Updated opensearch-py APIs to reflect [opensearch-api-specification@f2afd71](https://github.com/opensearch-project/opensearch-api-specification/commit/f2afd7171406c7477fbd644d74087bb0e2948c75)

--- a/opensearchpy/helpers/search.py
+++ b/opensearchpy/helpers/search.py
@@ -431,6 +431,7 @@ class Search(Request):
         s._highlight_opts = self._highlight_opts.copy()
         s._suggest = self._suggest.copy()
         s._script_fields = self._script_fields.copy()
+        s._collapse = self._collapse.copy()
         for x in ("query", "post_filter"):
             getattr(s, x)._proxied = getattr(self, x)._proxied
 

--- a/test_opensearchpy/test_helpers/test_search.py
+++ b/test_opensearchpy/test_helpers/test_search.py
@@ -623,12 +623,18 @@ def test_rescore_query_to_dict() -> None:
         },
     }
 
+
 def test_collapse_chaining() -> None:
     s = search.Search(index="index_name")
     s = s.filter("term", color="red")
     s = s.collapse(field="category")
     s = s.filter("term", brand="something")
 
-    assert {'query': {'bool': {'filter': [{'term': {'color': 'red'}},
-                                          {'term': {'brand': 'something'}}]}},
-            'collapse': {'field': 'category'}} == s.to_dict()
+    assert {
+        "query": {
+            "bool": {
+                "filter": [{"term": {"color": "red"}}, {"term": {"brand": "something"}}]
+            }
+        },
+        "collapse": {"field": "category"},
+    } == s.to_dict()

--- a/test_opensearchpy/test_helpers/test_search.py
+++ b/test_opensearchpy/test_helpers/test_search.py
@@ -622,3 +622,13 @@ def test_rescore_query_to_dict() -> None:
             },
         },
     }
+
+def test_collapse_chaining() -> None:
+    s = search.Search(index="index_name")
+    s = s.filter("term", color="red")
+    s = s.collapse(field="category")
+    s = s.filter("term", brand="something")
+
+    assert {'query': {'bool': {'filter': [{'term': {'color': 'red'}},
+                                          {'term': {'brand': 'something'}}]}},
+            'collapse': {'field': 'category'}} == s.to_dict()


### PR DESCRIPTION
### Description
When clone method is called for search.filter(), collapse attribute was not copied. Therefore, collapse attribute wasn't getting chained to the search object. This fix adds copying the collapse attribute to the search object in the clone method. 

### Issues Resolved
Resolves #[769]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
