### PR TITLE
Remove redundant six dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed deprecated `numpy.float_` and update NumPy/Pandas imports ([#762](https://github.com/opensearch-project/opensearch-py/pull/762))
 ### Deprecated
 ### Removed
+- Removed redundant dependency on six ([#781](https://github.com/opensearch-project/opensearch-py/pull/781))
 ### Fixed
 - Fixed Search helper to ensure proper retention of the _collapse attribute in chained operations. ([#771](https://github.com/opensearch-project/opensearch-py/pull/771))
 ### Updated APIs

--- a/noxfile.py
+++ b/noxfile.py
@@ -90,7 +90,6 @@ def lint(session: Any) -> None:
         "isort",
         "pylint",
         "types-requests",
-        "types-six",
         "types-simplejson",
         "types-python-dateutil",
         "types-PyYAML",

--- a/opensearchpy/_async/helpers/document.py
+++ b/opensearchpy/_async/helpers/document.py
@@ -11,8 +11,6 @@ import collections.abc as collections_abc
 from fnmatch import fnmatch
 from typing import Any, Optional, Tuple, Type
 
-from six import add_metaclass
-
 from opensearchpy._async.client import AsyncOpenSearch
 from opensearchpy._async.helpers.index import AsyncIndex
 from opensearchpy._async.helpers.search import AsyncSearch

--- a/opensearchpy/_async/helpers/document.py
+++ b/opensearchpy/_async/helpers/document.py
@@ -38,7 +38,7 @@ class AsyncIndexMeta(DocumentMeta):
         bases: Tuple[Type[ObjectBase]],
         attrs: Any,
     ) -> Any:
-        new_cls = super(AsyncIndexMeta, cls).__new__(cls, name, bases, attrs)
+        new_cls = super().__new__(cls, name, bases, attrs)
         if cls._document_initialized:
             index_opts = attrs.pop("Index", None)
             index = cls.construct_index(index_opts, bases)
@@ -67,8 +67,7 @@ class AsyncIndexMeta(DocumentMeta):
         return i
 
 
-@add_metaclass(AsyncIndexMeta)
-class AsyncDocument(ObjectBase):
+class AsyncDocument(ObjectBase, metaclass=AsyncIndexMeta):
     """
     Model-like class for persisting documents in opensearch.
     """
@@ -297,7 +296,7 @@ class AsyncDocument(ObjectBase):
             ``[]``, ``{}``) to be left on the document. Those values will be
             stripped out otherwise as they make no difference in opensearch.
         """
-        d = super(AsyncDocument, self).to_dict(skip_empty)
+        d = super().to_dict(skip_empty)
         if not include_meta:
             return d
 

--- a/opensearchpy/_async/helpers/faceted_search.py
+++ b/opensearchpy/_async/helpers/faceted_search.py
@@ -17,7 +17,7 @@ from opensearchpy.helpers.faceted_search import FacetedResponse
 from opensearchpy.helpers.query import MatchAll
 
 
-class AsyncFacetedSearch(object):
+class AsyncFacetedSearch:
     """
     Abstraction for creating faceted navigation searches that takes care of
     composing the queries, aggregations and filters as needed as well as
@@ -75,7 +75,7 @@ class AsyncFacetedSearch(object):
         self._filters: Any = {}
         self._sort = sort
         self.filter_values: Any = {}
-        for name, value in iteritems(filters):
+        for name, value in filters.items():
             self.add_filter(name, value)
 
         self._s = self.build_search()
@@ -140,10 +140,10 @@ class AsyncFacetedSearch(object):
         Add aggregations representing the facets selected, including potential
         filters.
         """
-        for f, facet in iteritems(self.facets):
+        for f, facet in self.facets.items():
             agg = facet.get_aggregation()
             agg_filter = MatchAll()
-            for field, filter in iteritems(self._filters):
+            for field, filter in self._filters.items():
                 if f == field:
                     continue
                 agg_filter &= filter
@@ -160,7 +160,7 @@ class AsyncFacetedSearch(object):
             return search
 
         post_filter = MatchAll()
-        for f in itervalues(self._filters):
+        for f in self._filters.values():
             post_filter &= f
         return search.post_filter(post_filter)
 

--- a/opensearchpy/_async/helpers/faceted_search.py
+++ b/opensearchpy/_async/helpers/faceted_search.py
@@ -10,8 +10,6 @@
 
 from typing import Any
 
-from six import iteritems, itervalues
-
 from opensearchpy._async.helpers.search import AsyncSearch
 from opensearchpy.helpers.faceted_search import FacetedResponse
 from opensearchpy.helpers.query import MatchAll

--- a/opensearchpy/_async/helpers/mapping.py
+++ b/opensearchpy/_async/helpers/mapping.py
@@ -18,7 +18,7 @@ from opensearchpy.helpers.field import Nested, Text
 from opensearchpy.helpers.mapping import META_FIELDS, Properties
 
 
-class AsyncMapping(object):
+class AsyncMapping:
     _meta: Any
     properties: Properties
 
@@ -104,11 +104,11 @@ class AsyncMapping(object):
         self._update_from_dict(raw["mappings"])
 
     def _update_from_dict(self, raw: Any) -> None:
-        for name, definition in iteritems(raw.get("properties", {})):
+        for name, definition in raw.get("properties", {}).items():
             self.field(name, definition)
 
         # metadata like _all etc
-        for name, value in iteritems(raw):
+        for name, value in raw.items():
             if name != "properties":
                 if isinstance(value, collections_abc.Mapping):
                     self.meta(name, **value)

--- a/opensearchpy/_async/helpers/mapping.py
+++ b/opensearchpy/_async/helpers/mapping.py
@@ -11,8 +11,6 @@ import collections.abc as collections_abc
 from itertools import chain
 from typing import Any
 
-from six import iteritems
-
 from opensearchpy.connection.async_connections import get_connection
 from opensearchpy.helpers.field import Nested, Text
 from opensearchpy.helpers.mapping import META_FIELDS, Properties

--- a/opensearchpy/_async/helpers/search.py
+++ b/opensearchpy/_async/helpers/search.py
@@ -10,8 +10,6 @@
 import copy
 from typing import Any, Sequence
 
-from six import iteritems, string_types
-
 from opensearchpy._async.helpers.actions import aiter, async_scan
 from opensearchpy.connection.async_connections import get_connection
 from opensearchpy.exceptions import IllegalOperation, TransportError

--- a/opensearchpy/_async/helpers/search.py
+++ b/opensearchpy/_async/helpers/search.py
@@ -37,7 +37,7 @@ class AsyncSearch(Request):
         All the parameters supplied (or omitted) at creation type can be later
         overridden by methods (`using`, `index` and `doc_type` respectively).
         """
-        super(AsyncSearch, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.aggs = AggsProxy(self)
         self._sort: Sequence[Any] = []
@@ -119,7 +119,7 @@ class AsyncSearch(Request):
         of all the underlying objects. Used internally by most state modifying
         APIs.
         """
-        s = super(AsyncSearch, self)._clone()
+        s = super()._clone()
 
         s._response_class = self._response_class
         s._sort = self._sort[:]
@@ -158,7 +158,7 @@ class AsyncSearch(Request):
         aggs = d.pop("aggs", d.pop("aggregations", {}))
         if aggs:
             self.aggs._params = {
-                "aggs": {name: A(value) for (name, value) in iteritems(aggs)}
+                "aggs": {name: A(value) for (name, value) in aggs.items()}
             }
         if "sort" in d:
             self._sort = d.pop("sort")
@@ -200,7 +200,7 @@ class AsyncSearch(Request):
         """
         s = self._clone()
         for name in kwargs:
-            if isinstance(kwargs[name], string_types):
+            if isinstance(kwargs[name], str):
                 kwargs[name] = {"script": kwargs[name]}
         s._script_fields.update(kwargs)
         return s
@@ -276,7 +276,7 @@ class AsyncSearch(Request):
         s = self._clone()
         s._sort = []
         for k in keys:
-            if isinstance(k, string_types) and k.startswith("-"):
+            if isinstance(k, str) and k.startswith("-"):
                 if k[1:] == "_score":
                     raise IllegalOperation("Sorting by `-_score` is not allowed.")
                 k = {k[1:]: {"order": "desc"}}
@@ -470,7 +470,7 @@ class AsyncMultiSearch(Request):
     """
 
     def __init__(self, **kwargs: Any) -> None:
-        super(AsyncMultiSearch, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._searches: Any = []
 
     def __getitem__(self, key: Any) -> Any:
@@ -480,7 +480,7 @@ class AsyncMultiSearch(Request):
         return iter(self._searches)
 
     def _clone(self) -> Any:
-        ms = super(AsyncMultiSearch, self)._clone()
+        ms = super()._clone()
         ms._searches = self._searches[:]
         return ms
 

--- a/opensearchpy/connection/async_connections.py
+++ b/opensearchpy/connection/async_connections.py
@@ -16,7 +16,7 @@ from opensearchpy._async.helpers.actions import aiter
 from opensearchpy.serializer import serializer
 
 
-class AsyncConnections(object):
+class AsyncConnections:
     _conns: Any
 
     """
@@ -92,7 +92,7 @@ class AsyncConnections(object):
         """
         # do not check isinstance(AsyncOpenSearch) so that people can wrap their
         # clients
-        if not isinstance(alias, string_types):
+        if not isinstance(alias, str):
             return alias
 
         # connection already established

--- a/opensearchpy/connection/async_connections.py
+++ b/opensearchpy/connection/async_connections.py
@@ -9,8 +9,6 @@
 
 from typing import Any
 
-from six import string_types
-
 import opensearchpy
 from opensearchpy._async.helpers.actions import aiter
 from opensearchpy.serializer import serializer

--- a/opensearchpy/connection/connections.py
+++ b/opensearchpy/connection/connections.py
@@ -26,8 +26,6 @@
 
 from typing import Any
 
-from six import string_types
-
 import opensearchpy
 from opensearchpy.serializer import serializer
 

--- a/opensearchpy/connection/connections.py
+++ b/opensearchpy/connection/connections.py
@@ -32,7 +32,7 @@ import opensearchpy
 from opensearchpy.serializer import serializer
 
 
-class Connections(object):
+class Connections:
     """
     Class responsible for holding connections to different clusters. Used as a
     singleton in this module.
@@ -106,7 +106,7 @@ class Connections(object):
         """
         # do not check isinstance(OpenSearch) so that people can wrap their
         # clients
-        if not isinstance(alias, string_types):
+        if not isinstance(alias, str):
             return alias
 
         # connection already established

--- a/opensearchpy/helpers/analysis.py
+++ b/opensearchpy/helpers/analysis.py
@@ -33,7 +33,7 @@ from opensearchpy.connection.connections import get_connection
 from .utils import AttrDict, DslBase, merge
 
 
-class AnalysisBase(object):
+class AnalysisBase:
     @classmethod
     def _type_shortcut(
         cls: Any, name_or_instance: Any, type: Any = None, **kwargs: Any
@@ -51,7 +51,7 @@ class AnalysisBase(object):
         )
 
 
-class CustomAnalysis(object):
+class CustomAnalysis:
     name: Optional[str] = "custom"
 
     def __init__(
@@ -59,14 +59,14 @@ class CustomAnalysis(object):
     ) -> None:
         self._builtin_type = builtin_type
         self._name = filter_name
-        super(CustomAnalysis, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def to_dict(self) -> Any:
         # only name to present in lists
         return self._name
 
     def get_definition(self) -> Any:
-        d = super(CustomAnalysis, self).to_dict()  # type: ignore
+        d = super().to_dict()  # type: ignore
         d = d.pop(self.name)
         d["type"] = self._builtin_type
         return d
@@ -106,12 +106,12 @@ class CustomAnalysisDefinition(CustomAnalysis):
         return out
 
 
-class BuiltinAnalysis(object):
+class BuiltinAnalysis:
     name: Optional[str] = "builtin"
 
     def __init__(self, name: Any) -> None:
         self._name = name
-        super(BuiltinAnalysis, self).__init__()
+        super().__init__()
 
     def to_dict(self) -> Any:
         # only name to present in lists
@@ -168,7 +168,7 @@ class CustomAnalyzer(CustomAnalysisDefinition, Analyzer):
             sec_def = definition.get(section, {})
             sec_names = analyzer_def[section]
 
-            if isinstance(sec_names, six.string_types):
+            if isinstance(sec_names, str):
                 body[section] = sec_def.get(sec_names, sec_names)
             else:
                 body[section] = [
@@ -235,7 +235,7 @@ class MultiplexerTokenFilter(CustomTokenFilter):
                 # comma delimited string given by user
                 (
                     fs
-                    if isinstance(fs, six.string_types)
+                    if isinstance(fs, str)
                     else
                     # list of strings or TokenFilter objects
                     ", ".join(f.to_dict() if hasattr(f, "to_dict") else f for f in fs)
@@ -251,7 +251,7 @@ class MultiplexerTokenFilter(CustomTokenFilter):
         fs: Any = {}
         d = {"filter": fs}
         for filters in self.filters:
-            if isinstance(filters, six.string_types):
+            if isinstance(filters, str):
                 continue
             fs.update(
                 {

--- a/opensearchpy/helpers/analysis.py
+++ b/opensearchpy/helpers/analysis.py
@@ -26,8 +26,6 @@
 
 from typing import Any, Optional
 
-import six
-
 from opensearchpy.connection.connections import get_connection
 
 from .utils import AttrDict, DslBase, merge

--- a/opensearchpy/helpers/document.py
+++ b/opensearchpy/helpers/document.py
@@ -28,8 +28,6 @@ import collections.abc as collections_abc
 from fnmatch import fnmatch
 from typing import Any, Tuple, Type
 
-from six import add_metaclass, iteritems
-
 from opensearchpy.connection.connections import get_connection
 from opensearchpy.exceptions import NotFoundError, RequestError
 

--- a/opensearchpy/helpers/document.py
+++ b/opensearchpy/helpers/document.py
@@ -41,7 +41,7 @@ from .search import Search
 from .utils import DOC_META_FIELDS, META_FIELDS, ObjectBase, merge
 
 
-class MetaField(object):
+class MetaField:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.args, self.kwargs = args, kwargs
 
@@ -55,7 +55,7 @@ class DocumentMeta(type):
     ) -> Any:
         # DocumentMeta filters attrs in place
         attrs["_doc_type"] = DocumentOptions(name, bases, attrs)
-        return super(DocumentMeta, cls).__new__(cls, name, bases, attrs)
+        return super().__new__(cls, name, bases, attrs)
 
 
 class IndexMeta(DocumentMeta):
@@ -69,7 +69,7 @@ class IndexMeta(DocumentMeta):
         bases: Tuple[Type[ObjectBase]],
         attrs: Any,
     ) -> Any:
-        new_cls = super(IndexMeta, cls).__new__(cls, name, bases, attrs)
+        new_cls = super().__new__(cls, name, bases, attrs)
         if cls._document_initialized:
             index_opts = attrs.pop("Index", None)
             index = cls.construct_index(index_opts, bases)
@@ -96,7 +96,7 @@ class IndexMeta(DocumentMeta):
         return i
 
 
-class DocumentOptions(object):
+class DocumentOptions:
     def __init__(
         self,
         name: str,
@@ -109,7 +109,7 @@ class DocumentOptions(object):
         self.mapping = getattr(meta, "mapping", Mapping())
 
         # register all declared fields into the mapping
-        for name, value in list(iteritems(attrs)):
+        for name, value in list(attrs.items()):
             if isinstance(value, Field):
                 self.mapping.field(name, value)
                 del attrs[name]
@@ -130,8 +130,7 @@ class DocumentOptions(object):
         return self.mapping.properties.name
 
 
-@add_metaclass(DocumentMeta)
-class InnerDoc(ObjectBase):
+class InnerDoc(ObjectBase, metaclass=DocumentMeta):
     """
     Common class for inner documents like Object or Nested
     """
@@ -140,11 +139,10 @@ class InnerDoc(ObjectBase):
     def from_opensearch(cls, data: Any, data_only: bool = False) -> Any:
         if data_only:
             data = {"_source": data}
-        return super(InnerDoc, cls).from_opensearch(data)
+        return super().from_opensearch(data)
 
 
-@add_metaclass(IndexMeta)
-class Document(ObjectBase):
+class Document(ObjectBase, metaclass=IndexMeta):
     """
     Model-like class for persisting documents in opensearch.
     """
@@ -353,7 +351,7 @@ class Document(ObjectBase):
             ``[]``, ``{}``) to be left on the document. Those values will be
             stripped out otherwise as they make no difference in opensearch.
         """
-        d = super(Document, self).to_dict(skip_empty=skip_empty)
+        d = super().to_dict(skip_empty=skip_empty)
         if not include_meta:
             return d
 

--- a/opensearchpy/helpers/faceted_search.py
+++ b/opensearchpy/helpers/faceted_search.py
@@ -254,9 +254,7 @@ class NestedFacet(Facet):
     def __init__(self, path: Any, nested_facet: Any) -> None:
         self._path = path
         self._inner = nested_facet
-        super().__init__(
-            path=path, aggs={"inner": nested_facet.get_aggregation()}
-        )
+        super().__init__(path=path, aggs={"inner": nested_facet.get_aggregation()})
 
     def get_values(self, data: Any, filter_values: Any) -> Any:
         return self._inner.get_values(data.inner, filter_values)

--- a/opensearchpy/helpers/faceted_search.py
+++ b/opensearchpy/helpers/faceted_search.py
@@ -26,8 +26,6 @@
 from datetime import datetime, timedelta
 from typing import Any, Optional
 
-from six import iteritems, itervalues
-
 from opensearchpy.helpers.aggs import A
 
 from .query import MatchAll, Nested, Range, Terms

--- a/opensearchpy/helpers/faceted_search.py
+++ b/opensearchpy/helpers/faceted_search.py
@@ -45,7 +45,7 @@ __all__ = [
 ]
 
 
-class Facet(object):
+class Facet:
     """
     A facet on faceted search. Wraps and aggregation and provides functionality
     to create a filter for selected values and return a list of facet values
@@ -146,7 +146,7 @@ class RangeFacet(Facet):
         return out
 
     def __init__(self, ranges: Any, **kwargs: Any) -> None:
-        super(RangeFacet, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._params["ranges"] = list(map(self._range_to_dict, ranges))
         self._params["keyed"] = False
         self._ranges = dict(ranges)
@@ -217,7 +217,7 @@ class DateHistogramFacet(Facet):
 
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("min_doc_count", 0)
-        super(DateHistogramFacet, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def get_value(self, bucket: Any) -> Any:
         if not isinstance(bucket["key"], datetime):
@@ -256,7 +256,7 @@ class NestedFacet(Facet):
     def __init__(self, path: Any, nested_facet: Any) -> None:
         self._path = path
         self._inner = nested_facet
-        super(NestedFacet, self).__init__(
+        super().__init__(
             path=path, aggs={"inner": nested_facet.get_aggregation()}
         )
 
@@ -278,7 +278,7 @@ class FacetedResponse(Response):
     def facets(self) -> Any:
         if not hasattr(self, "_facets"):
             super(AttrDict, self).__setattr__("_facets", AttrDict({}))
-            for name, facet in iteritems(self._faceted_search.facets):
+            for name, facet in self._faceted_search.facets.items():
                 self._facets[name] = facet.get_values(
                     getattr(getattr(self.aggregations, "_filter_" + name), name),
                     self._faceted_search.filter_values.get(name, ()),
@@ -286,7 +286,7 @@ class FacetedResponse(Response):
         return self._facets
 
 
-class FacetedSearch(object):
+class FacetedSearch:
     """
     Abstraction for creating faceted navigation searches that takes care of
     composing the queries, aggregations and filters as needed as well as
@@ -344,7 +344,7 @@ class FacetedSearch(object):
         self._filters: Any = {}
         self._sort = sort
         self.filter_values: Any = {}
-        for name, value in iteritems(filters):
+        for name, value in filters.items():
             self.add_filter(name, value)
 
         self._s = self.build_search()
@@ -409,10 +409,10 @@ class FacetedSearch(object):
         Add aggregations representing the facets selected, including potential
         filters.
         """
-        for f, facet in iteritems(self.facets):
+        for f, facet in self.facets.items():
             agg = facet.get_aggregation()
             agg_filter = MatchAll()
-            for field, filter in iteritems(self._filters):
+            for field, filter in self._filters.items():
                 if f == field:
                     continue
                 agg_filter &= filter
@@ -429,7 +429,7 @@ class FacetedSearch(object):
             return search
 
         post_filter = MatchAll()
-        for f in itervalues(self._filters):
+        for f in self._filters.values():
             post_filter &= f
         return search.post_filter(post_filter)
 

--- a/opensearchpy/helpers/field.py
+++ b/opensearchpy/helpers/field.py
@@ -374,9 +374,7 @@ class ScaledFloat(Float):
     name: Optional[str] = "scaled_float"
 
     def __init__(self, scaling_factor: Any, *args: Any, **kwargs: Any) -> None:
-        super().__init__(
-            scaling_factor=scaling_factor, *args, **kwargs
-        )
+        super().__init__(scaling_factor=scaling_factor, *args, **kwargs)
 
 
 class Double(Float):

--- a/opensearchpy/helpers/field.py
+++ b/opensearchpy/helpers/field.py
@@ -32,7 +32,6 @@ from datetime import date, datetime
 from typing import Any, Optional, Type
 
 from dateutil import parser, tz
-from six import integer_types, iteritems, string_types
 
 from ..exceptions import ValidationException
 from .query import Q

--- a/opensearchpy/helpers/mapping.py
+++ b/opensearchpy/helpers/mapping.py
@@ -28,8 +28,6 @@ import collections.abc as collections_abc
 from itertools import chain
 from typing import Any
 
-from six import iteritems, itervalues
-
 from opensearchpy.connection.connections import get_connection
 from opensearchpy.helpers.field import Nested, Text, construct_field
 

--- a/opensearchpy/helpers/mapping.py
+++ b/opensearchpy/helpers/mapping.py
@@ -53,7 +53,7 @@ class Properties(DslBase):
     _param_defs = {"properties": {"type": "field", "hash": True}}
 
     def __init__(self) -> None:
-        super(Properties, self).__init__()
+        super().__init__()
 
     def __repr__(self) -> str:
         return "Properties()"
@@ -65,7 +65,7 @@ class Properties(DslBase):
         return name in self.properties
 
     def to_dict(self) -> Any:
-        return super(Properties, self).to_dict()["properties"]
+        return super().to_dict()["properties"]
 
     def field(self, name: Any, *args: Any, **kwargs: Any) -> "Properties":
         self.properties[name] = construct_field(*args, **kwargs)
@@ -73,16 +73,14 @@ class Properties(DslBase):
 
     def _collect_fields(self) -> Any:
         """Iterate over all Field objects within, including multi fields."""
-        for f in itervalues(self.properties.to_dict()):
+        for f in self.properties.to_dict().values():
             yield f
             # multi fields
             if hasattr(f, "fields"):
-                for inner_f in itervalues(f.fields.to_dict()):
-                    yield inner_f
+                yield from f.fields.to_dict().values()
             # nested and inner objects
             if hasattr(f, "_collect_fields"):
-                for inner_f in f._collect_fields():
-                    yield inner_f
+                yield from f._collect_fields()
 
     def update(self, other_object: Any) -> None:
         if not hasattr(other_object, "properties"):
@@ -98,7 +96,7 @@ class Properties(DslBase):
             our[name] = other[name]
 
 
-class Mapping(object):
+class Mapping:
     def __init__(self) -> None:
         self.properties = Properties()
         self._meta: Any = {}
@@ -181,11 +179,11 @@ class Mapping(object):
         self._update_from_dict(raw["mappings"])
 
     def _update_from_dict(self, raw: Any) -> None:
-        for name, definition in iteritems(raw.get("properties", {})):
+        for name, definition in raw.get("properties", {}).items():
             self.field(name, definition)
 
         # metadata like _all etc
-        for name, value in iteritems(raw):
+        for name, value in raw.items():
             if name != "properties":
                 if isinstance(value, collections_abc.Mapping):
                     self.meta(name, **value)

--- a/opensearchpy/helpers/search.py
+++ b/opensearchpy/helpers/search.py
@@ -28,8 +28,6 @@ import collections.abc as collections_abc
 import copy
 from typing import Any
 
-from six import iteritems, string_types
-
 from opensearchpy.connection.connections import get_connection
 from opensearchpy.exceptions import TransportError
 from opensearchpy.helpers import scan

--- a/opensearchpy/helpers/search.py
+++ b/opensearchpy/helpers/search.py
@@ -41,7 +41,7 @@ from .response import Hit, Response
 from .utils import AttrDict, DslBase, recursive_to_dict
 
 
-class QueryProxy(object):
+class QueryProxy:
     """
     Simple proxy around DSL objects (queries) that can be called
     (to add query/post_filter) and also allows attribute access which is proxied to
@@ -79,7 +79,7 @@ class QueryProxy(object):
         if not attr_name.startswith("_"):
             self._proxied = Q(self._proxied.to_dict())
             setattr(self._proxied, attr_name, value)
-        super(QueryProxy, self).__setattr__(attr_name, value)
+        super().__setattr__(attr_name, value)
 
     def __getstate__(self) -> Any:
         return self._search, self._proxied, self._attr_name
@@ -88,7 +88,7 @@ class QueryProxy(object):
         self._search, self._proxied, self._attr_name = state
 
 
-class ProxyDescriptor(object):
+class ProxyDescriptor:
     """
     Simple descriptor to enable setting of queries and filters as:
 
@@ -117,10 +117,10 @@ class AggsProxy(AggBase, DslBase):
         self._params = {"aggs": {}}
 
     def to_dict(self) -> Any:
-        return super(AggsProxy, self).to_dict().get("aggs", {})
+        return super().to_dict().get("aggs", {})
 
 
-class Request(object):
+class Request:
     _doc_type: Any
     _doc_type_map: Any
 
@@ -195,7 +195,7 @@ class Request(object):
         else:
             indexes = []
             for i in index:
-                if isinstance(i, string_types):
+                if isinstance(i, str):
                     indexes.append(i)
                 elif isinstance(i, list):
                     indexes += i
@@ -333,7 +333,7 @@ class Search(Request):
         All the parameters supplied (or omitted) at creation type can be later
         overridden by methods (`using`, `index` and `doc_type` respectively).
         """
-        super(Search, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.aggs = AggsProxy(self)
         self._sort: Any = []
@@ -422,7 +422,7 @@ class Search(Request):
         of all the underlying objects. Used internally by most state modifying
         APIs.
         """
-        s = super(Search, self)._clone()
+        s = super()._clone()
 
         s._response_class = self._response_class
         s._sort = self._sort[:]
@@ -462,7 +462,7 @@ class Search(Request):
         aggs = d.pop("aggs", d.pop("aggregations", {}))
         if aggs:
             self.aggs._params = {
-                "aggs": {name: A(value) for (name, value) in iteritems(aggs)}
+                "aggs": {name: A(value) for (name, value) in aggs.items()}
             }
         if "sort" in d:
             self._sort = d.pop("sort")
@@ -504,7 +504,7 @@ class Search(Request):
         """
         s = self._clone()
         for name in kwargs:
-            if isinstance(kwargs[name], string_types):
+            if isinstance(kwargs[name], str):
                 kwargs[name] = {"script": kwargs[name]}
         s._script_fields.update(kwargs)
         return s
@@ -580,7 +580,7 @@ class Search(Request):
         s = self._clone()
         s._sort = []
         for k in keys:
-            if isinstance(k, string_types) and k.startswith("-"):
+            if isinstance(k, str) and k.startswith("-"):
                 if k[1:] == "_score":
                     raise IllegalOperation("Sorting by `-_score` is not allowed.")
                 k = {k[1:]: {"order": "desc"}}
@@ -801,7 +801,7 @@ class MultiSearch(Request):
     """
 
     def __init__(self, **kwargs: Any) -> None:
-        super(MultiSearch, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._searches: Any = []
 
     def __getitem__(self, key: Any) -> Any:
@@ -811,7 +811,7 @@ class MultiSearch(Request):
         return iter(self._searches)
 
     def _clone(self) -> Any:
-        ms = super(MultiSearch, self)._clone()
+        ms = super()._clone()
         ms._searches = self._searches[:]
         return ms
 

--- a/opensearchpy/helpers/utils.py
+++ b/opensearchpy/helpers/utils.py
@@ -29,8 +29,6 @@ import collections.abc as collections_abc
 from copy import copy
 from typing import Any, Callable, Dict, Optional, Tuple
 
-from six import add_metaclass, iteritems
-
 from opensearchpy.exceptions import UnknownDslObject, ValidationException
 
 SKIP_VALUES: Tuple[str, None] = ("", None)

--- a/opensearchpy/helpers/utils.py
+++ b/opensearchpy/helpers/utils.py
@@ -24,14 +24,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from __future__ import unicode_literals
 
 import collections.abc as collections_abc
 from copy import copy
 from typing import Any, Callable, Dict, Optional, Tuple
 
 from six import add_metaclass, iteritems
-from six.moves import map
 
 from opensearchpy.exceptions import UnknownDslObject, ValidationException
 
@@ -66,7 +64,7 @@ def _wrap(val: Any, obj_wrapper: Optional[Callable[..., Any]] = None) -> Any:
     return val
 
 
-class AttrList(object):
+class AttrList:
     def __init__(
         self, p: Any, obj_wrapper: Optional[Callable[..., Any]] = None
     ) -> None:
@@ -118,7 +116,7 @@ class AttrList(object):
         self._l_, self._obj_wrapper = state
 
 
-class AttrDict(object):
+class AttrDict:
     """
     Helper class to provide attribute like access (read and write) to
     dictionaries. Used to provide a convenient way to access both results and
@@ -127,7 +125,7 @@ class AttrDict(object):
 
     def __init__(self, d: Any) -> None:
         # assign the inner dict manually to prevent __setattr__ from firing
-        super(AttrDict, self).__setattr__("_d_", d)
+        super().__setattr__("_d_", d)
 
     def __contains__(self, key: Any) -> bool:
         return key in self._d_
@@ -160,7 +158,7 @@ class AttrDict(object):
         return (self._d_,)
 
     def __setstate__(self, state: Any) -> None:
-        super(AttrDict, self).__setattr__("_d_", state[0])
+        super().__setattr__("_d_", state[0])
 
     def __getattr__(self, attr_name: Any) -> Any:
         try:
@@ -204,7 +202,7 @@ class AttrDict(object):
             self._d_[name] = value
         else:
             # there is an attribute on the class (could be property, ..) - don't add it as field
-            super(AttrDict, self).__setattr__(name, value)
+            super().__setattr__(name, value)
 
     def __iter__(self) -> Any:
         return iter(self._d_)
@@ -230,7 +228,7 @@ class DslMeta(type):
 
     def __init__(cls: Any, name: str, bases: Any, attrs: Any) -> None:
         # TODO: why is it calling itself?!
-        super(DslMeta, cls).__init__(name, bases, attrs)
+        super().__init__(name, bases, attrs)
         # skip for DslBase
         if not hasattr(cls, "_type_shortcut"):
             return
@@ -252,8 +250,7 @@ class DslMeta(type):
             raise UnknownDslObject("DSL type %s does not exist." % name)
 
 
-@add_metaclass(DslMeta)
-class DslBase(object):
+class DslBase(metaclass=DslMeta):
     """
     Base class for all DSL objects - queries, filters, aggregations etc. Wraps
     a dictionary representing the object's json.
@@ -285,7 +282,7 @@ class DslBase(object):
 
     def __init__(self, _expand__to_dot: Any = EXPAND__TO_DOT, **params: Any) -> None:
         self._params = {}
-        for pname, pvalue in iteritems(params):
+        for pname, pvalue in params.items():
             if "__" in pname and _expand__to_dot:
                 pname = pname.replace("__", ".")
             self._setattr(pname, pvalue)
@@ -294,7 +291,7 @@ class DslBase(object):
         """Produce a repr of all our parameters to be used in __repr__."""
         return ", ".join(
             "{}={!r}".format(n.replace(".", "__"), v)
-            for (n, v) in sorted(iteritems(self._params))
+            for (n, v) in sorted(self._params.items())
             # make sure we don't include empty typed params
             if "type" not in self._param_defs.get(n, {}) or v
         )
@@ -310,7 +307,7 @@ class DslBase(object):
 
     def __setattr__(self, name: str, value: Any) -> None:
         if name.startswith("_"):
-            return super(DslBase, self).__setattr__(name, value)
+            return super().__setattr__(name, value)
         return self._setattr(name, value)
 
     def _setattr(self, name: Any, value: Any) -> None:
@@ -327,7 +324,7 @@ class DslBase(object):
                     if not isinstance(value, (tuple, list)):
                         value = (value,)
                     value = list(
-                        {k: shortcut(v) for (k, v) in iteritems(obj)} for obj in value
+                        {k: shortcut(v) for (k, v) in obj.items()} for obj in value
                     )
                 elif pinfo.get("multi"):
                     if not isinstance(value, (tuple, list)):
@@ -336,7 +333,7 @@ class DslBase(object):
 
                 # dict(name -> DslBase), make sure we pickup all the objs
                 elif pinfo.get("hash"):
-                    value = {k: shortcut(v) for (k, v) in iteritems(value)}
+                    value = {k: shortcut(v) for (k, v) in value.items()}
 
                 # single value object, just convert
                 else:
@@ -380,7 +377,7 @@ class DslBase(object):
         Serialize the DSL object to plain dict
         """
         d = {}
-        for pname, value in iteritems(self._params):
+        for pname, value in self._params.items():
             pinfo = self._param_defs.get(pname)
 
             # typed param
@@ -392,7 +389,7 @@ class DslBase(object):
                 # list of dict(name -> DslBase)
                 if pinfo.get("multi") and pinfo.get("hash"):
                     value = list(
-                        {k: v.to_dict() for k, v in iteritems(obj)} for obj in value
+                        {k: v.to_dict() for k, v in obj.items()} for obj in value
                     )
 
                 # multi-values are serialized as list of dicts
@@ -401,7 +398,7 @@ class DslBase(object):
 
                 # squash all the hash values into one dict
                 elif pinfo.get("hash"):
-                    value = {k: v.to_dict() for k, v in iteritems(value)}
+                    value = {k: v.to_dict() for k, v in value.items()}
 
                 # serialize single values
                 else:
@@ -427,13 +424,13 @@ class HitMeta(AttrDict):
     ) -> None:
         d = {
             k[1:] if k.startswith("_") else k: v
-            for (k, v) in iteritems(document)
+            for (k, v) in document.items()
             if k not in exclude
         }
         if "type" in d:
             # make sure we are consistent everywhere in python
             d["doc_type"] = d.pop("type")
-        super(HitMeta, self).__init__(d)
+        super().__init__(d)
 
 
 class ObjectBase(AttrDict):
@@ -447,7 +444,7 @@ class ObjectBase(AttrDict):
 
         super(AttrDict, self).__setattr__("meta", HitMeta(meta))
 
-        super(ObjectBase, self).__init__(kwargs)
+        super().__init__(kwargs)
 
     @classmethod
     def __list_fields(cls: Any) -> Any:
@@ -491,7 +488,7 @@ class ObjectBase(AttrDict):
         return doc
 
     def _from_dict(self, data: Any) -> None:
-        for k, v in iteritems(data):
+        for k, v in data.items():
             f = self.__get_field(k)
             if f and f._coerce:
                 v = f.deserialize(v)
@@ -508,7 +505,7 @@ class ObjectBase(AttrDict):
 
     def __getattr__(self, name: Any) -> Any:
         try:
-            return super(ObjectBase, self).__getattr__(name)
+            return super().__getattr__(name)
         except AttributeError:
             f = self.__get_field(name)
             if hasattr(f, "empty"):
@@ -521,7 +518,7 @@ class ObjectBase(AttrDict):
 
     def to_dict(self, skip_empty: Optional[bool] = True) -> Any:
         out = {}
-        for k, v in iteritems(self._d_):
+        for k, v in self._d_.items():
             # if this is a mapped field,
             f = self.__get_field(k)
             if f and f._coerce:
@@ -584,7 +581,7 @@ def merge(data: Any, new_data: Any, raise_on_conflict: bool = False) -> None:
             )
         )
 
-    for key, value in iteritems(new_data):
+    for key, value in new_data.items():
         if (
             key in data
             and isinstance(data[key], (AttrDict, collections_abc.Mapping))

--- a/opensearchpy/helpers/wrappers.py
+++ b/opensearchpy/helpers/wrappers.py
@@ -27,8 +27,6 @@
 import operator
 from typing import Any
 
-from six import iteritems, string_types
-
 from .utils import AttrDict
 
 

--- a/opensearchpy/helpers/wrappers.py
+++ b/opensearchpy/helpers/wrappers.py
@@ -57,14 +57,14 @@ class Range(AttrDict):
         if "lt" in data and "lte" in data:
             raise ValueError("You cannot specify both lt and lte for Range.")
 
-        super(Range, self).__init__(args[0] if args else kwargs)
+        super().__init__(args[0] if args else kwargs)
 
     def __repr__(self) -> str:
-        return "Range(%s)" % ", ".join("%s=%r" % op for op in iteritems(self._d_))
+        return "Range(%s)" % ", ".join("%s=%r" % op for op in self._d_.items())
 
     def __contains__(self, item: Any) -> bool:
-        if isinstance(item, string_types):
-            return super(Range, self).__contains__(item)
+        if isinstance(item, str):
+            return super().__contains__(item)
 
         for op in self.OPS:
             if op in self._d_ and not self.OPS[op](item, self._d_[op]):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [bdist_rpm]
 requires = python python-urllib3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,9 +14,7 @@ profile=black
 
 [black]
 max-line-length = 240
-target-version = 'py33'
+target-version = 'py38'
 
 [mypy]
 ignore_missing_imports=True
-
-

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ install_requires = [
     'urllib3>=1.26.18,<1.27 ; python_version < "3.10"',
     'urllib3>=1.26.18,!=2.2.0,<3 ; python_version >= "3.10"',
     "requests>=2.4.0, <3.0.0",
-    "six",
     "python-dateutil",
     "certifi>=2022.12.07",
     "Events",


### PR DESCRIPTION
### Description
_Describe what this change achieves._

This package only supports Python 3, however it still uses the [six](https://six.readthedocs.io/) compatibility library to support Python 2 and 3.

This PR removes the dependency, and replaces the six calls with direct Python 3 code.

This makes the install a bit quicker, smaller, and the code a bit faster by using the standard library instead of a package.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

None known.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

---

I did this using the https://github.com/asottile/pyupgrade tool that upgrades Python syntax.

We could run it on all the files, and upgrade to Python 3.8+ syntax (`--py38-plus`), but I wanted to keep the diff small, so I only ran it on files using six, and did the lowest syntax upgrade (`--py3-plus`):

```sh
rg six -l | xargs pyupgrade --py3-plus
```

(I do recommend running it on the whole codebase and for 3.8+, perhaps in another PR. For example `pyupgrade **/*.py --py38-plus` upgrades 84 further files.)

---

This PR also removes creation of universal wheels, that's only needed when supporting Python 2, and corrects the Black target version.