### PR TITLE
Allow the use of percent string in Bool.__and__ method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Fixed Search helper to ensure proper retention of the _collapse attribute in chained operations. ([#771](https://github.com/opensearch-project/opensearch-py/pull/771))
+- Fixed the use of `minimum_should_match` with `Bool` to allow the use of string-based value (percent string, combination). ([#780](https://github.com/opensearch-project/opensearch-py/pull/780))
 ### Updated APIs
 - Updated opensearch-py APIs to reflect [opensearch-api-specification@0b033a9](https://github.com/opensearch-project/opensearch-api-specification/commit/0b033a92cac4cb20ec3fb51350c139afc753b089)
 - Updated opensearch-py APIs to reflect [opensearch-api-specification@d5ca873](https://github.com/opensearch-project/opensearch-api-specification/commit/d5ca873d20ff54be16ec48e7bd629cda7c4a6332)

--- a/opensearchpy/helpers/query.py
+++ b/opensearchpy/helpers/query.py
@@ -219,10 +219,12 @@ class Bool(Query):
                 del q._params["minimum_should_match"]
 
             for qx in (self, other):
-                # TODO: percentages will fail here
                 min_should_match = qx._min_should_match
                 # all subqueries are required
-                if len(qx.should) <= min_should_match:
+                if (
+                    isinstance(min_should_match, int)
+                    and len(qx.should) <= min_should_match
+                ):
                     q.must.extend(qx.should)
                 # not all of them are required, use it and remember min_should_match
                 elif not q.should:


### PR DESCRIPTION
### Description
Allow the use of `50`, `"50"` or `"50%"` as valid value for `qx._min_should_match`/`min_should_match` in the `Bool.__and__` method.

Previously, if for any reason the `qx._min_should_match` was a string, a TypeError error was raise by the `if len(qx.should) <= min_should_match:`.

Still raise a ValueError if the given value is an invalid integer representation.

### Issues Resolved
Closes #779

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
