### PR TITLE
Fix bug where URL is being signed after being quoted

### DIFF
--- a/opensearchpy/helpers/asyncsigner.py
+++ b/opensearchpy/helpers/asyncsigner.py
@@ -8,6 +8,7 @@
 # GitHub history for details.
 
 from typing import Any, Dict, Optional, Union
+from ..compat import unquote
 
 
 class AWSV4SignerAsyncAuth:
@@ -56,7 +57,7 @@ class AWSV4SignerAsyncAuth:
         # create an AWS request object and sign it using SigV4Auth
         aws_request = AWSRequest(
             method=method,
-            url=url,
+            url=unquote(url),
             data=body,
         )
 

--- a/opensearchpy/helpers/asyncsigner.py
+++ b/opensearchpy/helpers/asyncsigner.py
@@ -8,6 +8,7 @@
 # GitHub history for details.
 
 from typing import Any, Dict, Optional, Union
+
 from ..compat import unquote
 
 


### PR DESCRIPTION
### Description

URL is being signed after being quoted, but should be before.

### Issues Resolved
Closed https://github.com/opensearch-project/opensearch-py/issues/833

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
