### PR TITLE
Fix nox generate

### DIFF
--- a/test_opensearchpy/test_async/test_plugins_client.py
+++ b/test_opensearchpy/test_async/test_plugins_client.py
@@ -8,6 +8,7 @@
 # GitHub history for details.
 
 
+import re
 import warnings
 
 import pytest
@@ -24,8 +25,7 @@ class TestPluginsClient:
             client = AsyncOpenSearch()
             # testing double-init here
             client.plugins.__init__(client)  # type: ignore # pylint: disable=unnecessary-dunder-call
-            assert (
-                str(w[0].message)
-                == "Cannot load `alerting` directly to AsyncOpenSearch as it already exists. Use "
-                "`AsyncOpenSearch.plugin.alerting` instead."
+            assert re.match(
+                r"Cannot load `\w+` directly to AsyncOpenSearch as it already exists. Use `AsyncOpenSearch.plugin.\w+` instead.",
+                str(w[0].message),
             )

--- a/test_opensearchpy/test_client/test_plugins/test_plugins_client.py
+++ b/test_opensearchpy/test_client/test_plugins/test_plugins_client.py
@@ -7,6 +7,8 @@
 # Modifications Copyright OpenSearch Contributors. See
 # GitHub history for details.
 
+import re
+
 from opensearchpy.client import OpenSearch
 
 from ...test_cases import TestCase
@@ -18,8 +20,9 @@ class TestPluginsClient(TestCase):
             client = OpenSearch()
             # double-init
             client.plugins.__init__(client)  # type: ignore # pylint: disable=unnecessary-dunder-call
-            self.assertEqual(
-                str(w.warnings[0].message),
-                "Cannot load `alerting` directly to OpenSearch as "
-                "it already exists. Use `OpenSearch.plugin.alerting` instead.",
+            self.assertTrue(
+                re.match(
+                    r"Cannot load `\w+` directly to OpenSearch as it already exists. Use `OpenSearch.plugin.\w+` instead.",
+                    str(w.warnings[0].message),
+                )
             )

--- a/utils/generate_api.py
+++ b/utils/generate_api.py
@@ -704,6 +704,10 @@ def read_modules() -> Any:
             namespace = "__init__"
             name = key
 
+        # FIXME: we have a hard-coded index_management that needs to be deprecated in favor of the auto-generated one
+        if namespace == "ism":
+            continue
+
         # Group the data in the current group by the "path" key
         paths = []
         all_paths_have_deprecation = True


### PR DESCRIPTION
### Description

Fixing the generator-caused failures in #814.

- The order of plugins may change, and the warning message will contain a different plugin. Use a regex to check the error.
- The API spec added index management as `ism`, which creates a duplicate to the existing `index_management`. The implementation re-orders `index` and `body` and is not compatible. For now let's skip that namespace. https://github.com/opensearch-project/opensearch-py/issues/831

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
