### PR TITLE
Fixed timeout argument in Transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix `Transport.perform_request`'s arguments `timeout` and `ignore` variable usage ([810](https://github.com/opensearch-project/opensearch-py/pull/810))
 ### Security
 
 ## [2.7.1]

--- a/opensearchpy/_async/transport.py
+++ b/opensearchpy/_async/transport.py
@@ -371,11 +371,13 @@ class AsyncTransport(Transport):
             underlying :class:`~opensearchpy.Connection` class for serialization
         :arg body: body of the request, will be serialized using serializer and
             passed to the connection
+        :arg timeout: timeout of the request. If it is not presented as argument
+            will be extracted from `params`
         """
         await self._async_call()
 
         method, params, body, ignore, timeout = self._resolve_request_args(
-            method, params, body
+            method, params, body, ignore, timeout
         )
 
         for attempt in range(self.max_retries + 1):

--- a/opensearchpy/transport.py
+++ b/opensearchpy/transport.py
@@ -408,7 +408,7 @@ class Transport:
             will be extracted from `params`
         """
         method, params, body, ignore, timeout = self._resolve_request_args(
-            method, params, body, timeout
+            method, params, body, ignore, timeout
         )
 
         for attempt in range(self.max_retries + 1):
@@ -480,6 +480,7 @@ class Transport:
             method: str,
             params: Any,
             body: Any,
+            ignore: Collection[int],
             timeout: Optional[Union[int, float]],
     ) -> Any:
         """Resolves parameters for .perform_request()"""
@@ -506,11 +507,11 @@ class Transport:
                 # bytes/str - no need to re-encode
                 pass
 
-        ignore = ()
         if params:
             if not timeout:
                 timeout = params.pop("request_timeout", None) or params.pop("timeout", None)
-            ignore = params.pop("ignore", ())
+            if not ignore:
+                ignore = params.pop("ignore", ())
             if isinstance(ignore, int):
                 ignore = (ignore,)
 

--- a/opensearchpy/transport.py
+++ b/opensearchpy/transport.py
@@ -476,12 +476,12 @@ class Transport:
         return self.connection_pool.close()
 
     def _resolve_request_args(
-            self,
-            method: str,
-            params: Any,
-            body: Any,
-            ignore: Collection[int],
-            timeout: Optional[Union[int, float]],
+        self,
+        method: str,
+        params: Any,
+        body: Any,
+        ignore: Collection[int],
+        timeout: Optional[Union[int, float]],
     ) -> Any:
         """Resolves parameters for .perform_request()"""
         if body is not None:
@@ -509,7 +509,9 @@ class Transport:
 
         if params:
             if not timeout:
-                timeout = params.pop("request_timeout", None) or params.pop("timeout", None)
+                timeout = params.pop("request_timeout", None) or params.pop(
+                    "timeout", None
+                )
             if not ignore:
                 ignore = params.pop("ignore", ())
             if isinstance(ignore, int):

--- a/test_opensearchpy/test_async/test_transport.py
+++ b/test_opensearchpy/test_async/test_transport.py
@@ -183,11 +183,11 @@ class TestTransport:
         await t.perform_request(method, url, params, body, timeout, ignore, headers)
 
         assert t.get_connection().calls == [
-                (
-                    (method, url, params, body.encode()),
-                    {"headers": headers, "ignore": ignore, "timeout": timeout}
-                )
-            ]
+            (
+                (method, url, params, body.encode()),
+                {"headers": headers, "ignore": ignore, "timeout": timeout},
+            )
+        ]
 
     async def test_request_with_custom_user_agent_header(self) -> None:
         t: Any = AsyncTransport([{}], connection_class=DummyConnection)

--- a/test_opensearchpy/test_async/test_transport.py
+++ b/test_opensearchpy/test_async/test_transport.py
@@ -175,6 +175,20 @@ class TestTransport:
             "headers": {"x-opaque-id": "request-1"},
         } == t.get_connection().calls[1][1]
 
+    async def test_perform_request_all_arguments_passed_correctly(self) -> None:
+        t: Any = AsyncTransport([{}], connection_class=DummyConnection)
+        method, url, params, body = "GET", "/test_url", {"params": "test"}, "test_body"
+        timeout, ignore, headers = 11, ("ignore",), {"h": "test"}
+
+        await t.perform_request(method, url, params, body, timeout, ignore, headers)
+
+        assert t.get_connection().calls == [
+                (
+                    (method, url, params, body.encode()),
+                    {"headers": headers, "ignore": ignore, "timeout": timeout}
+                )
+            ]
+
     async def test_request_with_custom_user_agent_header(self) -> None:
         t: Any = AsyncTransport([{}], connection_class=DummyConnection)
 

--- a/test_opensearchpy/test_transport.py
+++ b/test_opensearchpy/test_transport.py
@@ -260,6 +260,23 @@ class TestTransport(TestCase):
             "http://google.com:1234", t.connection_pool.connections[1].host
         )
 
+    def test_perform_request_all_arguments_passed_correctly(self) -> None:
+        t: Any = Transport([{}], connection_class=DummyConnection)
+        method, url, params, body = "GET", "/test_url", {"params": "test"}, "test_body"
+        timeout, ignore, headers = 11, ("ignore",), {"h": "test"}
+
+        t.perform_request(method, url, params, body, timeout, ignore, headers)
+
+        self.assertEqual(
+            t.get_connection().calls,
+            [
+                (
+                    (method, url, params, body.encode()),
+                    {"headers": headers, "ignore": ignore, "timeout": timeout}
+                )
+            ]
+        )
+
     def test_request_will_fail_after_x_retries(self) -> None:
         t: Any = Transport(
             [{"exception": ConnectionError(None, "abandon ship", Exception())}],

--- a/test_opensearchpy/test_transport.py
+++ b/test_opensearchpy/test_transport.py
@@ -272,9 +272,9 @@ class TestTransport(TestCase):
             [
                 (
                     (method, url, params, body.encode()),
-                    {"headers": headers, "ignore": ignore, "timeout": timeout}
+                    {"headers": headers, "ignore": ignore, "timeout": timeout},
                 )
-            ]
+            ],
         )
 
     def test_request_will_fail_after_x_retries(self) -> None:


### PR DESCRIPTION
### Description
Fixed bug https://github.com/opensearch-project/opensearch-py/issues/809

### Issues Resolved
- Timeout argument in Transport.perform_request is not used, because it is redefined just below


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
