### PR TITLE
Upgrade to aiohttp 3.10.6.

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -45,6 +45,12 @@ docker run -d -p 9200:9200 -p 9600:9600 -e OPENSEARCH_INITIAL_ADMIN_PASSWORD=myS
 
 Tests require a live instance of OpenSearch running in docker.
 
+Set the password for your docker instance.
+
+```
+export OPENSEARCH_PASSWORD=myStrongPassword123!
+```
+
 If you have one running.
 
 ```

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -20,6 +20,6 @@ black>=24.3.0
 twine
 
 # Requirements for testing [async] extra
-aiohttp>=3.9.4, <=3.10.5
+aiohttp>=3.9.4, <4
 pytest-asyncio<=0.24.0
 unasync


### PR DESCRIPTION
### Description

I couldn't figure out how to do this in https://github.com/opensearch-project/opensearch-py/pull/828 so I asked for help in https://github.com/aio-libs/aiohttp/issues/9297 which explained the change in 3.10.6. The solution also exists in https://stackoverflow.com/questions/57699218/how-can-i-mock-out-responses-made-by-aiohttp-clientsession.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
