### PR TITLE
Implement AsyncOpenSearch() parameter `ssl_assert_hostname`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Added `AsyncSearch#collapse` ([827](https://github.com/opensearch-project/opensearch-py/pull/827))
+- Implement `ssl_assert_hostname` boolean parameter for `AsyncOpenSearch.__init__()` ([#dummy](https://github.com/opensearch-project/opensearch-py/pull/dummy))
 ### Changed
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Added `AsyncSearch#collapse` ([827](https://github.com/opensearch-project/opensearch-py/pull/827))
-- Implement `ssl_assert_hostname` boolean parameter for `AsyncOpenSearch.__init__()` ([#dummy](https://github.com/opensearch-project/opensearch-py/pull/dummy))
+- Implement `ssl_assert_hostname` boolean parameter for `AsyncOpenSearch.__init__()` ([843](https://github.com/opensearch-project/opensearch-py/pull/843))
 ### Changed
 ### Deprecated
 ### Removed

--- a/docs/source/api-ref/clients/opensearch_client.md
+++ b/docs/source/api-ref/clients/opensearch_client.md
@@ -3,3 +3,7 @@
 ```{eval-rst}
 .. autoclass:: opensearchpy.OpenSearch
 ```
+
+```{eval-rst}
+.. autoclass:: opensearchpy.AsyncOpenSearch
+```

--- a/docs/source/api-ref/connection.md
+++ b/docs/source/api-ref/connection.md
@@ -1,4 +1,4 @@
-# connection 
+# Connection Types 
 
 ```{eval-rst}
 .. autoclass:: opensearchpy.Connection
@@ -10,6 +10,10 @@
 
 ```{eval-rst}
 .. autoclass:: opensearchpy.Urllib3HttpConnection
+```
+
+```{eval-rst}
+.. autoclass:: opensearchpy.AIOHttpConnection
 ```
 
 ```{eval-rst}

--- a/opensearchpy/_async/client/__init__.py
+++ b/opensearchpy/_async/client/__init__.py
@@ -109,7 +109,7 @@ class AsyncOpenSearch(Client):
         ])
 
     If using SSL, there are several parameters that control how we deal with
-    certificates (see :class:`~opensearchpy.Urllib3HttpConnection` for
+    certificates (see :class:`~opensearchpy.AIOHttpConnection` for
     detailed description of the options)::
 
         client = OpenSearch(
@@ -123,7 +123,7 @@ class AsyncOpenSearch(Client):
         )
 
     If using SSL, but don't verify the certs, a warning message is showed
-    optionally (see :class:`~opensearchpy.Urllib3HttpConnection` for
+    optionally (see :class:`~opensearchpy.AIOHttpConnection` for
     detailed description of the options)::
 
         client = OpenSearch(
@@ -132,12 +132,14 @@ class AsyncOpenSearch(Client):
             use_ssl=True,
             # no verify SSL certificates
             verify_certs=False,
+            # don't verify the hostname in the certificate
+            ssl_assert_hostname=False,
             # don't show warnings about ssl certs verification
             ssl_show_warn=False
         )
 
     SSL client authentication is supported
-    (see :class:`~opensearchpy.Urllib3HttpConnection` for
+    (see :class:`~opensearchpy.AIOHttpConnection` for
     detailed description of the options)::
 
         client = OpenSearch(

--- a/opensearchpy/_async/http_aiohttp.py
+++ b/opensearchpy/_async/http_aiohttp.py
@@ -85,6 +85,7 @@ class AIOHttpConnection(AsyncConnection):
         client_cert: Any = None,
         client_key: Any = None,
         ssl_version: Any = None,
+        ssl_assert_hostname: bool = True,
         ssl_assert_fingerprint: Any = None,
         maxsize: Optional[int] = 10,
         headers: Any = None,
@@ -177,7 +178,7 @@ class AIOHttpConnection(AsyncConnection):
 
             if verify_certs:
                 ssl_context.verify_mode = ssl.CERT_REQUIRED
-                ssl_context.check_hostname = True
+                ssl_context.check_hostname = ssl_assert_hostname
             else:
                 ssl_context.check_hostname = False
                 ssl_context.verify_mode = ssl.CERT_NONE

--- a/test_opensearchpy/test_async/test_connection.py
+++ b/test_opensearchpy/test_async/test_connection.py
@@ -97,6 +97,12 @@ class TestAIOHttpConnection:
         assert con.use_ssl
         assert con.session.connector._ssl == context
 
+    async def test_ssl_assert_hostname(self) -> None:
+        con = AIOHttpConnection(use_ssl=True, ssl_assert_hostname=False)
+        await con._create_aiohttp_session()
+        assert con.use_ssl
+        assert con.session.connector._ssl.check_hostname is False
+
     async def test_opaque_id(self) -> None:
         con = AIOHttpConnection(opaque_id="app-1")
         assert con.headers["x-opaque-id"] == "app-1"

--- a/test_opensearchpy/test_async/test_connection.py
+++ b/test_opensearchpy/test_async/test_connection.py
@@ -29,6 +29,7 @@ import gzip
 import io
 import json
 import ssl
+import sys
 import warnings
 from platform import python_version
 from typing import Any
@@ -228,7 +229,13 @@ class TestAIOHttpConnection:
                 use_ssl=True, verify_certs=False, ssl_show_warn=False
             )
             await con._create_aiohttp_session()
-            assert w == []
+            if sys.hexversion < 0x30c0700:
+                assert w == []
+            else:
+                assert len(w) == 1
+                assert (str(w[0].message) == "enable_cleanup_closed ignored because "
+                        "https://github.com/python/cpython/pull/118960 is fixed in "
+                        "Python version sys.version_info(major=3, minor=12, micro=7, releaselevel='final', serial=0)")
 
         assert isinstance(con.session, aiohttp.ClientSession)
 

--- a/test_opensearchpy/test_async/test_connection.py
+++ b/test_opensearchpy/test_async/test_connection.py
@@ -98,10 +98,16 @@ class TestAIOHttpConnection:
         assert con.session.connector._ssl == context
 
     async def test_ssl_assert_hostname(self) -> None:
+        con = AIOHttpConnection(use_ssl=True, ssl_assert_hostname=True)
+        await con._create_aiohttp_session()
+        assert con.use_ssl
+        assert con.session.connector._ssl.check_hostname is True
+        
         con = AIOHttpConnection(use_ssl=True, ssl_assert_hostname=False)
         await con._create_aiohttp_session()
         assert con.use_ssl
         assert con.session.connector._ssl.check_hostname is False
+
 
     async def test_opaque_id(self) -> None:
         con = AIOHttpConnection(opaque_id="app-1")

--- a/test_opensearchpy/test_async/test_connection.py
+++ b/test_opensearchpy/test_async/test_connection.py
@@ -229,13 +229,15 @@ class TestAIOHttpConnection:
                 use_ssl=True, verify_certs=False, ssl_show_warn=False
             )
             await con._create_aiohttp_session()
-            if sys.hexversion < 0x30c0700:
+            if sys.hexversion < 0x30C0700:
                 assert w == []
             else:
                 assert len(w) == 1
-                assert (str(w[0].message) == "enable_cleanup_closed ignored because "
-                        "https://github.com/python/cpython/pull/118960 is fixed in "
-                        "Python version sys.version_info(major=3, minor=12, micro=7, releaselevel='final', serial=0)")
+                assert (
+                    str(w[0].message) == "enable_cleanup_closed ignored because "
+                    "https://github.com/python/cpython/pull/118960 is fixed in "
+                    "Python version sys.version_info(major=3, minor=12, micro=7, releaselevel='final', serial=0)"
+                )
 
         assert isinstance(con.session, aiohttp.ClientSession)
 

--- a/test_opensearchpy/test_async/test_connection.py
+++ b/test_opensearchpy/test_async/test_connection.py
@@ -102,12 +102,11 @@ class TestAIOHttpConnection:
         await con._create_aiohttp_session()
         assert con.use_ssl
         assert con.session.connector._ssl.check_hostname is True
-        
+
         con = AIOHttpConnection(use_ssl=True, ssl_assert_hostname=False)
         await con._create_aiohttp_session()
         assert con.use_ssl
         assert con.session.connector._ssl.check_hostname is False
-
 
     async def test_opaque_id(self) -> None:
         con = AIOHttpConnection(opaque_id="app-1")


### PR DESCRIPTION
### Description
Implements the `ssl_assert_hostname` parameter for `AsyncOpenSearch()`.

### Issues Resolved
Closes #842

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
