### PR TITLE
Fix `/cluster/stats` in a backwards compatible way 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed the use of `minimum_should_match` with `Bool` to allow the use of string-based value (percent string, combination). ([#780](https://github.com/opensearch-project/opensearch-py/pull/780))
 - Fixed incorrect `retry_on_conflict` type ([#795](https://github.com/opensearch-project/opensearch-py/pull/795))
 ### Updated APIs
+- Updated opensearch-py APIs to reflect [opensearch-api-specification@4615564](https://github.com/opensearch-project/opensearch-api-specification/commit/4615564b05d410575bb6ed3ed34ea136bf2e4312)
 - Updated opensearch-py APIs to reflect [opensearch-api-specification@9d3bc34](https://github.com/opensearch-project/opensearch-api-specification/commit/9d3bc340ccd7d049e7d6e14a4aff2293780cb446)
 ### Dependencies
 - Bump `pytest-asyncio` from <=0.23.7 to <=0.23.8 ([#787](https://github.com/opensearch-project/opensearch-py/pull/787))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 ### Deprecated
 ### Removed
+### Updated APIs
+- Updated opensearch-py APIs to reflect [opensearch-api-specification@4615564](https://github.com/opensearch-project/opensearch-api-specification/commit/4615564b05d410575bb6ed3ed34ea136bf2e4312)
 ### Fixed
 - Fix `Transport.perform_request`'s arguments `timeout` and `ignore` variable usage ([810](https://github.com/opensearch-project/opensearch-py/pull/810))
 - Fix `Index.save` not passing through aliases to the underlying index ([823](https://github.com/opensearch-project/opensearch-py/pull/823))
@@ -36,7 +38,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed the use of `minimum_should_match` with `Bool` to allow the use of string-based value (percent string, combination). ([#780](https://github.com/opensearch-project/opensearch-py/pull/780))
 - Fixed incorrect `retry_on_conflict` type ([#795](https://github.com/opensearch-project/opensearch-py/pull/795))
 ### Updated APIs
-- Updated opensearch-py APIs to reflect [opensearch-api-specification@4615564](https://github.com/opensearch-project/opensearch-api-specification/commit/4615564b05d410575bb6ed3ed34ea136bf2e4312)
 - Updated opensearch-py APIs to reflect [opensearch-api-specification@9d3bc34](https://github.com/opensearch-project/opensearch-api-specification/commit/9d3bc340ccd7d049e7d6e14a4aff2293780cb446)
 ### Dependencies
 - Bump `pytest-asyncio` from <=0.23.7 to <=0.23.8 ([#787](https://github.com/opensearch-project/opensearch-py/pull/787))

--- a/opensearchpy/_async/client/__init__.py
+++ b/opensearchpy/_async/client/__init__.py
@@ -46,6 +46,8 @@ from .features import FeaturesClient
 from .http import HttpClient
 from .indices import IndicesClient
 from .ingest import IngestClient
+from .insights import InsightsClient
+from .list import ListClient
 from .nodes import NodesClient
 from .plugins import PluginsClient
 from .remote import RemoteClient
@@ -55,6 +57,7 @@ from .security import SecurityClient
 from .snapshot import SnapshotClient
 from .tasks import TasksClient
 from .utils import SKIP_IN_PATH, _bulk_body, _make_path, query_params
+from .wlm import WlmClient
 
 logger = logging.getLogger("opensearch")
 
@@ -216,6 +219,9 @@ class AsyncOpenSearch(Client):
         super().__init__(hosts, transport_class, **kwargs)
 
         # namespaced clients for compatibility with API names
+        self.wlm = WlmClient(self)
+        self.list = ListClient(self)
+        self.insights = InsightsClient(self)
         self.search_pipeline = SearchPipelineClient(self)
         self.cat = CatClient(self)
         self.cluster = ClusterClient(self)
@@ -269,13 +275,15 @@ class AsyncOpenSearch(Client):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -297,13 +305,15 @@ class AsyncOpenSearch(Client):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -346,18 +356,20 @@ class AsyncOpenSearch(Client):
         :arg id: Unique identifier for the document.
         :arg body: The document
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pipeline: ID of the pipeline to use to preprocess incoming
             documents. If the index has a default ingest pipeline specified, then
             setting the value to `_none` disables the default ingest pipeline for
             this request. If a final pipeline is configured it will always run,
             regardless of the value of this parameter.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg refresh: If `true`, OpenSearch refreshes the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` do
@@ -424,11 +436,13 @@ class AsyncOpenSearch(Client):
         :arg body: The document
         :arg id: Unique identifier for the document.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg if_primary_term: Only perform the operation if the document
             has this primary term.
         :arg if_seq_no: Only perform the operation if the document has
@@ -445,7 +459,7 @@ class AsyncOpenSearch(Client):
             this request. If a final pipeline is configured it will always run,
             regardless of the value of this parameter.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg refresh: If `true`, OpenSearch refreshes the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` do
@@ -520,18 +534,20 @@ class AsyncOpenSearch(Client):
         :arg _source_includes: A comma-separated list of source fields
             to include in the response.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pipeline: ID of the pipeline to use to preprocess incoming
             documents. If the index has a default ingest pipeline specified, then
             setting the value to `_none` disables the default ingest pipeline for
             this request. If a final pipeline is configured it will always run,
             regardless of the value of this parameter.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg refresh: If `true`, OpenSearch refreshes the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` do
@@ -575,17 +591,19 @@ class AsyncOpenSearch(Client):
 
 
         :arg body: Comma-separated list of scroll IDs to clear if none
-            was specified via the scroll_id parameter
+            was specified using the `scroll_id` parameter
         :arg scroll_id: Comma-separated list of scroll IDs to clear. To
             clear all scroll IDs, use `_all`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -634,13 +652,13 @@ class AsyncOpenSearch(Client):
 
         :arg body: Query to restrict the results specified with the
             Query DSL (optional)
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to search. Supports wildcards (`*`). To search all data streams
-            and indices, omit this parameter or use `*` or `_all`.
+            and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg analyze_wildcard: If `true`, wildcard and prefix queries
             are analyzed. This parameter can only be used when the `q` query string
             parameter is specified. Default is false.
@@ -654,18 +672,19 @@ class AsyncOpenSearch(Client):
             in the query string. This parameter can only be used when the `q` query
             string parameter is specified.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
-            separated values, such as `open,hidden`. Valid choices are all, closed,
-            hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            separated values, such as `open,hidden`.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_throttled: If `true`, concrete, expanded or aliased
-            indices are ignored when frozen.
+            indexes are ignored when frozen.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg lenient: If `true`, format-based query failures (such as
@@ -675,7 +694,7 @@ class AsyncOpenSearch(Client):
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg q: Query in the Lucene query string syntax.
         :arg routing: Custom value used to route operations to a
             specific shard.
@@ -722,17 +741,19 @@ class AsyncOpenSearch(Client):
         :arg index: Name of the target index.
         :arg id: Unique identifier for the document.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg if_primary_term: Only perform the operation if the document
             has this primary term.
         :arg if_seq_no: Only perform the operation if the document has
             this sequence number.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg refresh: If `true`, OpenSearch refreshes the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` do
@@ -812,20 +833,20 @@ class AsyncOpenSearch(Client):
         Deletes documents matching the provided query.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to search. Supports wildcards (`*`). To search all data streams
-            or indices, omit this parameter or use `*` or `_all`.
+            or indexes, omit this parameter or use `*` or `_all`.
         :arg body: The search definition using the Query DSL
-        :arg _source: True or false to return the _source field or not,
-            or a list of fields to return.
+        :arg _source: Set to `true` or `false` to return the `_source`
+            field or not, or a list of fields to return.
         :arg _source_excludes: List of fields to exclude from the
-            returned _source field.
+            returned `_source` field.
         :arg _source_includes: List of fields to extract and return from
-            the _source field.
+            the `_source` field.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with `foo` but no index starts with
             `bar`.
         :arg analyze_wildcard: If `true`, wildcard and prefix queries
@@ -838,17 +859,19 @@ class AsyncOpenSearch(Client):
         :arg df: Field to use as default where no field prefix is given
             in the query string.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg from_: Starting offset. Default is 0.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg lenient: If `true`, format-based query failures (such as
@@ -858,7 +881,7 @@ class AsyncOpenSearch(Client):
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg q: Query in the Lucene query string syntax.
         :arg refresh: If `true`, OpenSearch refreshes all shards
             involved in the delete by query after the request completes.
@@ -876,7 +899,7 @@ class AsyncOpenSearch(Client):
         :arg search_type: The type of the search operation. Available
             options: `query_then_fetch`, `dfs_query_then_fetch`. Valid choices are
             dfs_query_then_fetch, query_then_fetch.
-        :arg size: Deprecated, please use `max_docs` instead.
+        :arg size: Deprecated, use `max_docs` instead.
         :arg slices: The number of slices this task should be divided
             into. Valid choices are auto.
         :arg sort: A comma-separated list of <field>:<direction> pairs.
@@ -890,7 +913,7 @@ class AsyncOpenSearch(Client):
             caution. OpenSearch applies this parameter to each shard handling the
             request. When possible, let OpenSearch perform early termination
             automatically. Avoid specifying this parameter for requests that target
-            data streams with backing indices across multiple data tiers.
+            data streams with backing indexes across multiple data tiers.
         :arg timeout: Period each deletion request waits for active
             shards.
         :arg version: If `true`, returns the document version as part of
@@ -934,13 +957,15 @@ class AsyncOpenSearch(Client):
 
         :arg task_id: The ID for the task.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg requests_per_second: The throttle for this request in sub-
             requests per second.
         :arg source: The URL-encoded request definition. Useful for
@@ -980,17 +1005,19 @@ class AsyncOpenSearch(Client):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -1032,7 +1059,7 @@ class AsyncOpenSearch(Client):
         Returns information about whether a document exists in an index.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases. Supports wildcards (`*`).
         :arg id: Identifier of the document.
         :arg _source: `true` or `false` to return the `_source` field or
@@ -1042,15 +1069,17 @@ class AsyncOpenSearch(Client):
         :arg _source_includes: A comma-separated list of source fields
             to include in the response.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg realtime: If `true`, the request is real-time as opposed to
             near-real-time.
         :arg refresh: If `true`, OpenSearch refreshes all shards
@@ -1104,7 +1133,7 @@ class AsyncOpenSearch(Client):
         Returns information about whether a document source exists in an index.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases. Supports wildcards (`*`).
         :arg id: Identifier of the document.
         :arg _source: `true` or `false` to return the `_source` field or
@@ -1114,16 +1143,18 @@ class AsyncOpenSearch(Client):
         :arg _source_includes: A comma-separated list of source fields
             to include in the response.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg realtime: If true, the request is real-time as opposed to
+            response. Default is false.
+        :arg realtime: If `true`, the request is real-time as opposed to
             near-real-time.
         :arg refresh: If `true`, OpenSearch refreshes all shards
             involved in the delete by query after the request completes.
@@ -1182,8 +1213,8 @@ class AsyncOpenSearch(Client):
             index name can be provided to this parameter.
         :arg id: Defines the document ID.
         :arg body: The query definition using the Query DSL
-        :arg _source: True or false to return the `_source` field or
-            not, or a list of fields to return.
+        :arg _source: Set to `true` or `false` to return the `_source`
+            field or not, or a list of fields to return.
         :arg _source_excludes: A comma-separated list of source fields
             to exclude from the response.
         :arg _source_includes: A comma-separated list of source fields
@@ -1198,17 +1229,19 @@ class AsyncOpenSearch(Client):
         :arg df: Field to use as default where no field prefix is given
             in the query string. Default is _all.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg lenient: If `true`, format-based query failures (such as
             providing text to a numeric field) in the query string will be ignored.
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg q: Query in the Lucene query string syntax.
         :arg routing: Custom value used to route operations to a
             specific shard.
@@ -1248,38 +1281,39 @@ class AsyncOpenSearch(Client):
     ) -> Any:
         """
         Returns the information about the capabilities of fields among multiple
-        indices.
+        indexes.
 
 
         :arg body: An index filter specified with the Query DSL
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (*). To target all
-            data streams and indices, omit this parameter or use * or _all.
-        :arg allow_no_indices: If false, the request returns an error if
-            any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            data streams and indexes, omit this parameter or use * or `_all`.
+        :arg allow_no_indices: If `false`, the request returns an error
+            if any wildcard expression, index alias, or `_all` value targets only
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with foo but no index starts with
             bar.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
-            separated values, such as `open,hidden`. Valid choices are all, closed,
-            hidden, none, open.
+            separated values, such as `open,hidden`.
         :arg fields: Comma-separated list of fields to retrieve
             capabilities for. Wildcard (`*`) expressions are supported.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: If `true`, missing or closed indices
+            statistics. Default is True.
+        :arg ignore_unavailable: If `true`, missing or closed indexes
             are not included in the response.
-        :arg include_unmapped: If true, unmapped fields are included in
-            the response. Default is false.
+        :arg include_unmapped: If `true`, unmapped fields are included
+            in the response. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1321,27 +1355,29 @@ class AsyncOpenSearch(Client):
 
         :arg index: Name of the index that contains the document.
         :arg id: Unique identifier of the document.
-        :arg _source: True or false to return the _source field or not,
-            or a list of fields to return.
+        :arg _source: Set to `true` or `false` to return the `_source`
+            field or not, or a list of fields to return.
         :arg _source_excludes: A comma-separated list of source fields
             to exclude in the response.
         :arg _source_includes: A comma-separated list of source fields
             to include in the response.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg realtime: If `true`, the request is real-time as opposed to
             near-real-time.
-        :arg refresh: If true, OpenSearch refreshes the affected shards
-            to make this operation visible to search. If false, do nothing with
-            refreshes.
+        :arg refresh: If `true`, OpenSearch refreshes the affected
+            shards to make this operation visible to search. If `false`, do nothing
+            with refreshes.
         :arg routing: Target the specified primary shard.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
@@ -1352,8 +1388,9 @@ class AsyncOpenSearch(Client):
         :arg version: Explicit version number for concurrency control.
             The specified version must match the current version of the document for
             the request to succeed.
-        :arg version_type: Specific version type: internal, external,
-            external_gte. Valid choices are external, external_gte, force, internal.
+        :arg version_type: Specific version type: `internal`,
+            `external`, `external_gte`. Valid choices are external, external_gte,
+            force, internal.
         """
         for param in (index, id):
             if param in SKIP_IN_PATH:
@@ -1386,16 +1423,18 @@ class AsyncOpenSearch(Client):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Specify timeout for connection
+            use `cluster_manager_timeout` instead.): Specify timeout for connection
             to master
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1435,35 +1474,38 @@ class AsyncOpenSearch(Client):
 
         :arg index: Name of the index that contains the document.
         :arg id: Unique identifier of the document.
-        :arg _source: True or false to return the _source field or not,
-            or a list of fields to return.
+        :arg _source: Set to `true` or `false` to return the `_source`
+            field or not, or a list of fields to return.
         :arg _source_excludes: A comma-separated list of source fields
             to exclude in the response.
         :arg _source_includes: A comma-separated list of source fields
             to include in the response.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg realtime: Boolean) If true, the request is real-time as
+            response. Default is false.
+        :arg realtime: Boolean) If `true`, the request is real-time as
             opposed to near-real-time.
-        :arg refresh: If true, OpenSearch refreshes the affected shards
-            to make this operation visible to search. If false, do nothing with
-            refreshes.
+        :arg refresh: If `true`, OpenSearch refreshes the affected
+            shards to make this operation visible to search. If `false`, do nothing
+            with refreshes.
         :arg routing: Target the specified primary shard.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg version: Explicit version number for concurrency control.
             The specified version must match the current version of the document for
             the request to succeed.
-        :arg version_type: Specific version type: internal, external,
-            external_gte. Valid choices are external, external_gte, force, internal.
+        :arg version_type: Specific version type. One of `internal`,
+            `external`, `external_gte`. Valid choices are external, external_gte,
+            force, internal.
         """
         for param in (index, id):
             if param in SKIP_IN_PATH:
@@ -1507,8 +1549,8 @@ class AsyncOpenSearch(Client):
         :arg index: Name of the index to retrieve documents from when
             `ids` are specified, or when a document in the `docs` array does not
             specify an index.
-        :arg _source: True or false to return the `_source` field or
-            not, or a list of fields to return.
+        :arg _source: Set to `true` or `false` to return the `_source`
+            field or not, or a list of fields to return.
         :arg _source_excludes: A comma-separated list of source fields
             to exclude from the response. You can also use this parameter to exclude
             fields from the subset specified in `_source_includes` query parameter.
@@ -1518,15 +1560,17 @@ class AsyncOpenSearch(Client):
             using the `_source_excludes` query parameter. If the `_source` parameter
             is `false`, this parameter is ignored.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg realtime: If `true`, the request is real-time as opposed to
             near-real-time.
         :arg refresh: If `true`, the request refreshes relevant shards
@@ -1576,17 +1620,19 @@ class AsyncOpenSearch(Client):
 
         :arg body: The request definitions (metadata-search request
             definition pairs), separated by newlines
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             index aliases to search.
-        :arg ccs_minimize_roundtrips: If true, network roundtrips
+        :arg ccs_minimize_roundtrips: If `true`, network round-trips
             between the coordinating node and remote clusters are minimized for
             cross-cluster search requests. Default is True.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg max_concurrent_searches: Maximum number of concurrent
             searches the multi search API can execute.
         :arg max_concurrent_shard_requests: Maximum number of concurrent
@@ -1600,10 +1646,10 @@ class AsyncOpenSearch(Client):
             on its rewrite method i.e., if date filters are mandatory to match but
             the shard bounds and the query are disjoint.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg rest_total_hits_as_int: If true, hits.total are returned as
-            an integer in the response. Defaults to false, which returns an object.
-            Default is false.
+            response. Default is false.
+        :arg rest_total_hits_as_int: If `true`, `hits.total` are
+            returned as an integer in the response. Defaults to false, which returns
+            an object. Default is false.
         :arg search_type: Indicates whether global term and document
             frequencies should be used when scoring returned documents. Valid
             choices are dfs_query_then_fetch, query_then_fetch.
@@ -1649,21 +1695,23 @@ class AsyncOpenSearch(Client):
 
         :arg body: The request definitions (metadata-search request
             definition pairs), separated by newlines
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to search. Supports wildcards (`*`). To search all data streams
-            and indices, omit this parameter or use `*`.
+            and indexes, omit this parameter or use `*`.
         :arg ccs_minimize_roundtrips: If `true`, network round-trips are
             minimized for cross-cluster search requests. Default is True.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg max_concurrent_searches: Maximum number of concurrent
             searches the API can run.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg rest_total_hits_as_int: If `true`, the response returns
             `hits.total` as an integer. If `false`, it returns `hits.total` as an
             object. Default is false.
@@ -1722,7 +1770,7 @@ class AsyncOpenSearch(Client):
             document ids. See documentation.
         :arg index: Name of the index that contains the documents.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg field_statistics: If `true`, the response includes the
             document count, sum of document frequencies, and sum of total term
             frequencies. Default is True.
@@ -1730,10 +1778,12 @@ class AsyncOpenSearch(Client):
             fields to include in the statistics. Used as the default list unless a
             specific field list is provided in the `completion_fields` or
             `fielddata_fields` parameters.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ids: A comma-separated list of documents ids. You must
             define ids as parameter or set "ids" or "docs" in the request body
         :arg offsets: If `true`, the response includes term offsets.
@@ -1745,14 +1795,14 @@ class AsyncOpenSearch(Client):
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg realtime: If true, the request is real-time as opposed to
+            response. Default is false.
+        :arg realtime: If `true`, the request is real-time as opposed to
             near-real-time. Default is True.
         :arg routing: Custom value used to route operations to a
             specific shard.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
-        :arg term_statistics: If true, the response includes term
+        :arg term_statistics: If `true`, the response includes term
             frequency and document frequency. Default is false.
         :arg version: If `true`, returns the document version as part of
             a hit.
@@ -1796,17 +1846,19 @@ class AsyncOpenSearch(Client):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -1850,30 +1902,32 @@ class AsyncOpenSearch(Client):
 
         :arg body: The ranking evaluation search definition, including
             search requests, document ratings and ranking metric definition.
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             index aliases used to limit the request. Wildcard (`*`) expressions are
-            supported. To target all data streams and indices in a cluster, omit
+            supported. To target all data streams and indexes in a cluster, omit
             this parameter or use `_all` or `*`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with `foo` but no index starts with
             `bar`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: If `true`, missing or closed indices
+            statistics. Default is True.
+        :arg ignore_unavailable: If `true`, missing or closed indexes
             are not included in the response.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg search_type: Search operation type
+            response. Default is false.
+        :arg search_type: Search operation type Valid choices are
+            dfs_query_then_fetch, query_then_fetch.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1918,15 +1972,17 @@ class AsyncOpenSearch(Client):
         :arg body: The search definition using the Query DSL and the
             prototype for the index request.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg max_docs: Maximum number of documents to process. By
             default, all documents.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg refresh: If `true`, the request refreshes affected shards
             to make this operation visible to search.
         :arg requests_per_second: The throttle for this request in sub-
@@ -1969,13 +2025,15 @@ class AsyncOpenSearch(Client):
 
         :arg task_id: Identifier for the task.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg requests_per_second: The throttle for this request in sub-
             requests per second.
         :arg source: The URL-encoded request definition. Useful for
@@ -2003,17 +2061,19 @@ class AsyncOpenSearch(Client):
         Allows to use the Mustache language to pre-render a search definition.
 
 
-        :arg body: The search definition template and its params
+        :arg body: The search definition template and its parameters.
         :arg id: ID of the search template to render. If no `source` is
             specified, this or the `id` request body parameter is required.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2038,13 +2098,15 @@ class AsyncOpenSearch(Client):
 
         :arg body: The script to execute
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2080,16 +2142,18 @@ class AsyncOpenSearch(Client):
             parameter.
         :arg scroll_id: The scroll ID for scrolled search
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg rest_total_hits_as_int: If true, the API response's
-            hit.total property is returned as an integer. If false, the API
-            response's hit.total property is returned as an object. Default is
+            response. Default is false.
+        :arg rest_total_hits_as_int: If `true`, the API response's
+            `hit.total` property is returned as an integer. If `false`, the API
+            response's `hit.total` property is returned as an object. Default is
             false.
         :arg scroll: Period to retain the search context for scrolling.
         :arg source: The URL-encoded request definition. Useful for
@@ -2171,9 +2235,9 @@ class AsyncOpenSearch(Client):
 
 
         :arg body: The search definition using the Query DSL
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to search. Supports wildcards (`*`). To search all data streams
-            and indices, omit this parameter or use `*` or `_all`.
+            and indexes, omit this parameter or use `*` or `_all`.
         :arg _source: Indicates which source fields are returned for
             matching documents. These fields are returned in the `hits._source`
             property of the search response. Valid values are: `true` to return the
@@ -2191,15 +2255,15 @@ class AsyncOpenSearch(Client):
             is `false`, this parameter is ignored.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with `foo` but no index starts with
             `bar`.
-        :arg allow_partial_search_results: If true, returns partial
-            results if there are shard request timeouts or shard failures. If false,
-            returns an error with no partial results. Default is True.
-        :arg analyze_wildcard: If true, wildcard and prefix queries are
-            analyzed. This parameter can only be used when the q query string
+        :arg allow_partial_search_results: If `true`, returns partial
+            results if there are shard request timeouts or shard failures. If
+            `false`, returns an error with no partial results. Default is True.
+        :arg analyze_wildcard: If `true`, wildcard and prefix queries
+            are analyzed. This parameter can only be used when the q query string
             parameter is specified. Default is false.
         :arg analyzer: Analyzer to use for the query string. This
             parameter can only be used when the q query string parameter is
@@ -2212,7 +2276,7 @@ class AsyncOpenSearch(Client):
         :arg cancel_after_time_interval: The time after which the search
             request will be canceled. Request-level parameter takes precedence over
             `cancel_after_time_interval` cluster setting.
-        :arg ccs_minimize_roundtrips: If true, network round-trips
+        :arg ccs_minimize_roundtrips: If `true`, network round-trips
             between the coordinating node and the remote clusters are minimized when
             executing cross-cluster search (CCS) requests. Default is True.
         :arg default_operator: The default operator for query string
@@ -2224,28 +2288,29 @@ class AsyncOpenSearch(Client):
         :arg docvalue_fields: A comma-separated list of fields to return
             as the docvalue representation for each hit.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
-            separated values, such as `open,hidden`. Valid choices are all, closed,
-            hidden, none, open.
+            separated values, such as `open,hidden`.
         :arg explain: If `true`, returns detailed information about
             score computation as part of a hit.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg from_: Starting document offset. Needs to be non-negative.
             By default, you cannot page through more than 10,000 hits using the
             `from` and `size` parameters. To page through more hits, use the
             `search_after` parameter. Default is 0.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_throttled: If `true`, concrete, expanded or aliased
-            indices will be ignored when frozen.
+            indexes will be ignored when frozen.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg include_named_queries_score: Indicates whether
-            hit.matched_queries should be rendered as a map that includes the name
+            `hit.matched_queries` should be rendered as a map that includes the name
             of the matched query associated with its score (true) or as an array
             containing the name of the matched queries (false) Default is false.
         :arg lenient: If `true`, format-based query failures (such as
@@ -2287,7 +2352,7 @@ class AsyncOpenSearch(Client):
             `<custom-string>` to the same shards in the same order. Default is
             random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg q: Query in the Lucene query string syntax using query
             parameter search. Query parameter searches do not support the full
             OpenSearch Query DSL but are handy for testing.
@@ -2343,7 +2408,7 @@ class AsyncOpenSearch(Client):
             caution. OpenSearch applies this parameter to each shard handling the
             request. When possible, let OpenSearch perform early termination
             automatically. Avoid specifying this parameter for requests that target
-            data streams with backing indices across multiple data tiers. If set to
+            data streams with backing indexes across multiple data tiers. If set to
             `0` (default), the query does not terminate early.
         :arg timeout: Specifies the period of time to wait for a
             response from each shard. If no response is received before the timeout
@@ -2391,29 +2456,31 @@ class AsyncOpenSearch(Client):
         headers: Any = None,
     ) -> Any:
         """
-        Returns information about the indices and shards that a search request would be
+        Returns information about the indexes and shards that a search request would be
         executed against.
 
 
-        :arg index: Returns the indices and shards that a search request
+        :arg index: Returns the indexes and shards that a search request
             would be executed against.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with `foo` but no index starts with
             `bar`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg local: If `true`, the request retrieves information from
@@ -2421,7 +2488,7 @@ class AsyncOpenSearch(Client):
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg routing: Custom value used to route operations to a
             specific shard.
         :arg source: The URL-encoded request definition. Useful for
@@ -2462,19 +2529,19 @@ class AsyncOpenSearch(Client):
         Allows to use the Mustache language to pre-render a search definition.
 
 
-        :arg body: The search definition template and its params
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg body: The search definition template and its parameters.
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to search. Supports wildcards (*).
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with `foo` but no index starts with
             `bar`.
         :arg ccs_minimize_roundtrips: If `true`, network round-trips are
             minimized for cross-cluster search requests. Default is True.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
@@ -2482,21 +2549,23 @@ class AsyncOpenSearch(Client):
             `open`, `closed`, `hidden`, `none`.
         :arg explain: If `true`, the response includes additional
             details about score computation as part of a hit.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_throttled: If `true`, specified concrete, expanded,
-            or aliased indices are not included in the response when throttled.
+            or aliased indexes are not included in the response when throttled.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg profile: If `true`, the query execution is profiled.
-        :arg rest_total_hits_as_int: If true, hits.total are rendered as
-            an integer in the response. Default is false.
+        :arg rest_total_hits_as_int: If `true`, `hits.total` are
+            rendered as an integer in the response. Default is false.
         :arg routing: Custom value used to route operations to a
             specific shard.
         :arg scroll: Specifies how long a consistent view of the index
@@ -2555,7 +2624,7 @@ class AsyncOpenSearch(Client):
             termvectors for. See documentation.
         :arg id: Unique identifier of the document.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg field_statistics: If `true`, the response includes the
             document count, sum of document frequencies, and sum of total term
             frequencies. Default is True.
@@ -2563,10 +2632,12 @@ class AsyncOpenSearch(Client):
             fields to include in the statistics. Used as the default list unless a
             specific field list is provided in the `completion_fields` or
             `fielddata_fields` parameters.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg offsets: If `true`, the response includes term offsets.
             Default is True.
         :arg payloads: If `true`, the response includes term payloads.
@@ -2576,8 +2647,8 @@ class AsyncOpenSearch(Client):
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg realtime: If true, the request is real-time as opposed to
+            response. Default is false.
+        :arg realtime: If `true`, the request is real-time as opposed to
             near-real-time. Default is True.
         :arg routing: Custom value used to route operations to a
             specific shard.
@@ -2634,30 +2705,33 @@ class AsyncOpenSearch(Client):
         :arg id: Document ID
         :arg body: The request definition requires either `script` or
             partial `doc`
-        :arg _source: Set to false to disable source retrieval. You can
-            also specify a comma-separated list of the fields you want to retrieve.
+        :arg _source: Set to `false` to disable source retrieval. You
+            can also specify a comma-separated list of the fields you want to
+            retrieve.
         :arg _source_excludes: Specify the source fields you want to
             exclude.
         :arg _source_includes: Specify the source fields you want to
             retrieve.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg if_primary_term: Only perform the operation if the document
             has this primary term.
         :arg if_seq_no: Only perform the operation if the document has
             this sequence number.
         :arg lang: The script language. Default is painless.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg refresh: If 'true', OpenSearch refreshes the affected
-            shards to make this operation visible to search, if 'wait_for' then wait
-            for a refresh to make this operation visible to search, if 'false' do
-            nothing with refreshes. Valid choices are false, true, wait_for.
-        :arg require_alias: If true, the destination must be an index
+            shards to make this operation visible to search, if `wait_for` then wait
+            for a refresh to make this operation visible to search, if `false` do
+            nothing with refreshes.
+        :arg require_alias: If `true`, the destination must be an index
             alias. Default is false.
         :arg retry_on_conflict: Specify how many times should the
             operation be retried when a conflict occurs. Default is 0.
@@ -2738,20 +2812,20 @@ class AsyncOpenSearch(Client):
         for example to pick up a mapping change.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to search. Supports wildcards (`*`). To search all data streams
-            or indices, omit this parameter or use `*` or `_all`.
+            or indexes, omit this parameter or use `*` or `_all`.
         :arg body: The search definition using the Query DSL
-        :arg _source: True or false to return the _source field or not,
-            or a list of fields to return.
+        :arg _source: Set to `true` or `false` to return the `_source`
+            field or not, or a list of fields to return.
         :arg _source_excludes: List of fields to exclude from the
-            returned _source field.
+            returned `_source` field.
         :arg _source_includes: List of fields to extract and return from
-            the _source field.
+            the `_source` field.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with `foo` but no index starts with
             `bar`.
         :arg analyze_wildcard: If `true`, wildcard and prefix queries
@@ -2764,17 +2838,19 @@ class AsyncOpenSearch(Client):
         :arg df: Field to use as default where no field prefix is given
             in the query string.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg from_: Starting offset. Default is 0.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg lenient: If `true`, format-based query failures (such as
@@ -2789,7 +2865,7 @@ class AsyncOpenSearch(Client):
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg q: Query in the Lucene query string syntax.
         :arg refresh: If `true`, OpenSearch refreshes affected shards to
             make the operation visible to search.
@@ -2806,7 +2882,7 @@ class AsyncOpenSearch(Client):
         :arg search_type: The type of the search operation. Available
             options: `query_then_fetch`, `dfs_query_then_fetch`. Valid choices are
             dfs_query_then_fetch, query_then_fetch.
-        :arg size: Deprecated, please use `max_docs` instead.
+        :arg size: Deprecated, use `max_docs` instead.
         :arg slices: The number of slices this task should be divided
             into. Valid choices are auto.
         :arg sort: A comma-separated list of <field>:<direction> pairs.
@@ -2820,7 +2896,7 @@ class AsyncOpenSearch(Client):
             caution. OpenSearch applies this parameter to each shard handling the
             request. When possible, let OpenSearch perform early termination
             automatically. Avoid specifying this parameter for requests that target
-            data streams with backing indices across multiple data tiers.
+            data streams with backing indexes across multiple data tiers.
         :arg timeout: Period each update request waits for the following
             operations: dynamic mapping updates, waiting for active shards.
         :arg version: If `true`, returns the document version as part of
@@ -2863,13 +2939,15 @@ class AsyncOpenSearch(Client):
 
         :arg task_id: The ID for the task.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg requests_per_second: The throttle for this request in sub-
             requests per second.
         :arg source: The URL-encoded request definition. Useful for
@@ -2896,13 +2974,15 @@ class AsyncOpenSearch(Client):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2921,13 +3001,15 @@ class AsyncOpenSearch(Client):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2957,24 +3039,25 @@ class AsyncOpenSearch(Client):
         Creates point in time context.
 
 
-        :arg index: Comma-separated list of indices; use `_all` or empty
-            string to perform the operation on all indices.
+        :arg index: Comma-separated list of indexes; use `_all` or empty
+            string to perform the operation on all indexes.
         :arg allow_partial_pit_creation: Allow if point in time can be
             created with partial failures.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg keep_alive: Specify the keep alive for point in time.
         :arg preference: Specify the node or shard the operation should
             be performed on. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg routing: Comma-separated list of specific routing values.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
@@ -3000,13 +3083,15 @@ class AsyncOpenSearch(Client):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -3027,13 +3112,15 @@ class AsyncOpenSearch(Client):
 
         :arg body: The point-in-time ids to be deleted
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -3056,16 +3143,108 @@ class AsyncOpenSearch(Client):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
         return await self.transport.perform_request(
             "GET", "/_search/point_in_time/_all", params=params, headers=headers
+        )
+
+    @query_params(
+        "_source",
+        "_source_excludes",
+        "_source_includes",
+        "batch_interval",
+        "batch_size",
+        "error_trace",
+        "filter_path",
+        "human",
+        "pipeline",
+        "pretty",
+        "refresh",
+        "require_alias",
+        "routing",
+        "source",
+        "timeout",
+        "wait_for_active_shards",
+    )
+    async def bulk_stream(
+        self,
+        body: Any,
+        index: Any = None,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Allows to perform multiple index/update/delete operations using request
+        response streaming.
+
+
+        :arg body: The operation definition and data (action-data
+            pairs), separated by newlines
+        :arg index: Name of the data stream, index, or index alias to
+            perform bulk actions on.
+        :arg _source: `true` or `false` to return the `_source` field or
+            not, or a list of fields to return.
+        :arg _source_excludes: A comma-separated list of source fields
+            to exclude from the response.
+        :arg _source_includes: A comma-separated list of source fields
+            to include in the response.
+        :arg batch_interval: Specifies for how long bulk operations
+            should be accumulated into a batch before sending the batch to data
+            nodes.
+        :arg batch_size: Specifies how many bulk operations should be
+            accumulated into a batch before sending the batch to data nodes.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pipeline: ID of the pipeline to use to preprocess incoming
+            documents. If the index has a default ingest pipeline specified, then
+            setting the value to `_none` disables the default ingest pipeline for
+            this request. If a final pipeline is configured it will always run,
+            regardless of the value of this parameter.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg refresh: If `true`, OpenSearch refreshes the affected
+            shards to make this operation visible to search, if `wait_for` then wait
+            for a refresh to make this operation visible to search, if `false` do
+            nothing with refreshes. Valid values: `true`, `false`, `wait_for`.
+        :arg require_alias: If `true`, the request's actions must target
+            an index alias. Default is false.
+        :arg routing: Custom value used to route operations to a
+            specific shard.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        :arg timeout: Period each action waits for the following
+            operations: automatic index creation, dynamic mapping updates, waiting
+            for active shards.
+        :arg wait_for_active_shards: The number of shard copies that
+            must be active before proceeding with the operation. Set to all or any
+            positive integer up to the total number of shards in the index
+            (`number_of_replicas+1`). Valid choices are all, index-setting.
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+
+        body = _bulk_body(self.transport.serializer, body)
+        return await self.transport.perform_request(
+            "PUT",
+            _make_path(index, "_bulk", "stream"),
+            params=params,
+            headers=headers,
+            body=body,
         )

--- a/opensearchpy/_async/client/cat.py
+++ b/opensearchpy/_async/client/cat.py
@@ -61,30 +61,31 @@ class CatClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Shows information about currently configured aliases to indices including
-        filter and routing infos.
+        Shows information about currently configured aliases to indexes including
+        filter and routing info.
 
 
         :arg name: A comma-separated list of aliases to retrieve.
             Supports wildcards (`*`).  To retrieve all aliases, omit this parameter
             or use `*` or `_all`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -120,17 +121,19 @@ class CatClient(NamespacedClient):
         :arg bytes: The unit in which to display byte values. Valid
             choices are b, g, gb, k, kb, m, mb, p, pb, t, tb.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -175,22 +178,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -231,22 +236,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -277,24 +284,26 @@ class CatClient(NamespacedClient):
     ) -> Any:
         """
         Provides quick access to the document count of the entire cluster, or
-        individual indices.
+        individual indexes.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -325,7 +334,7 @@ class CatClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Shows how much heap memory is currently being used by fielddata on every data
+        Shows how much heap memory is currently being used by field data on every data
         node in the cluster.
 
 
@@ -334,17 +343,19 @@ class CatClient(NamespacedClient):
         :arg bytes: The unit used to display byte values. Valid choices
             are b, g, gb, k, kb, m, mb, p, pb, t, tb.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -382,25 +393,27 @@ class CatClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg time: The unit used to display time values. Valid choices
             are d, h, m, micros, ms, nanos, s.
-        :arg ts: If true, returns `HH:MM:SS` and Unix epoch timestamps.
-            Default is True.
+        :arg ts: If `true`, returns `HH:MM:SS` and Unix epoch
+            timestamps. Default is True.
         :arg v: Verbose mode. Display column headers. Default is false.
         """
         return await self.transport.perform_request(
@@ -418,13 +431,15 @@ class CatClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -460,43 +475,45 @@ class CatClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Returns information about indices: number of primaries and replicas, document
+        Returns information about indexes: number of primaries and replicas, document
         counts, disk size, ...
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg bytes: The unit used to display byte values. Valid choices
             are b, g, gb, k, kb, m, mb, p, pb, t, tb.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: The type of index that wildcard patterns
-            can match. Valid choices are all, closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            can match.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
-        :arg health: The health status used to limit returned indices.
-            By default, the response includes indices of any health status. Valid
+        :arg health: The health status used to limit returned indexes.
+            By default, the response includes indexes of any health status. Valid
             choices are green, red, yellow.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg include_unloaded_segments: If true, the response includes
+            statistics. Default is True.
+        :arg include_unloaded_segments: If `true`, the response includes
             information from segments that are not loaded into memory. Default is
             false.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg pri: If true, the response only includes information from
+            response. Default is false.
+        :arg pri: If `true`, the response only includes information from
             primary shards. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
@@ -537,22 +554,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -562,7 +581,7 @@ class CatClient(NamespacedClient):
         from warnings import warn
 
         warn(
-            "Deprecated: To promote inclusive language, please use '/_cat/cluster_manager' instead."
+            "Deprecated: To promote inclusive language, use '/_cat/cluster_manager' instead."
         )
         return await self.transport.perform_request(
             "GET", "/_cat/master", params=params, headers=headers
@@ -595,22 +614,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -653,25 +674,27 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg full_id: If `true`, return the full node ID. If `false`,
             return the shortened node ID. Default is false.
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local (Deprecated: This parameter does not cause this API
             to act locally.): Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -712,22 +735,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -766,17 +791,19 @@ class CatClient(NamespacedClient):
         :arg bytes: The unit in which to display byte values. Valid
             choices are b, g, gb, k, kb, m, mb, p, pb, t, tb.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -814,22 +841,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -875,17 +904,19 @@ class CatClient(NamespacedClient):
         :arg detailed: If `true`, the response includes detailed
             information about shard recoveries. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -925,22 +956,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -989,9 +1022,9 @@ class CatClient(NamespacedClient):
             names to limit the returned information.
         :arg active_only: If `true`, the response only includes ongoing
             segment replication events. Default is false.
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified).
+        :arg allow_no_indices: Whether to ignore if a wildcard indexes
+            expression resolves into no concrete indexes. (This includes `_all`
+            string or when no indexes have been specified).
         :arg bytes: The unit in which to display byte values. Valid
             choices are b, g, gb, k, kb, m, mb, p, pb, t, tb.
         :arg completed_only: If `true`, the response only includes
@@ -999,24 +1032,25 @@ class CatClient(NamespacedClient):
         :arg detailed: If `true`, the response includes detailed
             information about segment replications. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_throttled: Whether specified concrete, expanded or
-            aliased indices should be ignored when throttled.
-        :arg ignore_unavailable: Whether specified concrete indices
+            aliased indexes should be ignored when throttled.
+        :arg ignore_unavailable: Whether specified concrete indexes
             should be ignored when unavailable (missing or closed).
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg shards: Comma-separated list of shards to display.
@@ -1059,28 +1093,30 @@ class CatClient(NamespacedClient):
         Provides low-level information about the segments in the shards of an index.
 
 
-        :arg index: A comma-separated list of data streams, indices, and
+        :arg index: A comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg bytes: The unit used to display byte values. Valid choices
             are b, g, gb, k, kb, m, mb, p, pb, t, tb.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -1118,30 +1154,32 @@ class CatClient(NamespacedClient):
         Provides a detailed view of shard allocation on nodes.
 
 
-        :arg index: A comma-separated list of data streams, indices, and
+        :arg index: A comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg bytes: The unit used to display byte values. Valid choices
             are b, g, gb, k, kb, m, mb, p, pb, t, tb.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -1186,22 +1224,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg size: The multiplier in which to display values.
@@ -1249,22 +1289,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `true`, the response does not
             include information from unavailable snapshots. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -1312,15 +1354,17 @@ class CatClient(NamespacedClient):
         :arg detailed: If `true`, the response includes detailed
             information about shard recoveries. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg nodes: Comma-separated list of node IDs or names to limit
             the returned information; use `_local` to return information from the
             node you're connecting to, leave empty to get information from all
@@ -1328,7 +1372,7 @@ class CatClient(NamespacedClient):
         :arg parent_task_id: The parent task identifier, which is used
             to limit the response.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -1371,22 +1415,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for

--- a/opensearchpy/_async/client/cluster.py
+++ b/opensearchpy/_async/client/cluster.py
@@ -70,35 +70,36 @@ class ClusterClient(NamespacedClient):
         Returns basic information about the health of the cluster.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             index aliases used to limit the request. Wildcard expressions (*) are
-            supported. To target all data streams and indices in a cluster, omit
+            supported. To target all data streams and indexes in a cluster, omit
             this parameter or use `_all` or `*`.
         :arg awareness_attribute: The awareness attribute for which the
             health is required.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg level: Can be one of cluster, indices or shards. Controls
+            statistics. Default is True.
+        :arg level: Can be one of cluster, indexes or shards. Controls
             the details level of the health information returned. Valid choices are
             awareness_attributes, cluster, indices, shards.
-        :arg local: If true, the request retrieves information from the
-            local node only. Defaults to false, which means information is retrieved
-            from the master node. Default is false.
+        :arg local: If `true`, the request retrieves information from
+            the local node only. Defaults to false, which means information is
+            retrieved from the cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -111,11 +112,11 @@ class ClusterClient(NamespacedClient):
             normal, low, languid. Wait until all currently queued events with the
             given priority are processed. Valid choices are high, immediate,
             languid, low, normal, urgent.
-        :arg wait_for_no_initializing_shards: A boolean value which
+        :arg wait_for_no_initializing_shards: A Boolean value which
             controls whether to wait (until the timeout provided) for the cluster to
             have no shard initializations. Defaults to false, which means it will
             not wait for initializing shards.
-        :arg wait_for_no_relocating_shards: A boolean value which
+        :arg wait_for_no_relocating_shards: A Boolean value which
             controls whether to wait (until the timeout provided) for the cluster to
             have no shard relocations. Defaults to false, which means it will not
             wait for relocating shards.
@@ -158,20 +159,22 @@ class ClusterClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: If `true`, the request retrieves information from
             the local node only. If `false`, information is retrieved from the
-            master node. Default is false.
+            cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -209,38 +212,39 @@ class ClusterClient(NamespacedClient):
         :arg metric: Limit the information returned to the specified
             metrics
         :arg index: A comma-separated list of index names; use `_all` or
-            empty string to perform the operation on all indices
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified)
+            empty string to perform the operation on all indexes
+        :arg allow_no_indices: Whether to ignore if a wildcard indexes
+            expression resolves into no concrete indexes. (This includes `_all`
+            string or when no indexes have been specified)
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: Return settings in flat format. Default is
             false.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: Whether specified concrete indices
+            statistics. Default is True.
+        :arg ignore_unavailable: Whether specified concrete indexes
             should be ignored when unavailable (missing or closed)
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Specify timeout for connection
-            to master
+            use `cluster_manager_timeout` instead.): Specify timeout for connection
+            to cluster manager.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg wait_for_metadata_version: Wait for the metadata version to
-            be equal or greater than the specified metadata version
+            be equal or greater than the specified metadata version.
         :arg wait_for_timeout: The maximum time to wait for
-            wait_for_metadata_version before timing out
+            `wait_for_metadata_version` before timing out.
         """
         if index and metric in SKIP_IN_PATH:
             metric = "_all"
@@ -263,6 +267,8 @@ class ClusterClient(NamespacedClient):
     )
     async def stats(
         self,
+        metric: Any = None,
+        index_metric: Any = None,
         node_id: Any = None,
         params: Any = None,
         headers: Any = None,
@@ -271,18 +277,25 @@ class ClusterClient(NamespacedClient):
         Returns high-level overview of cluster statistics.
 
 
+        :arg metric: Limit the information returned to the specified
+            metrics.
+        :arg index_metric: Limit the information returned for indexes
+            metric to the specific index metrics. It can be used only if indexes (or
+            all) metric is specified.
         :arg node_id: Comma-separated list of node filters used to limit
             returned information. Defaults to all nodes in the cluster.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for each node to respond. If a node
@@ -329,25 +342,27 @@ class ClusterClient(NamespacedClient):
             `cancel`, `allocate`)
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
-        :arg dry_run: If true, then the request simulates the operation
-            only and returns the resulting state.
+        :arg dry_run: If `true`, then the request simulates the
+            operation only and returns the resulting state.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg explain: If true, then the response contains an explanation
-            of why the commands can or cannot be executed.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg explain: If `true`, then the response contains an
+            explanation of why the commands can or cannot be executed.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg metric: Limits the information returned to the specified
             metrics.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg retry_failed: If true, then retries allocation of shards
+            response. Default is false.
+        :arg retry_failed: If `true`, then retries allocation of shards
             that are blocked due to too many subsequent allocation failures.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
@@ -383,21 +398,23 @@ class ClusterClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg include_defaults: If `true`, returns default cluster
             settings from the local node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -434,18 +451,20 @@ class ClusterClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: Return settings in flat format. Default is
             false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Explicit operation timeout
@@ -468,13 +487,15 @@ class ClusterClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -504,17 +525,19 @@ class ClusterClient(NamespacedClient):
         :arg body: The index, shard, and primary flag to explain. Empty
             means 'explain the first unassigned shard'
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg include_disk_info: If true, returns information about disk
-            usage and shard sizes. Default is false.
-        :arg include_yes_decisions: If true, returns YES decisions in
+            statistics. Default is True.
+        :arg include_disk_info: If `true`, returns information about
+            disk usage and shard sizes. Default is false.
+        :arg include_yes_decisions: If `true`, returns YES decisions in
             explanation. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -551,17 +574,19 @@ class ClusterClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -603,20 +628,22 @@ class ClusterClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: If `true`, the request retrieves information from
             the local node only. If `false`, information is retrieved from the
-            master node. Default is false.
+            cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -653,7 +680,7 @@ class ClusterClient(NamespacedClient):
             includes the following built-in component templates: `logs-mappings`;
             'logs-settings`; `metrics-mappings`; `metrics-settings`;`synthetics-
             mapping`; `synthetics-settings`. OpenSearch Agent uses these templates
-            to configure backing indices for its data streams. If you use OpenSearch
+            to configure backing indexes for its data streams. If you use OpenSearch
             Agent and want to overwrite one of these templates, set the `version`
             for your replacement template higher than the current version. If you
             don't use OpenSearch Agent and want to disable all built-in component
@@ -665,17 +692,19 @@ class ClusterClient(NamespacedClient):
         :arg create: If `true`, this request cannot replace or update
             existing component templates. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Operation timeout.
@@ -717,20 +746,22 @@ class ClusterClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg local: If true, the request retrieves information from the
-            local node only. Defaults to false, which means information is retrieved
-            from the master node. Default is false.
+            statistics. Default is True.
+        :arg local: If `true`, the request retrieves information from
+            the local node only. Defaults to false, which means information is
+            retrieved from the cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -757,20 +788,22 @@ class ClusterClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg wait_for_removal: Specifies whether to wait for all
             excluded nodes to be removed from the cluster before clearing the voting
             configuration exclusions list. Defaults to true, meaning that all
             excluded nodes must be removed from the cluster before this API takes
-            any action. If set to false then the voting configuration exclusions
+            any action. If set to `false` then the voting configuration exclusions
             list is cleared even if some excluded nodes are still in the cluster.
             Default is True.
         """
@@ -801,19 +834,21 @@ class ClusterClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg node_ids: A comma-separated list of the persistent ids of
             the nodes to exclude from the voting configuration. If specified, you
-            may not also specify node_names.
+            may not also specify `node_names`.
         :arg node_names: A comma-separated list of the names of the
             nodes to exclude from the voting configuration. If specified, you may
-            not also specify node_ids.
+            not also specify `node_ids`.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: When adding a voting configuration exclusion, the
@@ -837,13 +872,15 @@ class ClusterClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -854,6 +891,7 @@ class ClusterClient(NamespacedClient):
     @query_params("error_trace", "filter_path", "human", "pretty", "source")
     async def delete_weighted_routing(
         self,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -862,13 +900,15 @@ class ClusterClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -877,6 +917,7 @@ class ClusterClient(NamespacedClient):
             "/_cluster/routing/awareness/weights",
             params=params,
             headers=headers,
+            body=body,
         )
 
     @query_params("error_trace", "filter_path", "human", "pretty", "source")
@@ -892,13 +933,15 @@ class ClusterClient(NamespacedClient):
 
         :arg awareness_attribute_name: Awareness attribute name.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -933,13 +976,15 @@ class ClusterClient(NamespacedClient):
 
         :arg attribute: Awareness attribute name.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -968,13 +1013,15 @@ class ClusterClient(NamespacedClient):
         :arg awareness_attribute_name: Awareness attribute name.
         :arg awareness_attribute_value: Awareness attribute value.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -999,6 +1046,7 @@ class ClusterClient(NamespacedClient):
     async def put_weighted_routing(
         self,
         attribute: Any,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -1008,13 +1056,15 @@ class ClusterClient(NamespacedClient):
 
         :arg attribute: Awareness attribute name.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1026,4 +1076,5 @@ class ClusterClient(NamespacedClient):
             _make_path("_cluster", "routing", "awareness", attribute, "weights"),
             params=params,
             headers=headers,
+            body=body,
         )

--- a/opensearchpy/_async/client/cluster.py
+++ b/opensearchpy/_async/client/cluster.py
@@ -267,11 +267,11 @@ class ClusterClient(NamespacedClient):
     )
     async def stats(
         self,
-        metric: Any = None,
-        index_metric: Any = None,
         node_id: Any = None,
         params: Any = None,
         headers: Any = None,
+        metric: Any = None,
+        index_metric: Any = None,
     ) -> Any:
         """
         Returns high-level overview of cluster statistics.
@@ -308,7 +308,9 @@ class ClusterClient(NamespacedClient):
             (
                 "/_cluster/stats"
                 if node_id in SKIP_IN_PATH
-                else _make_path("_cluster", "stats", "nodes", node_id)
+                else _make_path(
+                    "_cluster", "stats", metric, index_metric, "nodes", node_id
+                )
             ),
             params=params,
             headers=headers,

--- a/opensearchpy/_async/client/dangling_indices.py
+++ b/opensearchpy/_async/client/dangling_indices.py
@@ -61,25 +61,27 @@ class DanglingIndicesClient(NamespacedClient):
         Deletes the specified dangling index.
 
 
-        :arg index_uuid: The UUID of the dangling index
+        :arg index_uuid: The UUID of the dangling index.
         :arg accept_data_loss: Must be set to true in order to delete
-            the dangling index
+            the dangling index.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Specify timeout for connection
-            to master
+            use `cluster_manager_timeout` instead.): Specify timeout for connection
+            to cluster manager.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
-        :arg timeout: Explicit operation timeout
+        :arg timeout: Explicit operation timeout.
         """
         if index_uuid in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'index_uuid'.")
@@ -112,25 +114,27 @@ class DanglingIndicesClient(NamespacedClient):
         Imports the specified dangling index.
 
 
-        :arg index_uuid: The UUID of the dangling index
+        :arg index_uuid: The UUID of the dangling index.
         :arg accept_data_loss: Must be set to true in order to import
-            the dangling index
+            the dangling index.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Specify timeout for connection
-            to master
+            use `cluster_manager_timeout` instead.): Specify timeout for connection
+            to cluster manager.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
-        :arg timeout: Explicit operation timeout
+        :arg timeout: Explicit operation timeout.
         """
         if index_uuid in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'index_uuid'.")
@@ -146,17 +150,19 @@ class DanglingIndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Returns all dangling indices.
+        Returns all dangling indexes.
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """

--- a/opensearchpy/_async/client/indices.py
+++ b/opensearchpy/_async/client/indices.py
@@ -57,13 +57,15 @@ class IndicesClient(NamespacedClient):
             which the analysis should be performed
         :arg index: The name of the index to scope the operation.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -92,31 +94,33 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Performs the refresh operation in one or more indices.
+        Performs the refresh operation in one or more indexes.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -143,33 +147,35 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Performs the flush operation on one or more indices.
+        Performs the flush operation on one or more indexes.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to flush. Supports wildcards (`*`). To flush all data streams
-            and indices, omit this parameter or use `*` or `_all`.
+            and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg force: If `true`, the request forces a flush even if there
             are no changes to commit to the index.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg wait_if_ongoing: If `true`, the flush operation blocks
@@ -209,17 +215,19 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -269,21 +277,23 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg task_execution_timeout: Explicit task execution timeout,
-            only useful when wait_for_completion is false, defaults to 1h.
+            only useful when `wait_for_completion` is false, defaults to `1h`.
         :arg timeout: Period to wait for a response. If no response is
             received before the timeout expires, the request fails and returns an
             error.
@@ -328,46 +338,47 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Returns information about one or more indices.
+        Returns information about one or more indexes.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             index aliases used to limit the request. Wildcard expressions (*) are
             supported.
-        :arg allow_no_indices: If false, the request returns an error if
-            any wildcard expression, index alias, or _all value targets only missing
-            or closed indices. This behavior applies even if the request targets
-            other open indices. For example, a request targeting foo*,bar* returns
-            an error if an index starts with foo but no index starts with bar.
-            Default is false.
+        :arg allow_no_indices: If `false`, the request returns an error
+            if any wildcard expression, index alias, or `_all` value targets only
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting foo*,bar*
+            returns an error if an index starts with foo but no index starts with
+            bar. Default is false.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard expressions
             can match. If the request can target data streams, this argument
             determines whether wildcard expressions match hidden data streams.
-            Supports comma-separated values, such as open,hidden. Valid choices are
-            all, closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg flat_settings: If true, returns settings in flat format.
+            Supports comma-separated values, such as `open,hidden`.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: If false, requests that target a
+            statistics. Default is True.
+        :arg ignore_unavailable: If `false`, requests that target a
             missing index return an error. Default is false.
-        :arg include_defaults: If true, return all default settings in
+        :arg include_defaults: If `true`, return all default settings in
             the response. Default is false.
-        :arg local: If true, the request retrieves information from the
-            local node only. Defaults to false, which means information is retrieved
-            from the master node. Default is false.
+        :arg local: If `true`, the request retrieves information from
+            the local node only. Defaults to false, which means information is
+            retrieved from the cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -404,42 +415,44 @@ class IndicesClient(NamespacedClient):
         Opens an index.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). By default,
-            you must explicitly name the indices you using to limit the request. To
+            you must explicitly name the indexes you using to limit the request. To
             limit a request using `_all`, `*`, or other wildcard expressions, change
             the `action.destructive_requires_name` setting to false. You can update
             this setting in the `opensearch.yml` file or using the cluster update
             settings API.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg task_execution_timeout: Explicit task execution timeout,
-            only useful when wait_for_completion is false, defaults to 1h.
+            only useful when `wait_for_completion` is false, defaults to `1h`.
         :arg timeout: Period to wait for a response. If no response is
             received before the timeout expires, the request fails and returns an
             error.
@@ -485,29 +498,31 @@ class IndicesClient(NamespacedClient):
             names used to limit the request.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -548,35 +563,37 @@ class IndicesClient(NamespacedClient):
         Deletes an index.
 
 
-        :arg index: Comma-separated list of indices to delete. You
+        :arg index: Comma-separated list of indexes to delete. You
             cannot specify index aliases. By default, this parameter does not
             support wildcards (`*`) or `_all`. To use wildcards or `_all`, set the
             `action.destructive_requires_name` cluster setting to `false`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. Default is false.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. Default is false.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -614,27 +631,29 @@ class IndicesClient(NamespacedClient):
         Returns information about whether a particular index exists.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases. Supports wildcards (`*`).
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. Default is false.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. Default is false.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index. Default is false.
         :arg include_defaults: If `true`, return all default settings in
@@ -642,7 +661,7 @@ class IndicesClient(NamespacedClient):
         :arg local: If `true`, the request retrieves information from
             the local node only. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -683,29 +702,31 @@ class IndicesClient(NamespacedClient):
             string to perform the operation on all indices.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -748,39 +769,41 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Returns mappings for one or more indices.
+        Returns mappings for one or more indexes.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg local: If `true`, the request retrieves information from
             the local node only. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -813,24 +836,26 @@ class IndicesClient(NamespacedClient):
 
         :arg fields: Comma-separated list or wildcard expression of
             fields used to limit returned information.
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg include_defaults: If `true`, return all default settings in
@@ -838,7 +863,7 @@ class IndicesClient(NamespacedClient):
         :arg local: If `true`, the request retrieves information from
             the local node only. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -876,31 +901,33 @@ class IndicesClient(NamespacedClient):
 
         :arg name: Comma-separated list of aliases to check. Supports
             wildcards (`*`).
-        :arg index: Comma-separated list of data streams or indices used
+        :arg index: Comma-separated list of data streams or indexes used
             to limit the request. Supports wildcards (`*`). To target all data
-            streams and indices, omit this parameter or use `*` or `_all`.
+            streams and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, requests that include a
-            missing data stream or index in the target indices or data streams
+            missing data stream or index in the target indexes or data streams
             return an error.
         :arg local: If `true`, the request retrieves information from
             the local node only. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -933,33 +960,35 @@ class IndicesClient(NamespacedClient):
         Returns an alias.
 
 
-        :arg index: Comma-separated list of data streams or indices used
+        :arg index: Comma-separated list of data streams or indexes used
             to limit the request. Supports wildcards (`*`). To target all data
-            streams and indices, omit this parameter or use `*` or `_all`.
+            streams and indexes, omit this parameter or use `*` or `_all`.
         :arg name: Comma-separated list of aliases to retrieve. Supports
             wildcards (`*`). To retrieve all aliases, omit this parameter or use `*`
             or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg local: If `true`, the request retrieves information from
             the local node only. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -991,17 +1020,19 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -1036,24 +1067,26 @@ class IndicesClient(NamespacedClient):
         Deletes an alias.
 
 
-        :arg index: Comma-separated list of data streams or indices used
+        :arg index: Comma-separated list of data streams or indexes used
             to limit the request. Supports wildcards (`*`).
         :arg name: Comma-separated list of aliases to remove. Supports
             wildcards (`*`). To remove all aliases, use `*` or `_all`.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -1094,24 +1127,26 @@ class IndicesClient(NamespacedClient):
         :arg body: The template definition
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
-        :arg create: If true, this request cannot replace or update
+        :arg create: If `true`, this request cannot replace or update
             existing index templates. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg order: Order in which OpenSearch applies this template if
             index matches multiple templates.  Templates with lower 'order' values
             are merged first. Templates with higher 'order' values are merged later,
             overriding templates with lower values.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1152,20 +1187,22 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: Return settings in flat format. Default is
             false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1204,21 +1241,23 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: If `true`, the request retrieves information from
             the local node only. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1251,17 +1290,19 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -1298,48 +1339,49 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Returns settings for one or more indices.
+        Returns settings for one or more indexes.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg name: Comma-separated list or wildcard expression of
             settings to retrieve.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with foo but no index starts with
             `bar`.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
-            separated values, such as `open,hidden`. Valid choices are all, closed,
-            hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            separated values, such as `open,hidden`.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg include_defaults: If `true`, return all default settings in
             the response. Default is false.
         :arg local: If `true`, the request retrieves information from
             the local node only. If `false`, information is retrieved from the
-            master node. Default is false.
+            cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1373,40 +1415,41 @@ class IndicesClient(NamespacedClient):
         Updates the index settings.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with `foo` but no index starts with
             `bar`.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
-            separated values, such as `open,hidden`. Valid choices are all, closed,
-            hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            separated values, such as `open,hidden`.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: Whether specified concrete indices
+            statistics. Default is True.
+        :arg ignore_unavailable: Whether specified concrete indexes
             should be ignored when unavailable (missing or closed).
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg preserve_existing: If `true`, existing index settings
             remain unchanged. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -1452,41 +1495,42 @@ class IndicesClient(NamespacedClient):
 
 
         :arg index: A comma-separated list of index names; use `_all` or
-            empty string to perform the operation on all indices
+            empty string to perform the operation on all indexes
         :arg metric: Limit the information returned the specific
             metrics.
         :arg completion_fields: Comma-separated list or wildcard
-            expressions of fields to include in fielddata and suggest statistics.
+            expressions of fields to include in field data and suggest statistics.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
-            separated values, such as `open,hidden`. Valid choices are all, closed,
-            hidden, none, open.
+            separated values, such as `open,hidden`.
         :arg fielddata_fields: Comma-separated list or wildcard
-            expressions of fields to include in fielddata statistics.
+            expressions of fields to include in field data statistics.
         :arg fields: Comma-separated list or wildcard expressions of
             fields to include in the statistics.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg forbid_closed_indices: If true, statistics are not
-            collected from closed indices. Default is True.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg forbid_closed_indices: If `true`, statistics are not
+            collected from closed indexes. Default is True.
         :arg groups: Comma-separated list of search groups to include in
             the search statistics.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg include_segment_file_sizes: If true, the call reports the
+            statistics. Default is True.
+        :arg include_segment_file_sizes: If `true`, the call reports the
             aggregated disk usage of each one of the Lucene index files (only
             applies if segment stats are requested). Default is false.
-        :arg include_unloaded_segments: If true, the response includes
+        :arg include_unloaded_segments: If `true`, the response includes
             information from segments that are not loaded into memory. Default is
             false.
         :arg level: Indicates whether statistics are aggregated at the
             cluster, index, or shard level. Valid choices are cluster, indices,
             shards.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1515,28 +1559,30 @@ class IndicesClient(NamespacedClient):
         Provides low-level information about segments in a Lucene index.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg verbose: If `true`, the request returns a verbose response.
@@ -1577,15 +1623,15 @@ class IndicesClient(NamespacedClient):
 
 
         :arg body: The query definition specified with the Query DSL
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to search. Supports wildcards (`*`). To search all data streams
-            or indices, omit this parameter or use `*` or `_all`.
+            or indexes, omit this parameter or use `*` or `_all`.
         :arg all_shards: If `true`, the validation is executed on all
             shards instead of one random shard per index.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg analyze_wildcard: If `true`, wildcard and prefix queries
             are analyzed. Default is false.
         :arg analyzer: Analyzer to use for the query string. This
@@ -1597,7 +1643,7 @@ class IndicesClient(NamespacedClient):
             in the query string. This parameter can only be used when the `q` query
             string parameter is specified.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
@@ -1605,16 +1651,18 @@ class IndicesClient(NamespacedClient):
             `open`, `closed`, `hidden`, `none`.
         :arg explain: If `true`, the response returns detailed
             information if an error has occurred.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg lenient: If `true`, format-based query failures (such as
             providing text to a numeric field) in the query string will be ignored.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg q: Query in the Lucene query string syntax.
         :arg rewrite: If `true`, returns a more detailed explanation
             showing the actual Lucene query that will be executed.
@@ -1651,17 +1699,17 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Clears all or specific caches for one or more indices.
+        Clears all or specific caches for one or more indexes.
 
 
-        :arg index: Comma-separated list of indices; use `_all` or empty
-            string to perform the operation on all indices.
+        :arg index: Comma-separated list of indexes; use `_all` or empty
+            string to perform the operation on all indexes.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
@@ -1671,16 +1719,18 @@ class IndicesClient(NamespacedClient):
             `fields` parameter to clear the cache of specific fields only.
         :arg fields: Comma-separated list of field names used to limit
             the `fielddata` parameter.
-        :arg file: If true, clears the unused entries from the file
+        :arg file: If `true`, clears the unused entries from the file
             cache on nodes with the Search role. Default is false.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg query: If `true`, clears the query cache.
         :arg request: If `true`, clears the request cache.
         :arg source: The URL-encoded request definition. Useful for
@@ -1709,21 +1759,23 @@ class IndicesClient(NamespacedClient):
         Returns information about ongoing index shard recoveries.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg active_only: If `true`, the response only includes ongoing
             shard recoveries. Default is false.
         :arg detailed: If `true`, the response includes detailed
             information about shard recoveries. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1750,29 +1802,30 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        The _upgrade API is no longer useful and will be removed.
+        The `_upgrade` API is no longer useful and will be removed.
 
 
-        :arg index: Comma-separated list of indices; use `_all` or empty
-            string to perform the operation on all indices.
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified).
+        :arg index: Comma-separated list of indexes; use `_all` or empty
+            string to perform the operation on all indexes.
+        :arg allow_no_indices: Whether to ignore if a wildcard indexes
+            expression resolves into no concrete indexes. (This includes `_all`
+            string or when no indexes have been specified).
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: Whether specified concrete indices
+            statistics. Default is True.
+        :arg ignore_unavailable: Whether specified concrete indexes
             should be ignored when unavailable (missing or closed).
-        :arg only_ancient_segments: If true, only ancient (an older
+        :arg only_ancient_segments: If `true`, only ancient (an older
             Lucene major release) segments will be upgraded.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg wait_for_completion: Should this request wait until the
@@ -1799,27 +1852,28 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        The _upgrade API is no longer useful and will be removed.
+        The `_upgrade` API is no longer useful and will be removed.
 
 
-        :arg index: Comma-separated list of indices; use `_all` or empty
-            string to perform the operation on all indices.
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified).
+        :arg index: Comma-separated list of indexes; use `_all` or empty
+            string to perform the operation on all indexes.
+        :arg allow_no_indices: Whether to ignore if a wildcard indexes
+            expression resolves into no concrete indexes. (This includes `_all`
+            string or when no indexes have been specified).
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: Whether specified concrete indices
+            statistics. Default is True.
+        :arg ignore_unavailable: Whether specified concrete indexes
             should be ignored when unavailable (missing or closed).
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1845,29 +1899,30 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Provides store information for shard copies of indices.
+        Provides store information for shard copies of indexes.
 
 
-        :arg index: List of data streams, indices, and aliases used to
+        :arg index: List of data streams, indexes, and aliases used to
             limit the request.
-        :arg allow_no_indices: If false, the request returns an error if
-            any wildcard expression, index alias, or _all value targets only missing
-            or closed indices. This behavior applies even if the request targets
-            other open indices.
+        :arg allow_no_indices: If `false`, the request returns an error
+            if any wildcard expression, index alias, or `_all` value targets only
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
-            whether wildcard expressions match hidden data streams. Valid choices
-            are all, closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            whether wildcard expressions match hidden data streams.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: If true, missing or closed indices are
-            not included in the response.
+            statistics. Default is True.
+        :arg ignore_unavailable: If `true`, missing or closed indexes
+            are not included in the response.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg status: List of shard health statuses used to limit the
@@ -1899,26 +1954,27 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Performs the force merge operation on one or more indices.
+        Performs the force merge operation on one or more indexes.
 
 
         :arg index: A comma-separated list of index names; use `_all` or
-            empty string to perform the operation on all indices
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified)
+            empty string to perform the operation on all indexes
+        :arg allow_no_indices: Whether to ignore if a wildcard indexes
+            expression resolves into no concrete indexes. (This includes `_all`
+            string or when no indexes have been specified)
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flush: Specify whether the index should be flushed after
             performing the operation. Default is True.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: Whether specified concrete indices
+            statistics. Default is True.
+        :arg ignore_unavailable: Whether specified concrete indexes
             should be ignored when unavailable (missing or closed)
         :arg max_num_segments: The number of larger segments into which
             smaller segments are merged. Set this parameter to 1 to merge all
@@ -1927,7 +1983,7 @@ class IndicesClient(NamespacedClient):
         :arg only_expunge_deletes: Specify whether the operation should
             only expunge deleted documents
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg primary_only: Specify whether the operation should only
             perform on primary shards. Defaults to false. Default is false.
         :arg source: The URL-encoded request definition. Useful for
@@ -1974,21 +2030,23 @@ class IndicesClient(NamespacedClient):
         :arg copy_settings: whether or not to copy settings from the
             source index. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg task_execution_timeout: Explicit task execution timeout,
-            only useful when wait_for_completion is false, defaults to 1h.
+            only useful when `wait_for_completion` is false, defaults to `1h`.
         :arg timeout: Period to wait for a response. If no response is
             received before the timeout expires, the request fails and returns an
             error.
@@ -2047,21 +2105,23 @@ class IndicesClient(NamespacedClient):
         :arg copy_settings: whether or not to copy settings from the
             source index. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg task_execution_timeout: Explicit task execution timeout,
-            only useful when wait_for_completion is false, defaults to 1h.
+            only useful when `wait_for_completion` is false, defaults to `1h`.
         :arg timeout: Period to wait for a response. If no response is
             received before the timeout expires, the request fails and returns an
             error.
@@ -2120,17 +2180,19 @@ class IndicesClient(NamespacedClient):
             satisfies the specified conditions but does not perform a rollover.
             Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -2172,13 +2234,15 @@ class IndicesClient(NamespacedClient):
             faster.
         :arg body: The data stream definition
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2207,13 +2271,15 @@ class IndicesClient(NamespacedClient):
         :arg name: Comma-separated list of data streams to delete.
             Wildcard (`*`) expressions are supported.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2249,17 +2315,19 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -2302,21 +2370,23 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: Return settings in flat format. Default is
             false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2353,22 +2423,24 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg flat_settings: If true, returns settings in flat format.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg local: If true, the request retrieves information from the
-            local node only. Defaults to false, which means information is retrieved
-            from the master node. Default is false.
+            statistics. Default is True.
+        :arg local: If `true`, the request retrieves information from
+            the local node only. Defaults to false, which means information is
+            retrieved from the cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2407,16 +2479,18 @@ class IndicesClient(NamespacedClient):
         :arg create: If `true`, this request cannot replace or update
             existing index templates. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2468,17 +2542,19 @@ class IndicesClient(NamespacedClient):
             the template is not permanently added or updated in either case; it is
             only used for the simulation. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2508,13 +2584,15 @@ class IndicesClient(NamespacedClient):
             limit the request. Wildcard (`*`) expressions are supported. If omitted,
             all data streams are returned.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2551,23 +2629,25 @@ class IndicesClient(NamespacedClient):
             template for simulation purposes. Default is false.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
-        :arg create: If true, the template passed in the body is only
-            used if no existing templates match the same index patterns. If false,
+        :arg create: If `true`, the template passed in the body is only
+            used if no existing templates match the same index patterns. If `false`,
             the simulation uses the template with the highest priority. Note that
             the template is not permanently added or updated in either case; it is
             only used for the simulation. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2589,25 +2669,27 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Returns information about any matching indices, aliases, and data streams.
+        Returns information about any matching indexes, aliases, and data streams.
 
 
         :arg name: Comma-separated name(s) or index pattern(s) of the
-            indices, aliases, and data streams to resolve. Resources on remote
+            indexes, aliases, and data streams to resolve. Resources on remote
             clusters can be specified using the `<cluster>`:`<name>` syntax.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2642,30 +2724,31 @@ class IndicesClient(NamespacedClient):
         Adds a block to an index.
 
 
-        :arg index: A comma separated list of indices to add a block to
-        :arg block: The block to add (one of read, write, read_only or
-            metadata)
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified)
+        :arg index: A comma separated list of indexes to add a block to.
+        :arg block: The block to add (one of `read`, `write`,
+            `read_only` or `metadata`).
+        :arg allow_no_indices: Whether to ignore if a wildcard indexes
+            expression resolves into no concrete indexes. (This includes `_all`
+            string or when no indexes have been specified).
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: Whether specified concrete indices
-            should be ignored when unavailable (missing or closed)
+            statistics. Default is True.
+        :arg ignore_unavailable: Whether specified concrete indexes
+            should be ignored when unavailable (missing or closed).
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Specify timeout for connection
-            to master
+            use `cluster_manager_timeout` instead.): Specify timeout for connection
+            to cluster manager.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Explicit operation timeout
@@ -2693,13 +2776,15 @@ class IndicesClient(NamespacedClient):
             the request. Wildcard expressions (`*`) are supported. To target all
             data streams in a cluster, omit this parameter or use `*`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2734,25 +2819,27 @@ class IndicesClient(NamespacedClient):
 
         :arg body: The settings for the alias, such as `routing` or
             `filter`
-        :arg index: Comma-separated list of data streams or indices to
+        :arg index: Comma-separated list of data streams or indexes to
             add. Supports wildcards (`*`). Wildcard patterns that match both data
-            streams and indices return an error.
+            streams and indexes return an error.
         :arg name: Alias to update. If the alias doesn't exist, the
             request creates it. Index alias names support date math.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is

--- a/opensearchpy/_async/client/ingest.py
+++ b/opensearchpy/_async/client/ingest.py
@@ -65,17 +65,19 @@ class IngestClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -109,17 +111,19 @@ class IngestClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -164,17 +168,19 @@ class IngestClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -207,13 +213,15 @@ class IngestClient(NamespacedClient):
         :arg id: Pipeline to test. If you don't specify a `pipeline` in
             the request body, this parameter is required.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg verbose: If `true`, the response includes output data for
@@ -230,7 +238,7 @@ class IngestClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    @query_params("error_trace", "filter_path", "human", "pretty", "s", "source")
     async def processor_grok(
         self,
         params: Any = None,
@@ -241,13 +249,16 @@ class IngestClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
+        :arg s: Sort returned patterns by key name. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """

--- a/opensearchpy/_async/client/insights.py
+++ b/opensearchpy/_async/client/insights.py
@@ -18,32 +18,21 @@
 
 from typing import Any
 
-from .utils import SKIP_IN_PATH, NamespacedClient, query_params
+from .utils import NamespacedClient, query_params
 
 
-class RemoteStoreClient(NamespacedClient):
-    @query_params(
-        "cluster_manager_timeout",
-        "error_trace",
-        "filter_path",
-        "human",
-        "pretty",
-        "source",
-        "wait_for_completion",
-    )
-    def restore(
+class InsightsClient(NamespacedClient):
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def top_queries(
         self,
-        body: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Restores from remote store.
+        Retrieves the top queries based on the given metric type (latency, CPU, or
+        memory).
 
 
-        :arg body: Comma-separated list of index IDs
-        :arg cluster_manager_timeout: Operation timeout for connection
-            to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
             errors. Default is false.
         :arg filter_path: Used to reduce the response. This parameter
@@ -56,12 +45,7 @@ class RemoteStoreClient(NamespacedClient):
             response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
-        :arg wait_for_completion: Should this request wait until the
-            operation has completed before returning. Default is false.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
-        return self.transport.perform_request(
-            "POST", "/_remotestore/_restore", params=params, headers=headers, body=body
+        return await self.transport.perform_request(
+            "GET", "/_insights/top_queries", params=params, headers=headers
         )

--- a/opensearchpy/_async/client/list.py
+++ b/opensearchpy/_async/client/list.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+# ------------------------------------------------------------------------------------------
+# THIS CODE IS AUTOMATICALLY GENERATED AND MANUAL EDITS WILL BE LOST
+#
+# To contribute, kindly make modifications in the opensearch-py client generator
+# or in the OpenSearch API specification, and run `nox -rs generate`. See DEVELOPER_GUIDE.md
+# and https://github.com/opensearch-project/opensearch-api-specification for details.
+# -----------------------------------------------------------------------------------------+
+
+
+from typing import Any
+
+from .utils import NamespacedClient, _make_path, query_params
+
+
+class ListClient(NamespacedClient):
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def help(
+        self,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Returns help for the List APIs.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        return await self.transport.perform_request(
+            "GET", "/_list", params=params, headers=headers
+        )
+
+    @query_params(
+        "bytes",
+        "cluster_manager_timeout",
+        "error_trace",
+        "expand_wildcards",
+        "filter_path",
+        "format",
+        "h",
+        "health",
+        "help",
+        "human",
+        "include_unloaded_segments",
+        "local",
+        "master_timeout",
+        "next_token",
+        "pretty",
+        "pri",
+        "s",
+        "size",
+        "sort",
+        "source",
+        "time",
+        "v",
+    )
+    async def indices(
+        self,
+        index: Any = None,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Returns paginated information about indexes including number of primaries and
+        replicas, document counts, disk size.
+
+
+        :arg index: Comma-separated list of data streams, indexes, and
+            aliases used to limit the request. Supports wildcards (`*`). To target
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
+        :arg bytes: The unit used to display byte values. Valid choices
+            are b, g, gb, k, kb, m, mb, p, pb, t, tb.
+        :arg cluster_manager_timeout: Operation timeout for connection
+            to cluster-manager node.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg expand_wildcards: The type of index that wildcard patterns
+            can match.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header, such as
+            `JSON`, `YAML`.
+        :arg h: Comma-separated list of column names to display.
+        :arg health: The health status used to limit returned indexes.
+            By default, the response includes indexes of any health status. Valid
+            choices are green, red, yellow.
+        :arg help: Return help information. Default is false.
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg include_unloaded_segments: If `true`, the response includes
+            information from segments that are not loaded into memory. Default is
+            false.
+        :arg local: Return local information, do not retrieve the state
+            from cluster-manager node. Default is false.
+        :arg master_timeout (Deprecated: To promote inclusive language,
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
+        :arg next_token: Token to retrieve next page of indexes.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg pri: If `true`, the response only includes information from
+            primary shards. Default is false.
+        :arg s: Comma-separated list of column names or column aliases
+            to sort by.
+        :arg size: Maximum number of indexes to be displayed in a page.
+        :arg sort: Defines order in which indexes will be displayed.
+            Accepted values are `asc` and `desc`. If `desc`, most recently created
+            indexes would be displayed first. Valid choices are asc, desc.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        :arg time: The unit used to display time values. Valid choices
+            are d, h, m, micros, ms, nanos, s.
+        :arg v: Verbose mode. Display column headers. Default is false.
+        """
+        return await self.transport.perform_request(
+            "GET", _make_path("_list", "indices", index), params=params, headers=headers
+        )
+
+    @query_params(
+        "bytes",
+        "cluster_manager_timeout",
+        "error_trace",
+        "filter_path",
+        "format",
+        "h",
+        "help",
+        "human",
+        "local",
+        "master_timeout",
+        "next_token",
+        "pretty",
+        "s",
+        "size",
+        "sort",
+        "source",
+        "time",
+        "v",
+    )
+    async def shards(
+        self,
+        index: Any = None,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Returns paginated details of shard allocation on nodes.
+
+
+        :arg index: A comma-separated list of data streams, indexes, and
+            aliases used to limit the request. Supports wildcards (`*`). To target
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
+        :arg bytes: The unit used to display byte values. Valid choices
+            are b, g, gb, k, kb, m, mb, p, pb, t, tb.
+        :arg cluster_manager_timeout: Operation timeout for connection
+            to cluster-manager node.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header, such as
+            `JSON`, `YAML`.
+        :arg h: Comma-separated list of column names to display.
+        :arg help: Return help information. Default is false.
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg local: Return local information, do not retrieve the state
+            from cluster-manager node. Default is false.
+        :arg master_timeout (Deprecated: To promote inclusive language,
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
+        :arg next_token: Token to retrieve next page of shards.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg s: Comma-separated list of column names or column aliases
+            to sort by.
+        :arg size: Maximum number of shards to be displayed in a page.
+        :arg sort: Defines order in which shards will be displayed.
+            Accepted values are `asc` and `desc`. If `desc`, most recently created
+            shards would be displayed first. Valid choices are asc, desc.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        :arg time: The unit in which to display time values. Valid
+            choices are d, h, m, micros, ms, nanos, s.
+        :arg v: Verbose mode. Display column headers. Default is false.
+        """
+        return await self.transport.perform_request(
+            "GET", _make_path("_list", "shards", index), params=params, headers=headers
+        )

--- a/opensearchpy/_async/client/nodes.py
+++ b/opensearchpy/_async/client/nodes.py
@@ -52,18 +52,20 @@ class NodesClient(NamespacedClient):
         Reloads secure settings.
 
 
-        :arg body: An object containing the password for the opensearch
-            keystore
+        :arg body: An object containing the password for the OpenSearch
+            keystore.
         :arg node_id: The names of particular nodes in the cluster to
             target.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -91,6 +93,7 @@ class NodesClient(NamespacedClient):
         self,
         node_id: Any = None,
         metric: Any = None,
+        node_id_or_metric: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -101,17 +104,22 @@ class NodesClient(NamespacedClient):
         :arg node_id: Comma-separated list of node IDs or names used to
             limit returned information.
         :arg metric: Limits the information returned to the specific
-            metrics. Supports a comma-separated list, such as http,ingest.
+            metrics. Supports a comma-separated list, such as `http,ingest`.
+        :arg node_id_or_metric: Limits the information returned to a
+            list of node IDs or specific metrics. Supports a comma-separated list,
+            such as `node1,node2` or `http,ingest`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg flat_settings: If true, returns settings in flat format.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -153,31 +161,33 @@ class NodesClient(NamespacedClient):
             limit returned information.
         :arg metric: Limit the information returned to the specified
             metrics
-        :arg index_metric: Limit the information returned for indices
-            metric to the specific index metrics. It can be used only if indices (or
+        :arg index_metric: Limit the information returned for indexes
+            metric to the specific index metrics. It can be used only if indexes (or
             all) metric is specified.
         :arg completion_fields: Comma-separated list or wildcard
-            expressions of fields to include in fielddata and suggest statistics.
+            expressions of fields to include in field data and suggest statistics.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg fielddata_fields: Comma-separated list or wildcard
-            expressions of fields to include in fielddata statistics.
+            expressions of fields to include in field data statistics.
         :arg fields: Comma-separated list or wildcard expressions of
             fields to include in the statistics.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg groups: Comma-separated list of search groups to include in
             the search statistics.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg include_segment_file_sizes: If true, the call reports the
+            statistics. Default is True.
+        :arg include_segment_file_sizes: If `true`, the call reports the
             aggregated disk usage of each one of the Lucene index files (only
             applies if segment stats are requested). Default is false.
         :arg level: Indicates whether statistics are aggregated at the
             cluster, index, or shard level. Valid choices are cluster, indices,
             shards.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -223,18 +233,20 @@ class NodesClient(NamespacedClient):
         :arg doc_type: The type to sample. Valid choices are block, cpu,
             wait.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_idle_threads: Don't show threads that are in known-
             idle places, such as waiting on a socket select or pulling from an empty
             task queue. Default is True.
         :arg interval: The interval for the second sampling of threads.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg snapshots: Number of samples of thread stacktrace. Default
+            response. Default is false.
+        :arg snapshots: Number of samples of thread stack trace. Default
             is 10.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
@@ -273,13 +285,15 @@ class NodesClient(NamespacedClient):
             metrics. A comma-separated list of the following options: `_all`,
             `rest_actions`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is

--- a/opensearchpy/_async/client/plugins.py
+++ b/opensearchpy/_async/client/plugins.py
@@ -11,6 +11,8 @@ import warnings
 from typing import Any
 
 from ..plugins.alerting import AlertingClient
+from ..plugins.asynchronous_search import AsynchronousSearchClient
+from ..plugins.flow_framework import FlowFrameworkClient
 from ..plugins.index_management import IndexManagementClient
 from ..plugins.knn import KnnClient
 from ..plugins.ml import MlClient
@@ -18,6 +20,7 @@ from ..plugins.notifications import NotificationsClient
 from ..plugins.observability import ObservabilityClient
 from ..plugins.ppl import PplClient
 from ..plugins.query import QueryClient
+from ..plugins.replication import ReplicationClient
 from ..plugins.rollups import RollupsClient
 from ..plugins.sql import SqlClient
 from ..plugins.transforms import TransformsClient
@@ -26,6 +29,7 @@ from .utils import NamespacedClient
 
 
 class PluginsClient(NamespacedClient):
+    asynchronous_search: Any
     alerting: Any
     index_management: Any
     knn: Any
@@ -41,6 +45,9 @@ class PluginsClient(NamespacedClient):
     def __init__(self, client: Client) -> None:
         super().__init__(client)
 
+        self.replication = ReplicationClient(client)
+        self.flow_framework = FlowFrameworkClient(client)
+        self.asynchronous_search = AsynchronousSearchClient(client)
         self.alerting = AlertingClient(client)
         self.index_management = IndexManagementClient(client)
         self.knn = KnnClient(client)
@@ -59,6 +66,9 @@ class PluginsClient(NamespacedClient):
         # Issue : https://github.com/opensearch-project/opensearch-py/issues/90#issuecomment-1003396742
 
         plugins = [
+            "replication",
+            "flow_framework",
+            "asynchronous_search",
             "alerting",
             "index_management",
             "knn",

--- a/opensearchpy/_async/client/remote_store.py
+++ b/opensearchpy/_async/client/remote_store.py
@@ -45,13 +45,15 @@ class RemoteStoreClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg wait_for_completion: Should this request wait until the

--- a/opensearchpy/_async/client/search_pipeline.py
+++ b/opensearchpy/_async/client/search_pipeline.py
@@ -45,13 +45,15 @@ class SearchPipelineClient(NamespacedClient):
         :arg cluster_manager_timeout: operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -82,13 +84,15 @@ class SearchPipelineClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Operation timeout.
@@ -127,13 +131,15 @@ class SearchPipelineClient(NamespacedClient):
         :arg cluster_manager_timeout: operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Operation timeout.

--- a/opensearchpy/_async/client/security.py
+++ b/opensearchpy/_async/client/security.py
@@ -35,13 +35,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -61,13 +63,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -95,13 +99,15 @@ class SecurityClient(NamespacedClient):
 
         :arg action_group: The name of the action group to retrieve.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -128,13 +134,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -158,13 +166,15 @@ class SecurityClient(NamespacedClient):
 
         :arg action_group: The name of the action group to delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -195,13 +205,15 @@ class SecurityClient(NamespacedClient):
         :arg action_group: The name of the action group to create or
             replace.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -231,13 +243,15 @@ class SecurityClient(NamespacedClient):
 
         :arg action_group: The name of the action group to update.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -265,13 +279,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -299,13 +315,15 @@ class SecurityClient(NamespacedClient):
 
         :arg username: The name of the user to retrieve.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -330,13 +348,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -360,13 +380,15 @@ class SecurityClient(NamespacedClient):
 
         :arg username: The name of the user to delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -394,13 +416,15 @@ class SecurityClient(NamespacedClient):
 
         :arg username: The name of the user to be created.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -430,13 +454,15 @@ class SecurityClient(NamespacedClient):
 
         :arg username: The name of the user to update.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -464,13 +490,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -497,13 +525,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -528,13 +558,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -555,13 +587,15 @@ class SecurityClient(NamespacedClient):
 
         :arg role: The name of the role to delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -589,13 +623,15 @@ class SecurityClient(NamespacedClient):
 
         :arg role: The name of the role to be created.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -625,13 +661,15 @@ class SecurityClient(NamespacedClient):
 
         :arg role: The name of the role to update.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -659,13 +697,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -692,13 +732,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -723,13 +765,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -753,13 +797,15 @@ class SecurityClient(NamespacedClient):
 
         :arg role: The name of the role whose mapping needs to delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -787,13 +833,15 @@ class SecurityClient(NamespacedClient):
 
         :arg role: The name of the role to create a role mapping for.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -823,13 +871,15 @@ class SecurityClient(NamespacedClient):
 
         :arg role: The name of the role to update role-mapping for.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -857,13 +907,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -891,13 +943,15 @@ class SecurityClient(NamespacedClient):
 
         :arg tenant: The name of the tenant to retrieve.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -922,13 +976,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -949,13 +1005,15 @@ class SecurityClient(NamespacedClient):
 
         :arg tenant: The name of the tenant to delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -983,13 +1041,15 @@ class SecurityClient(NamespacedClient):
 
         :arg tenant: The name of the tenant to be created.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1019,13 +1079,15 @@ class SecurityClient(NamespacedClient):
 
         :arg tenant: The name of the tenant to update.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1053,13 +1115,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1085,13 +1149,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1111,17 +1177,19 @@ class SecurityClient(NamespacedClient):
     ) -> Any:
         """
         Adds or updates the existing configuration using the REST API. Only accessible
-        by admins and users with rest api access and only when put or patch is enabled.
+        by admins and users with REST API access and only when put or patch is enabled.
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1144,19 +1212,21 @@ class SecurityClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        A PATCH call is used to update the existing configuration using the REST API.
-        Only accessible by admins and users with rest api access and only when put or
+        A `PATCH` call is used to update the existing configuration using the REST API.
+        Only accessible by admins and users with REST API access and only when put or
         patch is enabled.
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1183,14 +1253,16 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg show_all: A boolean flag to include/exclude static nodes DN
+            response. Default is false.
+        :arg show_all: A Boolean flag to include/exclude static nodes DN
             from final result.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
@@ -1210,13 +1282,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1235,13 +1309,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1263,13 +1339,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1291,13 +1369,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1316,16 +1396,18 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg mode: A flag to indicate whether service should consider
             security-plugin's status before returning health response. `strict` mode
-            indicates service should check security plugin status.
+            indicates service should check Security plugin status.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1344,13 +1426,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1370,13 +1454,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1403,13 +1489,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1437,13 +1525,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1478,13 +1568,15 @@ class SecurityClient(NamespacedClient):
 
         :arg auth_type: The type of current authentication request.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg verbose: Indicates whether a verbose response should be
@@ -1505,13 +1597,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1530,13 +1624,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1556,13 +1652,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1585,13 +1683,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1611,18 +1711,20 @@ class SecurityClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Creates or replaces the allowlisted APIs. Accessible via Super Admin
+        Creates or replaces the permitted APIs. Accessible using Super Admin
         certificate or REST API permission.
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1650,13 +1752,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1685,13 +1789,15 @@ class SecurityClient(NamespacedClient):
 
         :arg username: The name of the user to be created.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1722,13 +1828,15 @@ class SecurityClient(NamespacedClient):
         :arg cluster_name: The cluster-name to delete from list of
             distinguished names.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1757,13 +1865,15 @@ class SecurityClient(NamespacedClient):
 
         :arg username: The name of the user to delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1789,13 +1899,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1824,13 +1936,15 @@ class SecurityClient(NamespacedClient):
         :arg username: The name of the user for whom an auth token is to
             be vended.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1854,19 +1968,21 @@ class SecurityClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Generates authorization token for the given user. Legacy API.  Not Implemented.
+        Generates authorization token for the given user. Legacy API. Not Implemented.
 
 
         :arg username: The name of the user for whom an auth token is to
             be vended.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1891,13 +2007,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1916,13 +2034,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1945,14 +2065,16 @@ class SecurityClient(NamespacedClient):
         :arg cluster_name: The cluster-name to retrieve nodes DN setting
             for.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg show_all: A boolean flag to include/exclude static nodes DN
+            response. Default is false.
+        :arg show_all: A Boolean flag to include/exclude static nodes DN
             from final result.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
@@ -1980,13 +2102,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2008,14 +2132,16 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg show_dn: A boolean flag to indicate whether all domain
+            response. Default is false.
+        :arg show_dn: A Boolean flag to indicate whether all domain
             names should be returned.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
@@ -2036,13 +2162,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2066,13 +2194,15 @@ class SecurityClient(NamespacedClient):
 
         :arg username: The name of the user to retrieve.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2097,13 +2227,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2122,13 +2254,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2148,13 +2282,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2182,15 +2318,17 @@ class SecurityClient(NamespacedClient):
         super-admins and with rest-api permissions when enabled.
 
 
-        :arg cluster_name: The cluster-name to update nodesDn value.
+        :arg cluster_name: The cluster name to update `nodesDn` value.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2218,13 +2356,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2244,13 +2384,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2272,16 +2414,18 @@ class SecurityClient(NamespacedClient):
         enabled.
 
 
-        :arg cluster_name: The cluster-name to create/update nodesDn
+        :arg cluster_name: The cluster-name to create/update `nodesDn`
             value for.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2311,16 +2455,18 @@ class SecurityClient(NamespacedClient):
         to v7.
 
 
-        :arg accept_invalid: A boolean flag to indicate whether invalid
+        :arg accept_invalid: A Boolean flag to indicate whether invalid
             v6 configuration should be allowed.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2339,13 +2485,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2366,13 +2514,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2401,13 +2551,15 @@ class SecurityClient(NamespacedClient):
         :arg cert_type: The type of certificates (HTTP, TRANSPORT, ALL)
             to retrieve from all nodes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: The maximum duration, in seconds, to be spent to
@@ -2443,13 +2595,15 @@ class SecurityClient(NamespacedClient):
         :arg cert_type: The type of certificates (HTTP, TRANSPORT, ALL)
             to retrieve for a node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: The maximum duration, in seconds, to be spent to

--- a/opensearchpy/_async/client/snapshot.py
+++ b/opensearchpy/_async/client/snapshot.py
@@ -69,17 +69,19 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg wait_for_completion: If `true`, the request returns a
@@ -123,16 +125,18 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -172,31 +176,33 @@ class SnapshotClient(NamespacedClient):
         :arg repository: Comma-separated list of snapshot repository
             names used to limit the request. Wildcard (*) expressions are supported.
         :arg snapshot: Comma-separated list of snapshot names to
-            retrieve. Also accepts wildcards (*). - To get information about all
-            snapshots in a registered repository, use a wildcard (*) or _all. - To
-            get information about any snapshots that are currently running, use
-            _current.
+            retrieve. Also accepts wildcards (`*`). - To get information about all
+            snapshots in a registered repository, use a wildcard (`*`) or `_all`. -
+            To get information about any snapshots that are currently running, use
+            `_current`.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: If false, the request returns an error
-            for any snapshots that are unavailable. Default is false.
+            statistics. Default is True.
+        :arg ignore_unavailable: If `false`, the request returns an
+            error for any snapshots that are unavailable. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
-        :arg verbose: If true, returns additional information about each
-            snapshot such as the version of OpenSearch which took the snapshot, the
-            start and end times of the snapshot, and the number of shards
+        :arg verbose: If `true`, returns additional information about
+            each snapshot such as the version of OpenSearch which took the snapshot,
+            the start and end times of the snapshot, and the number of shards
             snapshotted.
         """
         for param in (repository, snapshot):
@@ -235,16 +241,18 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Explicit operation timeout
@@ -283,18 +291,20 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -329,16 +339,18 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Explicit operation timeout
@@ -384,16 +396,18 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg wait_for_completion: Should this request wait until the
@@ -437,19 +451,21 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: Whether to ignore unavailable
-            snapshots, defaults to false which means a SnapshotMissingException is
+            snapshots, defaults to `false` which means a SnapshotMissingException is
             thrown Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -484,16 +500,18 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Explicit operation timeout
@@ -532,16 +550,18 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response.
@@ -575,7 +595,7 @@ class SnapshotClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Clones indices from one snapshot into another snapshot in the same repository.
+        Clones indexes from one snapshot into another snapshot in the same repository.
 
 
         :arg repository: A repository name
@@ -585,16 +605,18 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """

--- a/opensearchpy/_async/client/tasks.py
+++ b/opensearchpy/_async/client/tasks.py
@@ -69,13 +69,15 @@ class TasksClient(NamespacedClient):
         :arg detailed: If `true`, the response includes detailed
             information about shard recoveries. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg group_by: Key used to group tasks in the response. Valid
             choices are nodes, none, parents.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg nodes: Comma-separated list of node IDs or names to limit
             the returned information; use `_local` to return information from the
             node you're connecting to, leave empty to get information from all
@@ -84,7 +86,7 @@ class TasksClient(NamespacedClient):
             information. To return all tasks, omit this parameter or use a value of
             `-1`.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -122,16 +124,18 @@ class TasksClient(NamespacedClient):
         :arg actions: Comma-separated list or wildcard expression of
             actions used to limit the request.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg nodes: Comma-separated list of node IDs or names used to
             limit the request.
         :arg parent_task_id: Parent task ID used to limit the tasks.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg wait_for_completion: Should the request block until the
@@ -166,13 +170,15 @@ class TasksClient(NamespacedClient):
 
         :arg task_id: ID of the task.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is

--- a/opensearchpy/_async/client/wlm.py
+++ b/opensearchpy/_async/client/wlm.py
@@ -18,21 +18,19 @@
 
 from typing import Any
 
-from ..client.utils import SKIP_IN_PATH, NamespacedClient, query_params
+from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
-class PplClient(NamespacedClient):
-    @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
-    )
-    async def explain(
+class WlmClient(NamespacedClient):
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def create_query_group(
         self,
         body: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Shows how a query is executed against OpenSearch.
+        Creates a new query group and sets the resource limits for the new query group.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -41,14 +39,10 @@ class PplClient(NamespacedClient):
             takes a comma-separated list of filters. It supports using wildcards to
             match any field or part of a field’s name. You can also exclude fields
             with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
         :arg human: Whether to return human readable values for
             statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
             response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -56,113 +50,111 @@ class PplClient(NamespacedClient):
             raise ValueError("Empty value passed for a required argument 'body'.")
 
         return await self.transport.perform_request(
-            "POST", "/_plugins/_ppl/_explain", params=params, headers=headers, body=body
+            "PUT", "/_wlm/query_group", params=params, headers=headers, body=body
         )
 
-    @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
-    )
-    async def get_stats(
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def delete_query_group(
         self,
+        name: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Collect metrics for the plugin within the interval.
+        Deletes the specified query group.
 
 
+        :arg name: The name of the query group.
         :arg error_trace: Whether to include the stack trace of returned
             errors. Default is false.
         :arg filter_path: Used to reduce the response. This parameter
             takes a comma-separated list of filters. It supports using wildcards to
             match any field or part of a field’s name. You can also exclude fields
             with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
         :arg human: Whether to return human readable values for
             statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
             response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if name in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'name'.")
+
+        return await self.transport.perform_request(
+            "DELETE",
+            _make_path("_wlm", "query_group", name),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def get_query_group(
+        self,
+        name: Any = None,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Retrieves the specified query group. If no query group is specified, all query
+        groups in the cluster are retrieved.
+
+
+        :arg name: The name of the query group.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
         return await self.transport.perform_request(
-            "GET", "/_plugins/_ppl/stats", params=params, headers=headers
+            "GET",
+            _make_path("_wlm", "query_group", name),
+            params=params,
+            headers=headers,
         )
 
-    @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
-    )
-    async def post_stats(
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def update_query_group(
         self,
+        name: Any,
         body: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        By a stats endpoint, you are able to collect metrics for the plugin within the
-        interval.
+        Updates the specified query group.
 
 
+        :arg name: The name of the query group.
         :arg error_trace: Whether to include the stack trace of returned
             errors. Default is false.
         :arg filter_path: Used to reduce the response. This parameter
             takes a comma-separated list of filters. It supports using wildcards to
             match any field or part of a field’s name. You can also exclude fields
             with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
         :arg human: Whether to return human readable values for
             statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
             response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
+        for param in (name, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
 
         return await self.transport.perform_request(
-            "POST", "/_plugins/_ppl/stats", params=params, headers=headers, body=body
-        )
-
-    @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
-    )
-    async def query(
-        self,
-        body: Any,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Send a PPL query to the PPL plugin.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
-        return await self.transport.perform_request(
-            "POST", "/_plugins/_ppl", params=params, headers=headers, body=body
+            "PUT",
+            _make_path("_wlm", "query_group", name),
+            params=params,
+            headers=headers,
+            body=body,
         )

--- a/opensearchpy/_async/plugins/asynchronous_search.py
+++ b/opensearchpy/_async/plugins/asynchronous_search.py
@@ -18,21 +18,19 @@
 
 from typing import Any
 
-from ..client.utils import SKIP_IN_PATH, NamespacedClient, query_params
+from ..client.utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
-class PplClient(NamespacedClient):
-    @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
-    )
-    async def explain(
+class AsynchronousSearchClient(NamespacedClient):
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def delete(
         self,
-        body: Any,
+        id: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Shows how a query is executed against OpenSearch.
+        Delete asynchronous search.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -41,34 +39,76 @@ class PplClient(NamespacedClient):
             takes a comma-separated list of filters. It supports using wildcards to
             match any field or part of a field’s name. You can also exclude fields
             with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
         :arg human: Whether to return human readable values for
             statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
             response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
+        if id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'id'.")
 
         return await self.transport.perform_request(
-            "POST", "/_plugins/_ppl/_explain", params=params, headers=headers, body=body
+            "DELETE",
+            _make_path("_plugins", "_asynchronous_search", id),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def get(
+        self,
+        id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Get partial responses from asynchronous search.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'id'.")
+
+        return await self.transport.perform_request(
+            "GET",
+            _make_path("_plugins", "_asynchronous_search", id),
+            params=params,
+            headers=headers,
         )
 
     @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
+        "error_trace",
+        "filter_path",
+        "human",
+        "index",
+        "keep_alive",
+        "keep_on_completion",
+        "pretty",
+        "source",
+        "wait_for_completion_timeout",
     )
-    async def get_stats(
+    async def search(
         self,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Collect metrics for the plugin within the interval.
+        Perform an asynchronous search.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -77,33 +117,37 @@ class PplClient(NamespacedClient):
             takes a comma-separated list of filters. It supports using wildcards to
             match any field or part of a field’s name. You can also exclude fields
             with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
         :arg human: Whether to return human readable values for
             statistics. Default is True.
+        :arg index: The name of the index to be searched.
+        :arg keep_alive: The amount of time that the result is saved in
+            the cluster.
+        :arg keep_on_completion: Whether you want to save the results in
+            the cluster after the search is complete.
         :arg pretty: Whether to pretty format the returned JSON
             response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
+        :arg wait_for_completion_timeout: The amount of time that you
+            plan to wait for the results.
         """
         return await self.transport.perform_request(
-            "GET", "/_plugins/_ppl/stats", params=params, headers=headers
+            "POST",
+            "/_plugins/_asynchronous_search",
+            params=params,
+            headers=headers,
+            body=body,
         )
 
-    @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
-    )
-    async def post_stats(
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def stats(
         self,
-        body: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        By a stats endpoint, you are able to collect metrics for the plugin within the
-        interval.
+        Monitoring of asynchronous searches that are running, completed, and/or
+        persisted.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -112,57 +156,16 @@ class PplClient(NamespacedClient):
             takes a comma-separated list of filters. It supports using wildcards to
             match any field or part of a field’s name. You can also exclude fields
             with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
         :arg human: Whether to return human readable values for
             statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
             response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
         return await self.transport.perform_request(
-            "POST", "/_plugins/_ppl/stats", params=params, headers=headers, body=body
-        )
-
-    @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
-    )
-    async def query(
-        self,
-        body: Any,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Send a PPL query to the PPL plugin.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
-        return await self.transport.perform_request(
-            "POST", "/_plugins/_ppl", params=params, headers=headers, body=body
+            "GET",
+            "/_plugins/_asynchronous_search/stats",
+            params=params,
+            headers=headers,
         )

--- a/opensearchpy/_async/plugins/flow_framework.py
+++ b/opensearchpy/_async/plugins/flow_framework.py
@@ -21,16 +21,216 @@ from typing import Any
 from ..client.utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
-class ObservabilityClient(NamespacedClient):
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def create_object(
+class FlowFrameworkClient(NamespacedClient):
+    @query_params(
+        "error_trace",
+        "filter_path",
+        "human",
+        "pretty",
+        "provision",
+        "reprovision",
+        "source",
+        "update_fields",
+        "use_case",
+        "validation",
+    )
+    async def create(
         self,
         body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Creates a new observability object.
+        Create a workflow.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        :arg use_case: To use a workflow template, specify it in the
+            `use_case` query parameter when creating a workflow.
+        """
+        return await self.transport.perform_request(
+            "POST",
+            "/_plugins/_flow_framework/workflow",
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params(
+        "clear_status", "error_trace", "filter_path", "human", "pretty", "source"
+    )
+    async def delete(
+        self,
+        workflow_id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Delete a workflow.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if workflow_id in SKIP_IN_PATH:
+            raise ValueError(
+                "Empty value passed for a required argument 'workflow_id'."
+            )
+
+        return await self.transport.perform_request(
+            "DELETE",
+            _make_path("_plugins", "_flow_framework", "workflow", workflow_id),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params(
+        "allow_delete", "error_trace", "filter_path", "human", "pretty", "source"
+    )
+    async def deprovision(
+        self,
+        workflow_id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Deprovision workflow's resources when you no longer need it.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if workflow_id in SKIP_IN_PATH:
+            raise ValueError(
+                "Empty value passed for a required argument 'workflow_id'."
+            )
+
+        return await self.transport.perform_request(
+            "POST",
+            _make_path(
+                "_plugins", "_flow_framework", "workflow", workflow_id, "_deprovision"
+            ),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def get(
+        self,
+        workflow_id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Get a workflow.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if workflow_id in SKIP_IN_PATH:
+            raise ValueError(
+                "Empty value passed for a required argument 'workflow_id'."
+            )
+
+        return await self.transport.perform_request(
+            "GET",
+            _make_path("_plugins", "_flow_framework", "workflow", workflow_id),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("all", "error_trace", "filter_path", "human", "pretty", "source")
+    async def get_status(
+        self,
+        workflow_id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Get the provisioning deployment status until it is complete.
+
+
+        :arg all: The all parameter specifies whether the response
+            should return all fields. Default is false.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if workflow_id in SKIP_IN_PATH:
+            raise ValueError(
+                "Empty value passed for a required argument 'workflow_id'."
+            )
+
+        return await self.transport.perform_request(
+            "GET",
+            _make_path(
+                "_plugins", "_flow_framework", "workflow", workflow_id, "_status"
+            ),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params(
+        "error_trace", "filter_path", "human", "pretty", "source", "workflow_step"
+    )
+    async def get_steps(
+        self,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Get a list of workflow steps.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -47,25 +247,64 @@ class ObservabilityClient(NamespacedClient):
             libraries that do not accept a request body for non-POST requests.
         """
         return await self.transport.perform_request(
+            "GET",
+            "/_plugins/_flow_framework/workflow/_steps",
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def provision(
+        self,
+        workflow_id: Any,
+        body: Any = None,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Provisioning a workflow. This API is also executed when the Create or Update
+        Workflow API is called with the provision parameter set to true.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if workflow_id in SKIP_IN_PATH:
+            raise ValueError(
+                "Empty value passed for a required argument 'workflow_id'."
+            )
+
+        return await self.transport.perform_request(
             "POST",
-            "/_plugins/_observability/object",
+            _make_path(
+                "_plugins", "_flow_framework", "workflow", workflow_id, "_provision"
+            ),
             params=params,
             headers=headers,
             body=body,
         )
 
     @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def delete_object(
+    async def search(
         self,
-        object_id: Any,
+        body: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Deletes specific observability object specified by ID.
+        Search for workflows by using a query matching a field.
 
 
-        :arg object_id: The ID of the Observability Object.
         :arg error_trace: Whether to include the stack trace of returned
             errors. Default is false.
         :arg filter_path: Used to reduce the response. This parameter
@@ -79,160 +318,76 @@ class ObservabilityClient(NamespacedClient):
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if object_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'object_id'.")
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
 
         return await self.transport.perform_request(
-            "DELETE",
-            _make_path("_plugins", "_observability", "object", object_id),
+            "POST",
+            "/_plugins/_flow_framework/workflow/_search",
             params=params,
             headers=headers,
+            body=body,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def search_state(
+        self,
+        body: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Search for workflows by using a query matching a field.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+
+        return await self.transport.perform_request(
+            "POST",
+            "/_plugins/_flow_framework/workflow/state/_search",
+            params=params,
+            headers=headers,
+            body=body,
         )
 
     @query_params(
         "error_trace",
         "filter_path",
         "human",
-        "objectId",
-        "objectIdList",
         "pretty",
+        "provision",
+        "reprovision",
         "source",
+        "update_fields",
+        "use_case",
+        "validation",
     )
-    async def delete_objects(
+    async def update(
         self,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Deletes specific observability objects specified by ID or a list of IDs.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg objectId: The ID of a single Observability Object to
-            delete.
-        :arg objectIdList: A comma-separated list of Observability
-            Object IDs to delete.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        return await self.transport.perform_request(
-            "DELETE", "/_plugins/_observability/object", params=params, headers=headers
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def get_localstats(
-        self,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Retrieves Local Stats of all observability objects.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        return await self.transport.perform_request(
-            "GET",
-            "/_plugins/_observability/_local/stats",
-            params=params,
-            headers=headers,
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def get_object(
-        self,
-        object_id: Any,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Retrieves specific observability object specified by ID.
-
-
-        :arg object_id: The ID of the Observability Object.
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        if object_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'object_id'.")
-
-        return await self.transport.perform_request(
-            "GET",
-            _make_path("_plugins", "_observability", "object", object_id),
-            params=params,
-            headers=headers,
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def list_objects(
-        self,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Retrieves list of all observability objects.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        return await self.transport.perform_request(
-            "GET", "/_plugins/_observability/object", params=params, headers=headers
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def update_object(
-        self,
-        object_id: Any,
+        workflow_id: Any,
         body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Updates an existing observability object.
+        Update a workflow. You can only update a complete workflow if it has not yet
+        been provisioned.
 
 
-        :arg object_id: The ID of the Observability Object.
         :arg error_trace: Whether to include the stack trace of returned
             errors. Default is false.
         :arg filter_path: Used to reduce the response. This parameter
@@ -245,13 +400,17 @@ class ObservabilityClient(NamespacedClient):
             response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
+        :arg use_case: To use a workflow template, specify it in the
+            `use_case` query parameter when creating a workflow.
         """
-        if object_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'object_id'.")
+        if workflow_id in SKIP_IN_PATH:
+            raise ValueError(
+                "Empty value passed for a required argument 'workflow_id'."
+            )
 
         return await self.transport.perform_request(
             "PUT",
-            _make_path("_plugins", "_observability", "object", object_id),
+            _make_path("_plugins", "_flow_framework", "workflow", workflow_id),
             params=params,
             headers=headers,
             body=body,

--- a/opensearchpy/_async/plugins/knn.py
+++ b/opensearchpy/_async/plugins/knn.py
@@ -35,13 +35,15 @@ class KnnClient(NamespacedClient):
 
         :arg model_id: The id of the model.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -68,13 +70,15 @@ class KnnClient(NamespacedClient):
 
         :arg model_id: The id of the model.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -147,15 +151,15 @@ class KnnClient(NamespacedClient):
         Use an OpenSearch query to search for models in the index.
 
 
-        :arg _source: True or false to return the _source field or not,
-            or a list of fields to return.
+        :arg _source: Set to `true` or `false` to return the `_source`
+            field or not, or a list of fields to return.
         :arg _source_excludes: List of fields to exclude from the
-            returned _source field.
+            returned `_source` field.
         :arg _source_includes: List of fields to extract and return from
-            the _source field.
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified).
+            the `_source` field.
+        :arg allow_no_indices: Whether to ignore if a wildcard indexes
+            expression resolves into no concrete indexes. (This includes `_all`
+            string or when no indexes have been specified).
         :arg allow_partial_search_results: Indicate if an error should
             be returned if there is a partial search failure or timeout. Default is
             True.
@@ -177,20 +181,21 @@ class KnnClient(NamespacedClient):
         :arg docvalue_fields: Comma-separated list of fields to return
             as the docvalue representation of a field for each hit.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
+            concrete indexes that are open, closed or both.
         :arg explain: Specify whether to return detailed information
             about score computation as part of a hit.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg from_: Starting offset. Default is 0.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_throttled: Whether specified concrete, expanded or
-            aliased indices should be ignored when throttled.
-        :arg ignore_unavailable: Whether specified concrete indices
+            aliased indexes should be ignored when throttled.
+        :arg ignore_unavailable: Whether specified concrete indexes
             should be ignored when unavailable (missing or closed).
         :arg lenient: Specify whether format-based query failures (such
             as providing text to a numeric field) should be ignored.
@@ -203,18 +208,18 @@ class KnnClient(NamespacedClient):
             number of shards the search request expands to exceeds the threshold.
             This filter round-trip can limit the number of shards significantly if
             for instance a shard can not match any documents based on its rewrite
-            method ie. if date filters are mandatory to match but the shard bounds
-            and the query are disjoint.
+            method, that is if date filters are mandatory to match but the shard
+            bounds and the query are disjoint.
         :arg preference: Specify the node or shard the operation should
             be performed on. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg q: Query in the Lucene query string syntax.
         :arg request_cache: Specify if request cache should be used for
             this request or not, defaults to index level setting.
-        :arg rest_total_hits_as_int: Indicates whether hits.total should
-            be rendered as an integer or an object in the rest search response.
-            Default is false.
+        :arg rest_total_hits_as_int: Indicates whether `hits.total`
+            should be rendered as an integer or an object in the rest search
+            response. Default is false.
         :arg routing: Comma-separated list of specific routing values.
         :arg scroll: Specify how long a consistent view of the index
             should be maintained for scrolled search.
@@ -280,13 +285,15 @@ class KnnClient(NamespacedClient):
         :arg stat: Comma-separated list of stats to retrieve; use `_all`
             or empty string to retrieve all stats.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Operation timeout.
@@ -315,14 +322,16 @@ class KnnClient(NamespacedClient):
 
         :arg model_id: The id of the model.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg preference: Preferred node to execute training.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -349,16 +358,18 @@ class KnnClient(NamespacedClient):
         specified indexes.
 
 
-        :arg index: Comma-separated list of indices; use `_all` or empty
-            string to perform the operation on all indices.
+        :arg index: Comma-separated list of indexes; use `_all` or empty
+            string to perform the operation on all indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """

--- a/opensearchpy/_async/plugins/ml.py
+++ b/opensearchpy/_async/plugins/ml.py
@@ -34,13 +34,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -66,13 +68,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -100,13 +104,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -134,13 +140,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -166,13 +174,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -196,13 +206,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -226,13 +238,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -256,13 +270,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -288,13 +304,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -306,4 +324,172 @@ class MlClient(NamespacedClient):
             _make_path("_plugins", "_ml", "models", model_id, "_undeploy"),
             params=params,
             headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def create_connector(
+        self,
+        body: Any = None,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Creates a standalone connector.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        return await self.transport.perform_request(
+            "POST",
+            "/_plugins/_ml/connectors/_create",
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def delete_agent(
+        self,
+        agent_id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Delete an agent.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if agent_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'agent_id'.")
+
+        return await self.transport.perform_request(
+            "DELETE",
+            _make_path("_plugins", "_ml", "agents", agent_id),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def delete_connector(
+        self,
+        connector_id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Deletes a standalone connector.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if connector_id in SKIP_IN_PATH:
+            raise ValueError(
+                "Empty value passed for a required argument 'connector_id'."
+            )
+
+        return await self.transport.perform_request(
+            "DELETE",
+            _make_path("_plugins", "_ml", "connectors", connector_id),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def delete_task(
+        self,
+        task_id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Deletes a task.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if task_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'task_id'.")
+
+        return await self.transport.perform_request(
+            "DELETE",
+            _make_path("_plugins", "_ml", "tasks", task_id),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def register_agents(
+        self,
+        body: Any = None,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Register an agent.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        return await self.transport.perform_request(
+            "POST",
+            "/_plugins/_ml/agents/_register",
+            params=params,
+            headers=headers,
+            body=body,
         )

--- a/opensearchpy/_async/plugins/query.py
+++ b/opensearchpy/_async/plugins/query.py
@@ -35,13 +35,15 @@ class QueryClient(NamespacedClient):
 
         :arg datasource_name: The Name of the DataSource to delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -70,13 +72,15 @@ class QueryClient(NamespacedClient):
 
         :arg datasource_name: The Name of the DataSource to retrieve.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -104,13 +108,15 @@ class QueryClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -133,13 +139,15 @@ class QueryClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -159,13 +167,15 @@ class QueryClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """

--- a/opensearchpy/_async/plugins/replication.py
+++ b/opensearchpy/_async/plugins/replication.py
@@ -21,16 +21,47 @@ from typing import Any
 from ..client.utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
-class NotificationsClient(NamespacedClient):
+class ReplicationClient(NamespacedClient):
     @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def create_config(
+    async def autofollow_stats(
+        self,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Gets information about auto-follow activity and any replication rules
+        configured on the specified cluster.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        return await self.transport.perform_request(
+            "GET",
+            "/_plugins/_replication/autofollow_stats",
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def create_replication_rule(
         self,
         body: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Create channel configuration.
+        Automatically starts replication on indexes matching a specified pattern.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -51,273 +82,21 @@ class NotificationsClient(NamespacedClient):
 
         return await self.transport.perform_request(
             "POST",
-            "/_plugins/_notifications/configs",
+            "/_plugins/_replication/_autofollow",
             params=params,
             headers=headers,
             body=body,
         )
 
     @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def delete_config(
+    async def delete_replication_rule(
         self,
-        config_id: Any,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Delete a channel configuration.
-
-
-        :arg config_id: The ID of the channel configuration to delete.
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        if config_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'config_id'.")
-
-        return await self.transport.perform_request(
-            "DELETE",
-            _make_path("_plugins", "_notifications", "configs", config_id),
-            params=params,
-            headers=headers,
-        )
-
-    @query_params(
-        "config_id",
-        "config_id_list",
-        "error_trace",
-        "filter_path",
-        "human",
-        "pretty",
-        "source",
-    )
-    async def delete_configs(
-        self,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Delete multiple channel configurations.
-
-
-        :arg config_id: The ID of the channel configuration to delete.
-        :arg config_id_list: A comma-separated list of channel IDs to
-            delete.
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        return await self.transport.perform_request(
-            "DELETE", "/_plugins/_notifications/configs", params=params, headers=headers
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def get_config(
-        self,
-        config_id: Any,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Get a specific channel configuration.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        if config_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'config_id'.")
-
-        return await self.transport.perform_request(
-            "GET",
-            _make_path("_plugins", "_notifications", "configs", config_id),
-            params=params,
-            headers=headers,
-        )
-
-    @query_params(
-        "chime.url",
-        "chime.url.keyword",
-        "config_id",
-        "config_id_list",
-        "config_type",
-        "created_time_ms",
-        "description",
-        "description.keyword",
-        "email.email_account_id",
-        "email.email_group_id_list",
-        "email.recipient_list.recipient",
-        "email.recipient_list.recipient.keyword",
-        "email_group.recipient_list.recipient",
-        "email_group.recipient_list.recipient.keyword",
-        "error_trace",
-        "filter_path",
-        "human",
-        "is_enabled",
-        "last_updated_time_ms",
-        "microsoft_teams.url",
-        "microsoft_teams.url.keyword",
-        "name",
-        "name.keyword",
-        "pretty",
-        "query",
-        "ses_account.from_address",
-        "ses_account.from_address.keyword",
-        "ses_account.region",
-        "ses_account.role_arn",
-        "ses_account.role_arn.keyword",
-        "slack.url",
-        "slack.url.keyword",
-        "smtp_account.from_address",
-        "smtp_account.from_address.keyword",
-        "smtp_account.host",
-        "smtp_account.host.keyword",
-        "smtp_account.method",
-        "sns.role_arn",
-        "sns.role_arn.keyword",
-        "sns.topic_arn",
-        "sns.topic_arn.keyword",
-        "source",
-        "text_query",
-        "webhook.url",
-        "webhook.url.keyword",
-    )
-    async def get_configs(
-        self,
-        body: Any = None,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Get multiple channel configurations with filtering.
-
-
-        :arg config_id: Notification configuration ID.
-        :arg config_id_list: Notification configuration IDs.
-        :arg config_type: Type of notification configuration. Valid
-            choices are chime, email, email_group, microsoft_teams, ses_account,
-            slack, smtp_account, sns, webhook.
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        return await self.transport.perform_request(
-            "GET",
-            "/_plugins/_notifications/configs",
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def list_features(
-        self,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        List supported channel configurations.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        return await self.transport.perform_request(
-            "GET", "/_plugins/_notifications/features", params=params, headers=headers
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def send_test(
-        self,
-        config_id: Any,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Send a test notification.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        if config_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'config_id'.")
-
-        return await self.transport.perform_request(
-            "GET",
-            _make_path("_plugins", "_notifications", "feature", "test", config_id),
-            params=params,
-            headers=headers,
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def update_config(
-        self,
-        config_id: Any,
         body: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Update channel configuration.
+        Deletes the specified replication rule.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -333,26 +112,25 @@ class NotificationsClient(NamespacedClient):
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        for param in (config_id, body):
-            if param in SKIP_IN_PATH:
-                raise ValueError("Empty value passed for a required argument.")
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
 
         return await self.transport.perform_request(
-            "PUT",
-            _make_path("_plugins", "_notifications", "configs", config_id),
+            "DELETE",
+            "/_plugins/_replication/_autofollow",
             params=params,
             headers=headers,
             body=body,
         )
 
     @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def list_channels(
+    async def follower_stats(
         self,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        List created notification channels.
+        Gets information about follower (syncing) indexes on a specified cluster.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -369,5 +147,267 @@ class NotificationsClient(NamespacedClient):
             libraries that do not accept a request body for non-POST requests.
         """
         return await self.transport.perform_request(
-            "GET", "/_plugins/_notifications/channels", params=params, headers=headers
+            "GET",
+            "/_plugins/_replication/follower_stats",
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def leader_stats(
+        self,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Gets information about replicated leader indexes on a specified cluster.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        return await self.transport.perform_request(
+            "GET", "/_plugins/_replication/leader_stats", params=params, headers=headers
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def pause(
+        self,
+        index: Any,
+        body: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Pauses replication of the leader index.
+
+
+        :arg index: Name of the data stream, index, or index alias to
+            perform bulk actions on.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        for param in (index, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return await self.transport.perform_request(
+            "POST",
+            _make_path("_plugins", "_replication", index, "_pause"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def resume(
+        self,
+        index: Any,
+        body: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Resumes replication of the leader index.
+
+
+        :arg index: Name of the data stream, index, or index alias to
+            perform bulk actions on.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        for param in (index, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return await self.transport.perform_request(
+            "POST",
+            _make_path("_plugins", "_replication", index, "_resume"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def start(
+        self,
+        index: Any,
+        body: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Initiate replication of an index from the leader cluster to the follower
+        cluster.
+
+
+        :arg index: Name of the data stream, index, or index alias to
+            perform bulk actions on.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        for param in (index, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return await self.transport.perform_request(
+            "PUT",
+            _make_path("_plugins", "_replication", index, "_start"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def status(
+        self,
+        index: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Gets the status of index replication.
+
+
+        :arg index: Name of the data stream, index, or index alias to
+            perform bulk actions on.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if index in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'index'.")
+
+        return await self.transport.perform_request(
+            "GET",
+            _make_path("_plugins", "_replication", index, "_status"),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def stop(
+        self,
+        index: Any,
+        body: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Terminates replication and converts the follower index to a standard index.
+
+
+        :arg index: Name of the data stream, index, or index alias to
+            perform bulk actions on.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        for param in (index, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return await self.transport.perform_request(
+            "POST",
+            _make_path("_plugins", "_replication", index, "_stop"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    async def update_settings(
+        self,
+        index: Any,
+        body: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Updates settings on the follower index.
+
+
+        :arg index: Name of the data stream, index, or index alias to
+            perform bulk actions on.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        for param in (index, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return await self.transport.perform_request(
+            "PUT",
+            _make_path("_plugins", "_replication", index, "_update"),
+            params=params,
+            headers=headers,
+            body=body,
         )

--- a/opensearchpy/_async/plugins/rollups.py
+++ b/opensearchpy/_async/plugins/rollups.py
@@ -35,13 +35,15 @@ class RollupsClient(NamespacedClient):
 
         :arg id: Rollup to access
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -68,13 +70,15 @@ class RollupsClient(NamespacedClient):
 
         :arg id: Rollup to access
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -101,13 +105,15 @@ class RollupsClient(NamespacedClient):
 
         :arg id: Rollup to access
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -143,17 +149,19 @@ class RollupsClient(NamespacedClient):
 
         :arg id: Rollup to access
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg if_primary_term: Only perform the operation if the document
             has this primary term.
         :arg if_seq_no: Only perform the operation if the document has
             this sequence number.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -181,13 +189,15 @@ class RollupsClient(NamespacedClient):
 
         :arg id: Rollup to access
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -214,13 +224,15 @@ class RollupsClient(NamespacedClient):
 
         :arg id: Rollup to access
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """

--- a/opensearchpy/_async/plugins/sql.py
+++ b/opensearchpy/_async/plugins/sql.py
@@ -18,7 +18,7 @@
 
 from typing import Any
 
-from ..client.utils import SKIP_IN_PATH, NamespacedClient, query_params
+from ..client.utils import NamespacedClient, query_params
 
 
 class SqlClient(NamespacedClient):
@@ -27,7 +27,7 @@ class SqlClient(NamespacedClient):
     )
     async def close(
         self,
-        body: Any,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -36,23 +36,22 @@ class SqlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg sanitize: Specifies whether to escape special characters in
             the results Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
         return await self.transport.perform_request(
             "POST", "/_plugins/_sql/close", params=params, headers=headers, body=body
         )
@@ -62,7 +61,7 @@ class SqlClient(NamespacedClient):
     )
     async def explain(
         self,
-        body: Any,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -71,23 +70,22 @@ class SqlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg sanitize: Specifies whether to escape special characters in
             the results Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
         return await self.transport.perform_request(
             "POST", "/_plugins/_sql/_explain", params=params, headers=headers, body=body
         )
@@ -105,15 +103,17 @@ class SqlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg sanitize: Specifies whether to escape special characters in
             the results Default is True.
         :arg source: The URL-encoded request definition. Useful for
@@ -128,7 +128,7 @@ class SqlClient(NamespacedClient):
     )
     async def post_stats(
         self,
-        body: Any,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -138,23 +138,22 @@ class SqlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg sanitize: Specifies whether to escape special characters in
             the results Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
         return await self.transport.perform_request(
             "POST", "/_plugins/_sql/stats", params=params, headers=headers, body=body
         )
@@ -164,7 +163,7 @@ class SqlClient(NamespacedClient):
     )
     async def query(
         self,
-        body: Any,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -173,23 +172,22 @@ class SqlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg sanitize: Specifies whether to escape special characters in
             the results Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
         return await self.transport.perform_request(
             "POST", "/_plugins/_sql", params=params, headers=headers, body=body
         )
@@ -197,7 +195,7 @@ class SqlClient(NamespacedClient):
     @query_params("error_trace", "filter_path", "format", "human", "pretty", "source")
     async def settings(
         self,
-        body: Any,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -206,21 +204,20 @@ class SqlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
         return await self.transport.perform_request(
             "PUT",
             "/_plugins/_query/settings",

--- a/opensearchpy/_async/plugins/transforms.py
+++ b/opensearchpy/_async/plugins/transforms.py
@@ -35,13 +35,15 @@ class TransformsClient(NamespacedClient):
 
         :arg id: Transform to delete
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -68,13 +70,15 @@ class TransformsClient(NamespacedClient):
 
         :arg id: Transform to explain
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -101,13 +105,15 @@ class TransformsClient(NamespacedClient):
 
         :arg id: Transform to access
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -124,6 +130,7 @@ class TransformsClient(NamespacedClient):
     @query_params("error_trace", "filter_path", "human", "pretty", "source")
     async def preview(
         self,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -132,18 +139,24 @@ class TransformsClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
         return await self.transport.perform_request(
-            "GET", "/_plugins/_transform/_preview", params=params, headers=headers
+            "POST",
+            "/_plugins/_transform/_preview",
+            params=params,
+            headers=headers,
+            body=body,
         )
 
     @query_params(
@@ -163,23 +176,25 @@ class TransformsClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Create an index transform, or update a transform if if_seq_no and
-        if_primary_term are provided.
+        Create an index transform, or update a transform if `if_seq_no` and
+        `if_primary_term` are provided.
 
 
         :arg id: Transform to create/update
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg if_primary_term: Only perform the operation if the document
             has this primary term.
         :arg if_seq_no: Only perform the operation if the document has
             this sequence number.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -216,14 +231,16 @@ class TransformsClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg from_: The starting transform to return. Default is `0`.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg search: The search term to use to filter results.
         :arg size: Specifies the number of transforms to return. Default
             is `10`.
@@ -254,13 +271,15 @@ class TransformsClient(NamespacedClient):
 
         :arg id: Transform to start
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -287,13 +306,15 @@ class TransformsClient(NamespacedClient):
 
         :arg id: Transform to stop
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """

--- a/opensearchpy/client/__init__.py
+++ b/opensearchpy/client/__init__.py
@@ -46,6 +46,8 @@ from .features import FeaturesClient
 from .http import HttpClient
 from .indices import IndicesClient
 from .ingest import IngestClient
+from .insights import InsightsClient
+from .list import ListClient
 from .nodes import NodesClient
 from .plugins import PluginsClient
 from .remote import RemoteClient
@@ -55,6 +57,7 @@ from .security import SecurityClient
 from .snapshot import SnapshotClient
 from .tasks import TasksClient
 from .utils import SKIP_IN_PATH, _bulk_body, _make_path, query_params
+from .wlm import WlmClient
 
 logger = logging.getLogger("opensearch")
 
@@ -109,7 +112,7 @@ class OpenSearch(Client):
         ])
 
     If using SSL, there are several parameters that control how we deal with
-    certificates (see :class:`~opensearchpy.Urllib3HttpConnection` for
+    certificates (see :class:`~opensearchpy.AIOHttpConnection` for
     detailed description of the options)::
 
         client = OpenSearch(
@@ -123,7 +126,7 @@ class OpenSearch(Client):
         )
 
     If using SSL, but don't verify the certs, a warning message is showed
-    optionally (see :class:`~opensearchpy.Urllib3HttpConnection` for
+    optionally (see :class:`~opensearchpy.AIOHttpConnection` for
     detailed description of the options)::
 
         client = OpenSearch(
@@ -132,12 +135,14 @@ class OpenSearch(Client):
             use_ssl=True,
             # no verify SSL certificates
             verify_certs=False,
+            # don't verify the hostname in the certificate
+            ssl_assert_hostname=False,
             # don't show warnings about ssl certs verification
             ssl_show_warn=False
         )
 
     SSL client authentication is supported
-    (see :class:`~opensearchpy.Urllib3HttpConnection` for
+    (see :class:`~opensearchpy.AIOHttpConnection` for
     detailed description of the options)::
 
         client = OpenSearch(
@@ -214,6 +219,9 @@ class OpenSearch(Client):
         super().__init__(hosts, transport_class, **kwargs)
 
         # namespaced clients for compatibility with API names
+        self.wlm = WlmClient(self)
+        self.list = ListClient(self)
+        self.insights = InsightsClient(self)
         self.search_pipeline = SearchPipelineClient(self)
         self.cat = CatClient(self)
         self.cluster = ClusterClient(self)
@@ -267,13 +275,15 @@ class OpenSearch(Client):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -295,13 +305,15 @@ class OpenSearch(Client):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -344,18 +356,20 @@ class OpenSearch(Client):
         :arg id: Unique identifier for the document.
         :arg body: The document
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pipeline: ID of the pipeline to use to preprocess incoming
             documents. If the index has a default ingest pipeline specified, then
             setting the value to `_none` disables the default ingest pipeline for
             this request. If a final pipeline is configured it will always run,
             regardless of the value of this parameter.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg refresh: If `true`, OpenSearch refreshes the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` do
@@ -422,11 +436,13 @@ class OpenSearch(Client):
         :arg body: The document
         :arg id: Unique identifier for the document.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg if_primary_term: Only perform the operation if the document
             has this primary term.
         :arg if_seq_no: Only perform the operation if the document has
@@ -443,7 +459,7 @@ class OpenSearch(Client):
             this request. If a final pipeline is configured it will always run,
             regardless of the value of this parameter.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg refresh: If `true`, OpenSearch refreshes the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` do
@@ -518,18 +534,20 @@ class OpenSearch(Client):
         :arg _source_includes: A comma-separated list of source fields
             to include in the response.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pipeline: ID of the pipeline to use to preprocess incoming
             documents. If the index has a default ingest pipeline specified, then
             setting the value to `_none` disables the default ingest pipeline for
             this request. If a final pipeline is configured it will always run,
             regardless of the value of this parameter.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg refresh: If `true`, OpenSearch refreshes the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` do
@@ -573,17 +591,19 @@ class OpenSearch(Client):
 
 
         :arg body: Comma-separated list of scroll IDs to clear if none
-            was specified via the scroll_id parameter
+            was specified using the `scroll_id` parameter
         :arg scroll_id: Comma-separated list of scroll IDs to clear. To
             clear all scroll IDs, use `_all`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -632,13 +652,13 @@ class OpenSearch(Client):
 
         :arg body: Query to restrict the results specified with the
             Query DSL (optional)
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to search. Supports wildcards (`*`). To search all data streams
-            and indices, omit this parameter or use `*` or `_all`.
+            and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg analyze_wildcard: If `true`, wildcard and prefix queries
             are analyzed. This parameter can only be used when the `q` query string
             parameter is specified. Default is false.
@@ -652,18 +672,19 @@ class OpenSearch(Client):
             in the query string. This parameter can only be used when the `q` query
             string parameter is specified.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
-            separated values, such as `open,hidden`. Valid choices are all, closed,
-            hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            separated values, such as `open,hidden`.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_throttled: If `true`, concrete, expanded or aliased
-            indices are ignored when frozen.
+            indexes are ignored when frozen.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg lenient: If `true`, format-based query failures (such as
@@ -673,7 +694,7 @@ class OpenSearch(Client):
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg q: Query in the Lucene query string syntax.
         :arg routing: Custom value used to route operations to a
             specific shard.
@@ -720,17 +741,19 @@ class OpenSearch(Client):
         :arg index: Name of the target index.
         :arg id: Unique identifier for the document.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg if_primary_term: Only perform the operation if the document
             has this primary term.
         :arg if_seq_no: Only perform the operation if the document has
             this sequence number.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg refresh: If `true`, OpenSearch refreshes the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` do
@@ -810,20 +833,20 @@ class OpenSearch(Client):
         Deletes documents matching the provided query.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to search. Supports wildcards (`*`). To search all data streams
-            or indices, omit this parameter or use `*` or `_all`.
+            or indexes, omit this parameter or use `*` or `_all`.
         :arg body: The search definition using the Query DSL
-        :arg _source: True or false to return the _source field or not,
-            or a list of fields to return.
+        :arg _source: Set to `true` or `false` to return the `_source`
+            field or not, or a list of fields to return.
         :arg _source_excludes: List of fields to exclude from the
-            returned _source field.
+            returned `_source` field.
         :arg _source_includes: List of fields to extract and return from
-            the _source field.
+            the `_source` field.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with `foo` but no index starts with
             `bar`.
         :arg analyze_wildcard: If `true`, wildcard and prefix queries
@@ -836,17 +859,19 @@ class OpenSearch(Client):
         :arg df: Field to use as default where no field prefix is given
             in the query string.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg from_: Starting offset. Default is 0.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg lenient: If `true`, format-based query failures (such as
@@ -856,7 +881,7 @@ class OpenSearch(Client):
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg q: Query in the Lucene query string syntax.
         :arg refresh: If `true`, OpenSearch refreshes all shards
             involved in the delete by query after the request completes.
@@ -874,7 +899,7 @@ class OpenSearch(Client):
         :arg search_type: The type of the search operation. Available
             options: `query_then_fetch`, `dfs_query_then_fetch`. Valid choices are
             dfs_query_then_fetch, query_then_fetch.
-        :arg size: Deprecated, please use `max_docs` instead.
+        :arg size: Deprecated, use `max_docs` instead.
         :arg slices: The number of slices this task should be divided
             into. Valid choices are auto.
         :arg sort: A comma-separated list of <field>:<direction> pairs.
@@ -888,7 +913,7 @@ class OpenSearch(Client):
             caution. OpenSearch applies this parameter to each shard handling the
             request. When possible, let OpenSearch perform early termination
             automatically. Avoid specifying this parameter for requests that target
-            data streams with backing indices across multiple data tiers.
+            data streams with backing indexes across multiple data tiers.
         :arg timeout: Period each deletion request waits for active
             shards.
         :arg version: If `true`, returns the document version as part of
@@ -932,13 +957,15 @@ class OpenSearch(Client):
 
         :arg task_id: The ID for the task.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg requests_per_second: The throttle for this request in sub-
             requests per second.
         :arg source: The URL-encoded request definition. Useful for
@@ -978,17 +1005,19 @@ class OpenSearch(Client):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -1030,7 +1059,7 @@ class OpenSearch(Client):
         Returns information about whether a document exists in an index.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases. Supports wildcards (`*`).
         :arg id: Identifier of the document.
         :arg _source: `true` or `false` to return the `_source` field or
@@ -1040,15 +1069,17 @@ class OpenSearch(Client):
         :arg _source_includes: A comma-separated list of source fields
             to include in the response.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg realtime: If `true`, the request is real-time as opposed to
             near-real-time.
         :arg refresh: If `true`, OpenSearch refreshes all shards
@@ -1102,7 +1133,7 @@ class OpenSearch(Client):
         Returns information about whether a document source exists in an index.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases. Supports wildcards (`*`).
         :arg id: Identifier of the document.
         :arg _source: `true` or `false` to return the `_source` field or
@@ -1112,16 +1143,18 @@ class OpenSearch(Client):
         :arg _source_includes: A comma-separated list of source fields
             to include in the response.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg realtime: If true, the request is real-time as opposed to
+            response. Default is false.
+        :arg realtime: If `true`, the request is real-time as opposed to
             near-real-time.
         :arg refresh: If `true`, OpenSearch refreshes all shards
             involved in the delete by query after the request completes.
@@ -1180,8 +1213,8 @@ class OpenSearch(Client):
             index name can be provided to this parameter.
         :arg id: Defines the document ID.
         :arg body: The query definition using the Query DSL
-        :arg _source: True or false to return the `_source` field or
-            not, or a list of fields to return.
+        :arg _source: Set to `true` or `false` to return the `_source`
+            field or not, or a list of fields to return.
         :arg _source_excludes: A comma-separated list of source fields
             to exclude from the response.
         :arg _source_includes: A comma-separated list of source fields
@@ -1196,17 +1229,19 @@ class OpenSearch(Client):
         :arg df: Field to use as default where no field prefix is given
             in the query string. Default is _all.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg lenient: If `true`, format-based query failures (such as
             providing text to a numeric field) in the query string will be ignored.
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg q: Query in the Lucene query string syntax.
         :arg routing: Custom value used to route operations to a
             specific shard.
@@ -1246,38 +1281,39 @@ class OpenSearch(Client):
     ) -> Any:
         """
         Returns the information about the capabilities of fields among multiple
-        indices.
+        indexes.
 
 
         :arg body: An index filter specified with the Query DSL
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (*). To target all
-            data streams and indices, omit this parameter or use * or _all.
-        :arg allow_no_indices: If false, the request returns an error if
-            any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            data streams and indexes, omit this parameter or use * or `_all`.
+        :arg allow_no_indices: If `false`, the request returns an error
+            if any wildcard expression, index alias, or `_all` value targets only
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with foo but no index starts with
             bar.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
-            separated values, such as `open,hidden`. Valid choices are all, closed,
-            hidden, none, open.
+            separated values, such as `open,hidden`.
         :arg fields: Comma-separated list of fields to retrieve
             capabilities for. Wildcard (`*`) expressions are supported.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: If `true`, missing or closed indices
+            statistics. Default is True.
+        :arg ignore_unavailable: If `true`, missing or closed indexes
             are not included in the response.
-        :arg include_unmapped: If true, unmapped fields are included in
-            the response. Default is false.
+        :arg include_unmapped: If `true`, unmapped fields are included
+            in the response. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1319,27 +1355,29 @@ class OpenSearch(Client):
 
         :arg index: Name of the index that contains the document.
         :arg id: Unique identifier of the document.
-        :arg _source: True or false to return the _source field or not,
-            or a list of fields to return.
+        :arg _source: Set to `true` or `false` to return the `_source`
+            field or not, or a list of fields to return.
         :arg _source_excludes: A comma-separated list of source fields
             to exclude in the response.
         :arg _source_includes: A comma-separated list of source fields
             to include in the response.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg realtime: If `true`, the request is real-time as opposed to
             near-real-time.
-        :arg refresh: If true, OpenSearch refreshes the affected shards
-            to make this operation visible to search. If false, do nothing with
-            refreshes.
+        :arg refresh: If `true`, OpenSearch refreshes the affected
+            shards to make this operation visible to search. If `false`, do nothing
+            with refreshes.
         :arg routing: Target the specified primary shard.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
@@ -1350,8 +1388,9 @@ class OpenSearch(Client):
         :arg version: Explicit version number for concurrency control.
             The specified version must match the current version of the document for
             the request to succeed.
-        :arg version_type: Specific version type: internal, external,
-            external_gte. Valid choices are external, external_gte, force, internal.
+        :arg version_type: Specific version type: `internal`,
+            `external`, `external_gte`. Valid choices are external, external_gte,
+            force, internal.
         """
         for param in (index, id):
             if param in SKIP_IN_PATH:
@@ -1384,16 +1423,18 @@ class OpenSearch(Client):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Specify timeout for connection
+            use `cluster_manager_timeout` instead.): Specify timeout for connection
             to master
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1433,35 +1474,38 @@ class OpenSearch(Client):
 
         :arg index: Name of the index that contains the document.
         :arg id: Unique identifier of the document.
-        :arg _source: True or false to return the _source field or not,
-            or a list of fields to return.
+        :arg _source: Set to `true` or `false` to return the `_source`
+            field or not, or a list of fields to return.
         :arg _source_excludes: A comma-separated list of source fields
             to exclude in the response.
         :arg _source_includes: A comma-separated list of source fields
             to include in the response.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg realtime: Boolean) If true, the request is real-time as
+            response. Default is false.
+        :arg realtime: Boolean) If `true`, the request is real-time as
             opposed to near-real-time.
-        :arg refresh: If true, OpenSearch refreshes the affected shards
-            to make this operation visible to search. If false, do nothing with
-            refreshes.
+        :arg refresh: If `true`, OpenSearch refreshes the affected
+            shards to make this operation visible to search. If `false`, do nothing
+            with refreshes.
         :arg routing: Target the specified primary shard.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg version: Explicit version number for concurrency control.
             The specified version must match the current version of the document for
             the request to succeed.
-        :arg version_type: Specific version type: internal, external,
-            external_gte. Valid choices are external, external_gte, force, internal.
+        :arg version_type: Specific version type. One of `internal`,
+            `external`, `external_gte`. Valid choices are external, external_gte,
+            force, internal.
         """
         for param in (index, id):
             if param in SKIP_IN_PATH:
@@ -1505,8 +1549,8 @@ class OpenSearch(Client):
         :arg index: Name of the index to retrieve documents from when
             `ids` are specified, or when a document in the `docs` array does not
             specify an index.
-        :arg _source: True or false to return the `_source` field or
-            not, or a list of fields to return.
+        :arg _source: Set to `true` or `false` to return the `_source`
+            field or not, or a list of fields to return.
         :arg _source_excludes: A comma-separated list of source fields
             to exclude from the response. You can also use this parameter to exclude
             fields from the subset specified in `_source_includes` query parameter.
@@ -1516,15 +1560,17 @@ class OpenSearch(Client):
             using the `_source_excludes` query parameter. If the `_source` parameter
             is `false`, this parameter is ignored.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg realtime: If `true`, the request is real-time as opposed to
             near-real-time.
         :arg refresh: If `true`, the request refreshes relevant shards
@@ -1574,17 +1620,19 @@ class OpenSearch(Client):
 
         :arg body: The request definitions (metadata-search request
             definition pairs), separated by newlines
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             index aliases to search.
-        :arg ccs_minimize_roundtrips: If true, network roundtrips
+        :arg ccs_minimize_roundtrips: If `true`, network round-trips
             between the coordinating node and remote clusters are minimized for
             cross-cluster search requests. Default is True.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg max_concurrent_searches: Maximum number of concurrent
             searches the multi search API can execute.
         :arg max_concurrent_shard_requests: Maximum number of concurrent
@@ -1598,10 +1646,10 @@ class OpenSearch(Client):
             on its rewrite method i.e., if date filters are mandatory to match but
             the shard bounds and the query are disjoint.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg rest_total_hits_as_int: If true, hits.total are returned as
-            an integer in the response. Defaults to false, which returns an object.
-            Default is false.
+            response. Default is false.
+        :arg rest_total_hits_as_int: If `true`, `hits.total` are
+            returned as an integer in the response. Defaults to false, which returns
+            an object. Default is false.
         :arg search_type: Indicates whether global term and document
             frequencies should be used when scoring returned documents. Valid
             choices are dfs_query_then_fetch, query_then_fetch.
@@ -1647,21 +1695,23 @@ class OpenSearch(Client):
 
         :arg body: The request definitions (metadata-search request
             definition pairs), separated by newlines
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to search. Supports wildcards (`*`). To search all data streams
-            and indices, omit this parameter or use `*`.
+            and indexes, omit this parameter or use `*`.
         :arg ccs_minimize_roundtrips: If `true`, network round-trips are
             minimized for cross-cluster search requests. Default is True.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg max_concurrent_searches: Maximum number of concurrent
             searches the API can run.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg rest_total_hits_as_int: If `true`, the response returns
             `hits.total` as an integer. If `false`, it returns `hits.total` as an
             object. Default is false.
@@ -1720,7 +1770,7 @@ class OpenSearch(Client):
             document ids. See documentation.
         :arg index: Name of the index that contains the documents.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg field_statistics: If `true`, the response includes the
             document count, sum of document frequencies, and sum of total term
             frequencies. Default is True.
@@ -1728,10 +1778,12 @@ class OpenSearch(Client):
             fields to include in the statistics. Used as the default list unless a
             specific field list is provided in the `completion_fields` or
             `fielddata_fields` parameters.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ids: A comma-separated list of documents ids. You must
             define ids as parameter or set "ids" or "docs" in the request body
         :arg offsets: If `true`, the response includes term offsets.
@@ -1743,14 +1795,14 @@ class OpenSearch(Client):
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg realtime: If true, the request is real-time as opposed to
+            response. Default is false.
+        :arg realtime: If `true`, the request is real-time as opposed to
             near-real-time. Default is True.
         :arg routing: Custom value used to route operations to a
             specific shard.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
-        :arg term_statistics: If true, the response includes term
+        :arg term_statistics: If `true`, the response includes term
             frequency and document frequency. Default is false.
         :arg version: If `true`, returns the document version as part of
             a hit.
@@ -1794,17 +1846,19 @@ class OpenSearch(Client):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -1848,30 +1902,32 @@ class OpenSearch(Client):
 
         :arg body: The ranking evaluation search definition, including
             search requests, document ratings and ranking metric definition.
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             index aliases used to limit the request. Wildcard (`*`) expressions are
-            supported. To target all data streams and indices in a cluster, omit
+            supported. To target all data streams and indexes in a cluster, omit
             this parameter or use `_all` or `*`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with `foo` but no index starts with
             `bar`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: If `true`, missing or closed indices
+            statistics. Default is True.
+        :arg ignore_unavailable: If `true`, missing or closed indexes
             are not included in the response.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg search_type: Search operation type
+            response. Default is false.
+        :arg search_type: Search operation type Valid choices are
+            dfs_query_then_fetch, query_then_fetch.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1916,15 +1972,17 @@ class OpenSearch(Client):
         :arg body: The search definition using the Query DSL and the
             prototype for the index request.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg max_docs: Maximum number of documents to process. By
             default, all documents.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg refresh: If `true`, the request refreshes affected shards
             to make this operation visible to search.
         :arg requests_per_second: The throttle for this request in sub-
@@ -1967,13 +2025,15 @@ class OpenSearch(Client):
 
         :arg task_id: Identifier for the task.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg requests_per_second: The throttle for this request in sub-
             requests per second.
         :arg source: The URL-encoded request definition. Useful for
@@ -2001,17 +2061,19 @@ class OpenSearch(Client):
         Allows to use the Mustache language to pre-render a search definition.
 
 
-        :arg body: The search definition template and its params
+        :arg body: The search definition template and its parameters.
         :arg id: ID of the search template to render. If no `source` is
             specified, this or the `id` request body parameter is required.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2036,13 +2098,15 @@ class OpenSearch(Client):
 
         :arg body: The script to execute
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2078,16 +2142,18 @@ class OpenSearch(Client):
             parameter.
         :arg scroll_id: The scroll ID for scrolled search
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg rest_total_hits_as_int: If true, the API response's
-            hit.total property is returned as an integer. If false, the API
-            response's hit.total property is returned as an object. Default is
+            response. Default is false.
+        :arg rest_total_hits_as_int: If `true`, the API response's
+            `hit.total` property is returned as an integer. If `false`, the API
+            response's `hit.total` property is returned as an object. Default is
             false.
         :arg scroll: Period to retain the search context for scrolling.
         :arg source: The URL-encoded request definition. Useful for
@@ -2169,9 +2235,9 @@ class OpenSearch(Client):
 
 
         :arg body: The search definition using the Query DSL
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to search. Supports wildcards (`*`). To search all data streams
-            and indices, omit this parameter or use `*` or `_all`.
+            and indexes, omit this parameter or use `*` or `_all`.
         :arg _source: Indicates which source fields are returned for
             matching documents. These fields are returned in the `hits._source`
             property of the search response. Valid values are: `true` to return the
@@ -2189,15 +2255,15 @@ class OpenSearch(Client):
             is `false`, this parameter is ignored.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with `foo` but no index starts with
             `bar`.
-        :arg allow_partial_search_results: If true, returns partial
-            results if there are shard request timeouts or shard failures. If false,
-            returns an error with no partial results. Default is True.
-        :arg analyze_wildcard: If true, wildcard and prefix queries are
-            analyzed. This parameter can only be used when the q query string
+        :arg allow_partial_search_results: If `true`, returns partial
+            results if there are shard request timeouts or shard failures. If
+            `false`, returns an error with no partial results. Default is True.
+        :arg analyze_wildcard: If `true`, wildcard and prefix queries
+            are analyzed. This parameter can only be used when the q query string
             parameter is specified. Default is false.
         :arg analyzer: Analyzer to use for the query string. This
             parameter can only be used when the q query string parameter is
@@ -2210,7 +2276,7 @@ class OpenSearch(Client):
         :arg cancel_after_time_interval: The time after which the search
             request will be canceled. Request-level parameter takes precedence over
             `cancel_after_time_interval` cluster setting.
-        :arg ccs_minimize_roundtrips: If true, network round-trips
+        :arg ccs_minimize_roundtrips: If `true`, network round-trips
             between the coordinating node and the remote clusters are minimized when
             executing cross-cluster search (CCS) requests. Default is True.
         :arg default_operator: The default operator for query string
@@ -2222,28 +2288,29 @@ class OpenSearch(Client):
         :arg docvalue_fields: A comma-separated list of fields to return
             as the docvalue representation for each hit.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
-            separated values, such as `open,hidden`. Valid choices are all, closed,
-            hidden, none, open.
+            separated values, such as `open,hidden`.
         :arg explain: If `true`, returns detailed information about
             score computation as part of a hit.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg from_: Starting document offset. Needs to be non-negative.
             By default, you cannot page through more than 10,000 hits using the
             `from` and `size` parameters. To page through more hits, use the
             `search_after` parameter. Default is 0.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_throttled: If `true`, concrete, expanded or aliased
-            indices will be ignored when frozen.
+            indexes will be ignored when frozen.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg include_named_queries_score: Indicates whether
-            hit.matched_queries should be rendered as a map that includes the name
+            `hit.matched_queries` should be rendered as a map that includes the name
             of the matched query associated with its score (true) or as an array
             containing the name of the matched queries (false) Default is false.
         :arg lenient: If `true`, format-based query failures (such as
@@ -2285,7 +2352,7 @@ class OpenSearch(Client):
             `<custom-string>` to the same shards in the same order. Default is
             random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg q: Query in the Lucene query string syntax using query
             parameter search. Query parameter searches do not support the full
             OpenSearch Query DSL but are handy for testing.
@@ -2341,7 +2408,7 @@ class OpenSearch(Client):
             caution. OpenSearch applies this parameter to each shard handling the
             request. When possible, let OpenSearch perform early termination
             automatically. Avoid specifying this parameter for requests that target
-            data streams with backing indices across multiple data tiers. If set to
+            data streams with backing indexes across multiple data tiers. If set to
             `0` (default), the query does not terminate early.
         :arg timeout: Specifies the period of time to wait for a
             response from each shard. If no response is received before the timeout
@@ -2389,29 +2456,31 @@ class OpenSearch(Client):
         headers: Any = None,
     ) -> Any:
         """
-        Returns information about the indices and shards that a search request would be
+        Returns information about the indexes and shards that a search request would be
         executed against.
 
 
-        :arg index: Returns the indices and shards that a search request
+        :arg index: Returns the indexes and shards that a search request
             would be executed against.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with `foo` but no index starts with
             `bar`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg local: If `true`, the request retrieves information from
@@ -2419,7 +2488,7 @@ class OpenSearch(Client):
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg routing: Custom value used to route operations to a
             specific shard.
         :arg source: The URL-encoded request definition. Useful for
@@ -2460,19 +2529,19 @@ class OpenSearch(Client):
         Allows to use the Mustache language to pre-render a search definition.
 
 
-        :arg body: The search definition template and its params
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg body: The search definition template and its parameters.
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to search. Supports wildcards (*).
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with `foo` but no index starts with
             `bar`.
         :arg ccs_minimize_roundtrips: If `true`, network round-trips are
             minimized for cross-cluster search requests. Default is True.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
@@ -2480,21 +2549,23 @@ class OpenSearch(Client):
             `open`, `closed`, `hidden`, `none`.
         :arg explain: If `true`, the response includes additional
             details about score computation as part of a hit.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_throttled: If `true`, specified concrete, expanded,
-            or aliased indices are not included in the response when throttled.
+            or aliased indexes are not included in the response when throttled.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg profile: If `true`, the query execution is profiled.
-        :arg rest_total_hits_as_int: If true, hits.total are rendered as
-            an integer in the response. Default is false.
+        :arg rest_total_hits_as_int: If `true`, `hits.total` are
+            rendered as an integer in the response. Default is false.
         :arg routing: Custom value used to route operations to a
             specific shard.
         :arg scroll: Specifies how long a consistent view of the index
@@ -2553,7 +2624,7 @@ class OpenSearch(Client):
             termvectors for. See documentation.
         :arg id: Unique identifier of the document.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg field_statistics: If `true`, the response includes the
             document count, sum of document frequencies, and sum of total term
             frequencies. Default is True.
@@ -2561,10 +2632,12 @@ class OpenSearch(Client):
             fields to include in the statistics. Used as the default list unless a
             specific field list is provided in the `completion_fields` or
             `fielddata_fields` parameters.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg offsets: If `true`, the response includes term offsets.
             Default is True.
         :arg payloads: If `true`, the response includes term payloads.
@@ -2574,8 +2647,8 @@ class OpenSearch(Client):
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg realtime: If true, the request is real-time as opposed to
+            response. Default is false.
+        :arg realtime: If `true`, the request is real-time as opposed to
             near-real-time. Default is True.
         :arg routing: Custom value used to route operations to a
             specific shard.
@@ -2632,30 +2705,33 @@ class OpenSearch(Client):
         :arg id: Document ID
         :arg body: The request definition requires either `script` or
             partial `doc`
-        :arg _source: Set to false to disable source retrieval. You can
-            also specify a comma-separated list of the fields you want to retrieve.
+        :arg _source: Set to `false` to disable source retrieval. You
+            can also specify a comma-separated list of the fields you want to
+            retrieve.
         :arg _source_excludes: Specify the source fields you want to
             exclude.
         :arg _source_includes: Specify the source fields you want to
             retrieve.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg if_primary_term: Only perform the operation if the document
             has this primary term.
         :arg if_seq_no: Only perform the operation if the document has
             this sequence number.
         :arg lang: The script language. Default is painless.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg refresh: If 'true', OpenSearch refreshes the affected
-            shards to make this operation visible to search, if 'wait_for' then wait
-            for a refresh to make this operation visible to search, if 'false' do
-            nothing with refreshes. Valid choices are false, true, wait_for.
-        :arg require_alias: If true, the destination must be an index
+            shards to make this operation visible to search, if `wait_for` then wait
+            for a refresh to make this operation visible to search, if `false` do
+            nothing with refreshes.
+        :arg require_alias: If `true`, the destination must be an index
             alias. Default is false.
         :arg retry_on_conflict: Specify how many times should the
             operation be retried when a conflict occurs. Default is 0.
@@ -2736,20 +2812,20 @@ class OpenSearch(Client):
         for example to pick up a mapping change.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to search. Supports wildcards (`*`). To search all data streams
-            or indices, omit this parameter or use `*` or `_all`.
+            or indexes, omit this parameter or use `*` or `_all`.
         :arg body: The search definition using the Query DSL
-        :arg _source: True or false to return the _source field or not,
-            or a list of fields to return.
+        :arg _source: Set to `true` or `false` to return the `_source`
+            field or not, or a list of fields to return.
         :arg _source_excludes: List of fields to exclude from the
-            returned _source field.
+            returned `_source` field.
         :arg _source_includes: List of fields to extract and return from
-            the _source field.
+            the `_source` field.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with `foo` but no index starts with
             `bar`.
         :arg analyze_wildcard: If `true`, wildcard and prefix queries
@@ -2762,17 +2838,19 @@ class OpenSearch(Client):
         :arg df: Field to use as default where no field prefix is given
             in the query string.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg from_: Starting offset. Default is 0.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg lenient: If `true`, format-based query failures (such as
@@ -2787,7 +2865,7 @@ class OpenSearch(Client):
         :arg preference: Specifies the node or shard the operation
             should be performed on. Random by default. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg q: Query in the Lucene query string syntax.
         :arg refresh: If `true`, OpenSearch refreshes affected shards to
             make the operation visible to search.
@@ -2804,7 +2882,7 @@ class OpenSearch(Client):
         :arg search_type: The type of the search operation. Available
             options: `query_then_fetch`, `dfs_query_then_fetch`. Valid choices are
             dfs_query_then_fetch, query_then_fetch.
-        :arg size: Deprecated, please use `max_docs` instead.
+        :arg size: Deprecated, use `max_docs` instead.
         :arg slices: The number of slices this task should be divided
             into. Valid choices are auto.
         :arg sort: A comma-separated list of <field>:<direction> pairs.
@@ -2818,7 +2896,7 @@ class OpenSearch(Client):
             caution. OpenSearch applies this parameter to each shard handling the
             request. When possible, let OpenSearch perform early termination
             automatically. Avoid specifying this parameter for requests that target
-            data streams with backing indices across multiple data tiers.
+            data streams with backing indexes across multiple data tiers.
         :arg timeout: Period each update request waits for the following
             operations: dynamic mapping updates, waiting for active shards.
         :arg version: If `true`, returns the document version as part of
@@ -2861,13 +2939,15 @@ class OpenSearch(Client):
 
         :arg task_id: The ID for the task.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg requests_per_second: The throttle for this request in sub-
             requests per second.
         :arg source: The URL-encoded request definition. Useful for
@@ -2894,13 +2974,15 @@ class OpenSearch(Client):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2919,13 +3001,15 @@ class OpenSearch(Client):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2955,24 +3039,25 @@ class OpenSearch(Client):
         Creates point in time context.
 
 
-        :arg index: Comma-separated list of indices; use `_all` or empty
-            string to perform the operation on all indices.
+        :arg index: Comma-separated list of indexes; use `_all` or empty
+            string to perform the operation on all indexes.
         :arg allow_partial_pit_creation: Allow if point in time can be
             created with partial failures.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg keep_alive: Specify the keep alive for point in time.
         :arg preference: Specify the node or shard the operation should
             be performed on. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg routing: Comma-separated list of specific routing values.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
@@ -2998,13 +3083,15 @@ class OpenSearch(Client):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -3025,13 +3112,15 @@ class OpenSearch(Client):
 
         :arg body: The point-in-time ids to be deleted
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -3054,16 +3143,108 @@ class OpenSearch(Client):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
         return self.transport.perform_request(
             "GET", "/_search/point_in_time/_all", params=params, headers=headers
+        )
+
+    @query_params(
+        "_source",
+        "_source_excludes",
+        "_source_includes",
+        "batch_interval",
+        "batch_size",
+        "error_trace",
+        "filter_path",
+        "human",
+        "pipeline",
+        "pretty",
+        "refresh",
+        "require_alias",
+        "routing",
+        "source",
+        "timeout",
+        "wait_for_active_shards",
+    )
+    def bulk_stream(
+        self,
+        body: Any,
+        index: Any = None,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Allows to perform multiple index/update/delete operations using request
+        response streaming.
+
+
+        :arg body: The operation definition and data (action-data
+            pairs), separated by newlines
+        :arg index: Name of the data stream, index, or index alias to
+            perform bulk actions on.
+        :arg _source: `true` or `false` to return the `_source` field or
+            not, or a list of fields to return.
+        :arg _source_excludes: A comma-separated list of source fields
+            to exclude from the response.
+        :arg _source_includes: A comma-separated list of source fields
+            to include in the response.
+        :arg batch_interval: Specifies for how long bulk operations
+            should be accumulated into a batch before sending the batch to data
+            nodes.
+        :arg batch_size: Specifies how many bulk operations should be
+            accumulated into a batch before sending the batch to data nodes.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pipeline: ID of the pipeline to use to preprocess incoming
+            documents. If the index has a default ingest pipeline specified, then
+            setting the value to `_none` disables the default ingest pipeline for
+            this request. If a final pipeline is configured it will always run,
+            regardless of the value of this parameter.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg refresh: If `true`, OpenSearch refreshes the affected
+            shards to make this operation visible to search, if `wait_for` then wait
+            for a refresh to make this operation visible to search, if `false` do
+            nothing with refreshes. Valid values: `true`, `false`, `wait_for`.
+        :arg require_alias: If `true`, the request's actions must target
+            an index alias. Default is false.
+        :arg routing: Custom value used to route operations to a
+            specific shard.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        :arg timeout: Period each action waits for the following
+            operations: automatic index creation, dynamic mapping updates, waiting
+            for active shards.
+        :arg wait_for_active_shards: The number of shard copies that
+            must be active before proceeding with the operation. Set to all or any
+            positive integer up to the total number of shards in the index
+            (`number_of_replicas+1`). Valid choices are all, index-setting.
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+
+        body = _bulk_body(self.transport.serializer, body)
+        return self.transport.perform_request(
+            "PUT",
+            _make_path(index, "_bulk", "stream"),
+            params=params,
+            headers=headers,
+            body=body,
         )

--- a/opensearchpy/client/cat.py
+++ b/opensearchpy/client/cat.py
@@ -61,30 +61,31 @@ class CatClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Shows information about currently configured aliases to indices including
-        filter and routing infos.
+        Shows information about currently configured aliases to indexes including
+        filter and routing info.
 
 
         :arg name: A comma-separated list of aliases to retrieve.
             Supports wildcards (`*`).  To retrieve all aliases, omit this parameter
             or use `*` or `_all`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -120,17 +121,19 @@ class CatClient(NamespacedClient):
         :arg bytes: The unit in which to display byte values. Valid
             choices are b, g, gb, k, kb, m, mb, p, pb, t, tb.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -175,22 +178,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -231,22 +236,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -277,24 +284,26 @@ class CatClient(NamespacedClient):
     ) -> Any:
         """
         Provides quick access to the document count of the entire cluster, or
-        individual indices.
+        individual indexes.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -325,7 +334,7 @@ class CatClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Shows how much heap memory is currently being used by fielddata on every data
+        Shows how much heap memory is currently being used by field data on every data
         node in the cluster.
 
 
@@ -334,17 +343,19 @@ class CatClient(NamespacedClient):
         :arg bytes: The unit used to display byte values. Valid choices
             are b, g, gb, k, kb, m, mb, p, pb, t, tb.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -382,25 +393,27 @@ class CatClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg time: The unit used to display time values. Valid choices
             are d, h, m, micros, ms, nanos, s.
-        :arg ts: If true, returns `HH:MM:SS` and Unix epoch timestamps.
-            Default is True.
+        :arg ts: If `true`, returns `HH:MM:SS` and Unix epoch
+            timestamps. Default is True.
         :arg v: Verbose mode. Display column headers. Default is false.
         """
         return self.transport.perform_request(
@@ -418,13 +431,15 @@ class CatClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -460,43 +475,45 @@ class CatClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Returns information about indices: number of primaries and replicas, document
+        Returns information about indexes: number of primaries and replicas, document
         counts, disk size, ...
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg bytes: The unit used to display byte values. Valid choices
             are b, g, gb, k, kb, m, mb, p, pb, t, tb.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: The type of index that wildcard patterns
-            can match. Valid choices are all, closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            can match.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
-        :arg health: The health status used to limit returned indices.
-            By default, the response includes indices of any health status. Valid
+        :arg health: The health status used to limit returned indexes.
+            By default, the response includes indexes of any health status. Valid
             choices are green, red, yellow.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg include_unloaded_segments: If true, the response includes
+            statistics. Default is True.
+        :arg include_unloaded_segments: If `true`, the response includes
             information from segments that are not loaded into memory. Default is
             false.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg pri: If true, the response only includes information from
+            response. Default is false.
+        :arg pri: If `true`, the response only includes information from
             primary shards. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
@@ -537,22 +554,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -562,7 +581,7 @@ class CatClient(NamespacedClient):
         from warnings import warn
 
         warn(
-            "Deprecated: To promote inclusive language, please use '/_cat/cluster_manager' instead."
+            "Deprecated: To promote inclusive language, use '/_cat/cluster_manager' instead."
         )
         return self.transport.perform_request(
             "GET", "/_cat/master", params=params, headers=headers
@@ -595,22 +614,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -653,25 +674,27 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg full_id: If `true`, return the full node ID. If `false`,
             return the shortened node ID. Default is false.
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local (Deprecated: This parameter does not cause this API
             to act locally.): Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -712,22 +735,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -766,17 +791,19 @@ class CatClient(NamespacedClient):
         :arg bytes: The unit in which to display byte values. Valid
             choices are b, g, gb, k, kb, m, mb, p, pb, t, tb.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -814,22 +841,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -875,17 +904,19 @@ class CatClient(NamespacedClient):
         :arg detailed: If `true`, the response includes detailed
             information about shard recoveries. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -925,22 +956,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -989,9 +1022,9 @@ class CatClient(NamespacedClient):
             names to limit the returned information.
         :arg active_only: If `true`, the response only includes ongoing
             segment replication events. Default is false.
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified).
+        :arg allow_no_indices: Whether to ignore if a wildcard indexes
+            expression resolves into no concrete indexes. (This includes `_all`
+            string or when no indexes have been specified).
         :arg bytes: The unit in which to display byte values. Valid
             choices are b, g, gb, k, kb, m, mb, p, pb, t, tb.
         :arg completed_only: If `true`, the response only includes
@@ -999,24 +1032,25 @@ class CatClient(NamespacedClient):
         :arg detailed: If `true`, the response includes detailed
             information about segment replications. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_throttled: Whether specified concrete, expanded or
-            aliased indices should be ignored when throttled.
-        :arg ignore_unavailable: Whether specified concrete indices
+            aliased indexes should be ignored when throttled.
+        :arg ignore_unavailable: Whether specified concrete indexes
             should be ignored when unavailable (missing or closed).
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg shards: Comma-separated list of shards to display.
@@ -1059,28 +1093,30 @@ class CatClient(NamespacedClient):
         Provides low-level information about the segments in the shards of an index.
 
 
-        :arg index: A comma-separated list of data streams, indices, and
+        :arg index: A comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg bytes: The unit used to display byte values. Valid choices
             are b, g, gb, k, kb, m, mb, p, pb, t, tb.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -1118,30 +1154,32 @@ class CatClient(NamespacedClient):
         Provides a detailed view of shard allocation on nodes.
 
 
-        :arg index: A comma-separated list of data streams, indices, and
+        :arg index: A comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg bytes: The unit used to display byte values. Valid choices
             are b, g, gb, k, kb, m, mb, p, pb, t, tb.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -1186,22 +1224,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg size: The multiplier in which to display values.
@@ -1249,22 +1289,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `true`, the response does not
             include information from unavailable snapshots. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -1312,15 +1354,17 @@ class CatClient(NamespacedClient):
         :arg detailed: If `true`, the response includes detailed
             information about shard recoveries. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg nodes: Comma-separated list of node IDs or names to limit
             the returned information; use `_local` to return information from the
             node you're connecting to, leave empty to get information from all
@@ -1328,7 +1372,7 @@ class CatClient(NamespacedClient):
         :arg parent_task_id: The parent task identifier, which is used
             to limit the response.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for
@@ -1371,22 +1415,24 @@ class CatClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg h: Comma-separated list of column names to display.
         :arg help: Return help information. Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg s: Comma-separated list of column names or column aliases
             to sort by.
         :arg source: The URL-encoded request definition. Useful for

--- a/opensearchpy/client/cluster.py
+++ b/opensearchpy/client/cluster.py
@@ -70,35 +70,36 @@ class ClusterClient(NamespacedClient):
         Returns basic information about the health of the cluster.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             index aliases used to limit the request. Wildcard expressions (*) are
-            supported. To target all data streams and indices in a cluster, omit
+            supported. To target all data streams and indexes in a cluster, omit
             this parameter or use `_all` or `*`.
         :arg awareness_attribute: The awareness attribute for which the
             health is required.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg level: Can be one of cluster, indices or shards. Controls
+            statistics. Default is True.
+        :arg level: Can be one of cluster, indexes or shards. Controls
             the details level of the health information returned. Valid choices are
             awareness_attributes, cluster, indices, shards.
-        :arg local: If true, the request retrieves information from the
-            local node only. Defaults to false, which means information is retrieved
-            from the master node. Default is false.
+        :arg local: If `true`, the request retrieves information from
+            the local node only. Defaults to false, which means information is
+            retrieved from the cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -111,11 +112,11 @@ class ClusterClient(NamespacedClient):
             normal, low, languid. Wait until all currently queued events with the
             given priority are processed. Valid choices are high, immediate,
             languid, low, normal, urgent.
-        :arg wait_for_no_initializing_shards: A boolean value which
+        :arg wait_for_no_initializing_shards: A Boolean value which
             controls whether to wait (until the timeout provided) for the cluster to
             have no shard initializations. Defaults to false, which means it will
             not wait for initializing shards.
-        :arg wait_for_no_relocating_shards: A boolean value which
+        :arg wait_for_no_relocating_shards: A Boolean value which
             controls whether to wait (until the timeout provided) for the cluster to
             have no shard relocations. Defaults to false, which means it will not
             wait for relocating shards.
@@ -158,20 +159,22 @@ class ClusterClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: If `true`, the request retrieves information from
             the local node only. If `false`, information is retrieved from the
-            master node. Default is false.
+            cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -209,38 +212,39 @@ class ClusterClient(NamespacedClient):
         :arg metric: Limit the information returned to the specified
             metrics
         :arg index: A comma-separated list of index names; use `_all` or
-            empty string to perform the operation on all indices
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified)
+            empty string to perform the operation on all indexes
+        :arg allow_no_indices: Whether to ignore if a wildcard indexes
+            expression resolves into no concrete indexes. (This includes `_all`
+            string or when no indexes have been specified)
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: Return settings in flat format. Default is
             false.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: Whether specified concrete indices
+            statistics. Default is True.
+        :arg ignore_unavailable: Whether specified concrete indexes
             should be ignored when unavailable (missing or closed)
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Specify timeout for connection
-            to master
+            use `cluster_manager_timeout` instead.): Specify timeout for connection
+            to cluster manager.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg wait_for_metadata_version: Wait for the metadata version to
-            be equal or greater than the specified metadata version
+            be equal or greater than the specified metadata version.
         :arg wait_for_timeout: The maximum time to wait for
-            wait_for_metadata_version before timing out
+            `wait_for_metadata_version` before timing out.
         """
         if index and metric in SKIP_IN_PATH:
             metric = "_all"
@@ -263,6 +267,8 @@ class ClusterClient(NamespacedClient):
     )
     def stats(
         self,
+        metric: Any = None,
+        index_metric: Any = None,
         node_id: Any = None,
         params: Any = None,
         headers: Any = None,
@@ -271,18 +277,25 @@ class ClusterClient(NamespacedClient):
         Returns high-level overview of cluster statistics.
 
 
+        :arg metric: Limit the information returned to the specified
+            metrics.
+        :arg index_metric: Limit the information returned for indexes
+            metric to the specific index metrics. It can be used only if indexes (or
+            all) metric is specified.
         :arg node_id: Comma-separated list of node filters used to limit
             returned information. Defaults to all nodes in the cluster.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for each node to respond. If a node
@@ -329,25 +342,27 @@ class ClusterClient(NamespacedClient):
             `cancel`, `allocate`)
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
-        :arg dry_run: If true, then the request simulates the operation
-            only and returns the resulting state.
+        :arg dry_run: If `true`, then the request simulates the
+            operation only and returns the resulting state.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg explain: If true, then the response contains an explanation
-            of why the commands can or cannot be executed.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg explain: If `true`, then the response contains an
+            explanation of why the commands can or cannot be executed.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg metric: Limits the information returned to the specified
             metrics.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg retry_failed: If true, then retries allocation of shards
+            response. Default is false.
+        :arg retry_failed: If `true`, then retries allocation of shards
             that are blocked due to too many subsequent allocation failures.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
@@ -383,21 +398,23 @@ class ClusterClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg include_defaults: If `true`, returns default cluster
             settings from the local node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -434,18 +451,20 @@ class ClusterClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: Return settings in flat format. Default is
             false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Explicit operation timeout
@@ -468,13 +487,15 @@ class ClusterClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -504,17 +525,19 @@ class ClusterClient(NamespacedClient):
         :arg body: The index, shard, and primary flag to explain. Empty
             means 'explain the first unassigned shard'
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg include_disk_info: If true, returns information about disk
-            usage and shard sizes. Default is false.
-        :arg include_yes_decisions: If true, returns YES decisions in
+            statistics. Default is True.
+        :arg include_disk_info: If `true`, returns information about
+            disk usage and shard sizes. Default is false.
+        :arg include_yes_decisions: If `true`, returns YES decisions in
             explanation. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -551,17 +574,19 @@ class ClusterClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -603,20 +628,22 @@ class ClusterClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: If `true`, the request retrieves information from
             the local node only. If `false`, information is retrieved from the
-            master node. Default is false.
+            cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -653,7 +680,7 @@ class ClusterClient(NamespacedClient):
             includes the following built-in component templates: `logs-mappings`;
             'logs-settings`; `metrics-mappings`; `metrics-settings`;`synthetics-
             mapping`; `synthetics-settings`. OpenSearch Agent uses these templates
-            to configure backing indices for its data streams. If you use OpenSearch
+            to configure backing indexes for its data streams. If you use OpenSearch
             Agent and want to overwrite one of these templates, set the `version`
             for your replacement template higher than the current version. If you
             don't use OpenSearch Agent and want to disable all built-in component
@@ -665,17 +692,19 @@ class ClusterClient(NamespacedClient):
         :arg create: If `true`, this request cannot replace or update
             existing component templates. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Operation timeout.
@@ -717,20 +746,22 @@ class ClusterClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg local: If true, the request retrieves information from the
-            local node only. Defaults to false, which means information is retrieved
-            from the master node. Default is false.
+            statistics. Default is True.
+        :arg local: If `true`, the request retrieves information from
+            the local node only. Defaults to false, which means information is
+            retrieved from the cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -757,20 +788,22 @@ class ClusterClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg wait_for_removal: Specifies whether to wait for all
             excluded nodes to be removed from the cluster before clearing the voting
             configuration exclusions list. Defaults to true, meaning that all
             excluded nodes must be removed from the cluster before this API takes
-            any action. If set to false then the voting configuration exclusions
+            any action. If set to `false` then the voting configuration exclusions
             list is cleared even if some excluded nodes are still in the cluster.
             Default is True.
         """
@@ -801,19 +834,21 @@ class ClusterClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg node_ids: A comma-separated list of the persistent ids of
             the nodes to exclude from the voting configuration. If specified, you
-            may not also specify node_names.
+            may not also specify `node_names`.
         :arg node_names: A comma-separated list of the names of the
             nodes to exclude from the voting configuration. If specified, you may
-            not also specify node_ids.
+            not also specify `node_ids`.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: When adding a voting configuration exclusion, the
@@ -837,13 +872,15 @@ class ClusterClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -854,6 +891,7 @@ class ClusterClient(NamespacedClient):
     @query_params("error_trace", "filter_path", "human", "pretty", "source")
     def delete_weighted_routing(
         self,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -862,13 +900,15 @@ class ClusterClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -877,6 +917,7 @@ class ClusterClient(NamespacedClient):
             "/_cluster/routing/awareness/weights",
             params=params,
             headers=headers,
+            body=body,
         )
 
     @query_params("error_trace", "filter_path", "human", "pretty", "source")
@@ -892,13 +933,15 @@ class ClusterClient(NamespacedClient):
 
         :arg awareness_attribute_name: Awareness attribute name.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -933,13 +976,15 @@ class ClusterClient(NamespacedClient):
 
         :arg attribute: Awareness attribute name.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -968,13 +1013,15 @@ class ClusterClient(NamespacedClient):
         :arg awareness_attribute_name: Awareness attribute name.
         :arg awareness_attribute_value: Awareness attribute value.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -999,6 +1046,7 @@ class ClusterClient(NamespacedClient):
     def put_weighted_routing(
         self,
         attribute: Any,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -1008,13 +1056,15 @@ class ClusterClient(NamespacedClient):
 
         :arg attribute: Awareness attribute name.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1026,4 +1076,5 @@ class ClusterClient(NamespacedClient):
             _make_path("_cluster", "routing", "awareness", attribute, "weights"),
             params=params,
             headers=headers,
+            body=body,
         )

--- a/opensearchpy/client/cluster.py
+++ b/opensearchpy/client/cluster.py
@@ -267,11 +267,11 @@ class ClusterClient(NamespacedClient):
     )
     def stats(
         self,
-        metric: Any = None,
-        index_metric: Any = None,
         node_id: Any = None,
         params: Any = None,
         headers: Any = None,
+        metric: Any = None,
+        index_metric: Any = None,
     ) -> Any:
         """
         Returns high-level overview of cluster statistics.
@@ -308,7 +308,9 @@ class ClusterClient(NamespacedClient):
             (
                 "/_cluster/stats"
                 if node_id in SKIP_IN_PATH
-                else _make_path("_cluster", "stats", "nodes", node_id)
+                else _make_path(
+                    "_cluster", "stats", metric, index_metric, "nodes", node_id
+                )
             ),
             params=params,
             headers=headers,

--- a/opensearchpy/client/dangling_indices.py
+++ b/opensearchpy/client/dangling_indices.py
@@ -61,25 +61,27 @@ class DanglingIndicesClient(NamespacedClient):
         Deletes the specified dangling index.
 
 
-        :arg index_uuid: The UUID of the dangling index
+        :arg index_uuid: The UUID of the dangling index.
         :arg accept_data_loss: Must be set to true in order to delete
-            the dangling index
+            the dangling index.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Specify timeout for connection
-            to master
+            use `cluster_manager_timeout` instead.): Specify timeout for connection
+            to cluster manager.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
-        :arg timeout: Explicit operation timeout
+        :arg timeout: Explicit operation timeout.
         """
         if index_uuid in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'index_uuid'.")
@@ -112,25 +114,27 @@ class DanglingIndicesClient(NamespacedClient):
         Imports the specified dangling index.
 
 
-        :arg index_uuid: The UUID of the dangling index
+        :arg index_uuid: The UUID of the dangling index.
         :arg accept_data_loss: Must be set to true in order to import
-            the dangling index
+            the dangling index.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Specify timeout for connection
-            to master
+            use `cluster_manager_timeout` instead.): Specify timeout for connection
+            to cluster manager.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
-        :arg timeout: Explicit operation timeout
+        :arg timeout: Explicit operation timeout.
         """
         if index_uuid in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'index_uuid'.")
@@ -146,17 +150,19 @@ class DanglingIndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Returns all dangling indices.
+        Returns all dangling indexes.
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """

--- a/opensearchpy/client/indices.py
+++ b/opensearchpy/client/indices.py
@@ -57,13 +57,15 @@ class IndicesClient(NamespacedClient):
             which the analysis should be performed
         :arg index: The name of the index to scope the operation.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -92,31 +94,33 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Performs the refresh operation in one or more indices.
+        Performs the refresh operation in one or more indexes.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -143,33 +147,35 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Performs the flush operation on one or more indices.
+        Performs the flush operation on one or more indexes.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to flush. Supports wildcards (`*`). To flush all data streams
-            and indices, omit this parameter or use `*` or `_all`.
+            and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg force: If `true`, the request forces a flush even if there
             are no changes to commit to the index.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg wait_if_ongoing: If `true`, the flush operation blocks
@@ -209,17 +215,19 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -269,21 +277,23 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg task_execution_timeout: Explicit task execution timeout,
-            only useful when wait_for_completion is false, defaults to 1h.
+            only useful when `wait_for_completion` is false, defaults to `1h`.
         :arg timeout: Period to wait for a response. If no response is
             received before the timeout expires, the request fails and returns an
             error.
@@ -328,46 +338,47 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Returns information about one or more indices.
+        Returns information about one or more indexes.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             index aliases used to limit the request. Wildcard expressions (*) are
             supported.
-        :arg allow_no_indices: If false, the request returns an error if
-            any wildcard expression, index alias, or _all value targets only missing
-            or closed indices. This behavior applies even if the request targets
-            other open indices. For example, a request targeting foo*,bar* returns
-            an error if an index starts with foo but no index starts with bar.
-            Default is false.
+        :arg allow_no_indices: If `false`, the request returns an error
+            if any wildcard expression, index alias, or `_all` value targets only
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting foo*,bar*
+            returns an error if an index starts with foo but no index starts with
+            bar. Default is false.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard expressions
             can match. If the request can target data streams, this argument
             determines whether wildcard expressions match hidden data streams.
-            Supports comma-separated values, such as open,hidden. Valid choices are
-            all, closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg flat_settings: If true, returns settings in flat format.
+            Supports comma-separated values, such as `open,hidden`.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: If false, requests that target a
+            statistics. Default is True.
+        :arg ignore_unavailable: If `false`, requests that target a
             missing index return an error. Default is false.
-        :arg include_defaults: If true, return all default settings in
+        :arg include_defaults: If `true`, return all default settings in
             the response. Default is false.
-        :arg local: If true, the request retrieves information from the
-            local node only. Defaults to false, which means information is retrieved
-            from the master node. Default is false.
+        :arg local: If `true`, the request retrieves information from
+            the local node only. Defaults to false, which means information is
+            retrieved from the cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -404,42 +415,44 @@ class IndicesClient(NamespacedClient):
         Opens an index.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). By default,
-            you must explicitly name the indices you using to limit the request. To
+            you must explicitly name the indexes you using to limit the request. To
             limit a request using `_all`, `*`, or other wildcard expressions, change
             the `action.destructive_requires_name` setting to false. You can update
             this setting in the `opensearch.yml` file or using the cluster update
             settings API.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg task_execution_timeout: Explicit task execution timeout,
-            only useful when wait_for_completion is false, defaults to 1h.
+            only useful when `wait_for_completion` is false, defaults to `1h`.
         :arg timeout: Period to wait for a response. If no response is
             received before the timeout expires, the request fails and returns an
             error.
@@ -485,29 +498,31 @@ class IndicesClient(NamespacedClient):
             names used to limit the request.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -548,35 +563,37 @@ class IndicesClient(NamespacedClient):
         Deletes an index.
 
 
-        :arg index: Comma-separated list of indices to delete. You
+        :arg index: Comma-separated list of indexes to delete. You
             cannot specify index aliases. By default, this parameter does not
             support wildcards (`*`) or `_all`. To use wildcards or `_all`, set the
             `action.destructive_requires_name` cluster setting to `false`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. Default is false.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. Default is false.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -614,27 +631,29 @@ class IndicesClient(NamespacedClient):
         Returns information about whether a particular index exists.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases. Supports wildcards (`*`).
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. Default is false.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. Default is false.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index. Default is false.
         :arg include_defaults: If `true`, return all default settings in
@@ -642,7 +661,7 @@ class IndicesClient(NamespacedClient):
         :arg local: If `true`, the request retrieves information from
             the local node only. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -683,29 +702,31 @@ class IndicesClient(NamespacedClient):
             string to perform the operation on all indices.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -748,39 +769,41 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Returns mappings for one or more indices.
+        Returns mappings for one or more indexes.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg local: If `true`, the request retrieves information from
             the local node only. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -813,24 +836,26 @@ class IndicesClient(NamespacedClient):
 
         :arg fields: Comma-separated list or wildcard expression of
             fields used to limit returned information.
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg include_defaults: If `true`, return all default settings in
@@ -838,7 +863,7 @@ class IndicesClient(NamespacedClient):
         :arg local: If `true`, the request retrieves information from
             the local node only. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -876,31 +901,33 @@ class IndicesClient(NamespacedClient):
 
         :arg name: Comma-separated list of aliases to check. Supports
             wildcards (`*`).
-        :arg index: Comma-separated list of data streams or indices used
+        :arg index: Comma-separated list of data streams or indexes used
             to limit the request. Supports wildcards (`*`). To target all data
-            streams and indices, omit this parameter or use `*` or `_all`.
+            streams and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, requests that include a
-            missing data stream or index in the target indices or data streams
+            missing data stream or index in the target indexes or data streams
             return an error.
         :arg local: If `true`, the request retrieves information from
             the local node only. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -933,33 +960,35 @@ class IndicesClient(NamespacedClient):
         Returns an alias.
 
 
-        :arg index: Comma-separated list of data streams or indices used
+        :arg index: Comma-separated list of data streams or indexes used
             to limit the request. Supports wildcards (`*`). To target all data
-            streams and indices, omit this parameter or use `*` or `_all`.
+            streams and indexes, omit this parameter or use `*` or `_all`.
         :arg name: Comma-separated list of aliases to retrieve. Supports
             wildcards (`*`). To retrieve all aliases, omit this parameter or use `*`
             or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg local: If `true`, the request retrieves information from
             the local node only. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -991,17 +1020,19 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -1036,24 +1067,26 @@ class IndicesClient(NamespacedClient):
         Deletes an alias.
 
 
-        :arg index: Comma-separated list of data streams or indices used
+        :arg index: Comma-separated list of data streams or indexes used
             to limit the request. Supports wildcards (`*`).
         :arg name: Comma-separated list of aliases to remove. Supports
             wildcards (`*`). To remove all aliases, use `*` or `_all`.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -1094,24 +1127,26 @@ class IndicesClient(NamespacedClient):
         :arg body: The template definition
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
-        :arg create: If true, this request cannot replace or update
+        :arg create: If `true`, this request cannot replace or update
             existing index templates. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg order: Order in which OpenSearch applies this template if
             index matches multiple templates.  Templates with lower 'order' values
             are merged first. Templates with higher 'order' values are merged later,
             overriding templates with lower values.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1152,20 +1187,22 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: Return settings in flat format. Default is
             false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1204,21 +1241,23 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: If `true`, the request retrieves information from
             the local node only. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1251,17 +1290,19 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -1298,48 +1339,49 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Returns settings for one or more indices.
+        Returns settings for one or more indexes.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg name: Comma-separated list or wildcard expression of
             settings to retrieve.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with foo but no index starts with
             `bar`.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
-            separated values, such as `open,hidden`. Valid choices are all, closed,
-            hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            separated values, such as `open,hidden`.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg include_defaults: If `true`, return all default settings in
             the response. Default is false.
         :arg local: If `true`, the request retrieves information from
             the local node only. If `false`, information is retrieved from the
-            master node. Default is false.
+            cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1373,40 +1415,41 @@ class IndicesClient(NamespacedClient):
         Updates the index settings.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices. For example, a request targeting `foo*,bar*`
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes. For example, a request targeting `foo*,bar*`
             returns an error if an index starts with `foo` but no index starts with
             `bar`.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
-            separated values, such as `open,hidden`. Valid choices are all, closed,
-            hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            separated values, such as `open,hidden`.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: Whether specified concrete indices
+            statistics. Default is True.
+        :arg ignore_unavailable: Whether specified concrete indexes
             should be ignored when unavailable (missing or closed).
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg preserve_existing: If `true`, existing index settings
             remain unchanged. Default is false.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -1452,41 +1495,42 @@ class IndicesClient(NamespacedClient):
 
 
         :arg index: A comma-separated list of index names; use `_all` or
-            empty string to perform the operation on all indices
+            empty string to perform the operation on all indexes
         :arg metric: Limit the information returned the specific
             metrics.
         :arg completion_fields: Comma-separated list or wildcard
-            expressions of fields to include in fielddata and suggest statistics.
+            expressions of fields to include in field data and suggest statistics.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
-            separated values, such as `open,hidden`. Valid choices are all, closed,
-            hidden, none, open.
+            separated values, such as `open,hidden`.
         :arg fielddata_fields: Comma-separated list or wildcard
-            expressions of fields to include in fielddata statistics.
+            expressions of fields to include in field data statistics.
         :arg fields: Comma-separated list or wildcard expressions of
             fields to include in the statistics.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg forbid_closed_indices: If true, statistics are not
-            collected from closed indices. Default is True.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg forbid_closed_indices: If `true`, statistics are not
+            collected from closed indexes. Default is True.
         :arg groups: Comma-separated list of search groups to include in
             the search statistics.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg include_segment_file_sizes: If true, the call reports the
+            statistics. Default is True.
+        :arg include_segment_file_sizes: If `true`, the call reports the
             aggregated disk usage of each one of the Lucene index files (only
             applies if segment stats are requested). Default is false.
-        :arg include_unloaded_segments: If true, the response includes
+        :arg include_unloaded_segments: If `true`, the response includes
             information from segments that are not loaded into memory. Default is
             false.
         :arg level: Indicates whether statistics are aggregated at the
             cluster, index, or shard level. Valid choices are cluster, indices,
             shards.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1515,28 +1559,30 @@ class IndicesClient(NamespacedClient):
         Provides low-level information about segments in a Lucene index.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg verbose: If `true`, the request returns a verbose response.
@@ -1577,15 +1623,15 @@ class IndicesClient(NamespacedClient):
 
 
         :arg body: The query definition specified with the Query DSL
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases to search. Supports wildcards (`*`). To search all data streams
-            or indices, omit this parameter or use `*` or `_all`.
+            or indexes, omit this parameter or use `*` or `_all`.
         :arg all_shards: If `true`, the validation is executed on all
             shards instead of one random shard per index.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg analyze_wildcard: If `true`, wildcard and prefix queries
             are analyzed. Default is false.
         :arg analyzer: Analyzer to use for the query string. This
@@ -1597,7 +1643,7 @@ class IndicesClient(NamespacedClient):
             in the query string. This parameter can only be used when the `q` query
             string parameter is specified.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
@@ -1605,16 +1651,18 @@ class IndicesClient(NamespacedClient):
             `open`, `closed`, `hidden`, `none`.
         :arg explain: If `true`, the response returns detailed
             information if an error has occurred.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg lenient: If `true`, format-based query failures (such as
             providing text to a numeric field) in the query string will be ignored.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg q: Query in the Lucene query string syntax.
         :arg rewrite: If `true`, returns a more detailed explanation
             showing the actual Lucene query that will be executed.
@@ -1651,17 +1699,17 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Clears all or specific caches for one or more indices.
+        Clears all or specific caches for one or more indexes.
 
 
-        :arg index: Comma-separated list of indices; use `_all` or empty
-            string to perform the operation on all indices.
+        :arg index: Comma-separated list of indexes; use `_all` or empty
+            string to perform the operation on all indexes.
         :arg allow_no_indices: If `false`, the request returns an error
             if any wildcard expression, index alias, or `_all` value targets only
-            missing or closed indices. This behavior applies even if the request
-            targets other open indices.
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
@@ -1671,16 +1719,18 @@ class IndicesClient(NamespacedClient):
             `fields` parameter to clear the cache of specific fields only.
         :arg fields: Comma-separated list of field names used to limit
             the `fielddata` parameter.
-        :arg file: If true, clears the unused entries from the file
+        :arg file: If `true`, clears the unused entries from the file
             cache on nodes with the Search role. Default is false.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: If `false`, the request returns an
             error if it targets a missing or closed index.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg query: If `true`, clears the query cache.
         :arg request: If `true`, clears the request cache.
         :arg source: The URL-encoded request definition. Useful for
@@ -1709,21 +1759,23 @@ class IndicesClient(NamespacedClient):
         Returns information about ongoing index shard recoveries.
 
 
-        :arg index: Comma-separated list of data streams, indices, and
+        :arg index: Comma-separated list of data streams, indexes, and
             aliases used to limit the request. Supports wildcards (`*`). To target
-            all data streams and indices, omit this parameter or use `*` or `_all`.
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
         :arg active_only: If `true`, the response only includes ongoing
             shard recoveries. Default is false.
         :arg detailed: If `true`, the response includes detailed
             information about shard recoveries. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1750,29 +1802,30 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        The _upgrade API is no longer useful and will be removed.
+        The `_upgrade` API is no longer useful and will be removed.
 
 
-        :arg index: Comma-separated list of indices; use `_all` or empty
-            string to perform the operation on all indices.
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified).
+        :arg index: Comma-separated list of indexes; use `_all` or empty
+            string to perform the operation on all indexes.
+        :arg allow_no_indices: Whether to ignore if a wildcard indexes
+            expression resolves into no concrete indexes. (This includes `_all`
+            string or when no indexes have been specified).
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: Whether specified concrete indices
+            statistics. Default is True.
+        :arg ignore_unavailable: Whether specified concrete indexes
             should be ignored when unavailable (missing or closed).
-        :arg only_ancient_segments: If true, only ancient (an older
+        :arg only_ancient_segments: If `true`, only ancient (an older
             Lucene major release) segments will be upgraded.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg wait_for_completion: Should this request wait until the
@@ -1799,27 +1852,28 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        The _upgrade API is no longer useful and will be removed.
+        The `_upgrade` API is no longer useful and will be removed.
 
 
-        :arg index: Comma-separated list of indices; use `_all` or empty
-            string to perform the operation on all indices.
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified).
+        :arg index: Comma-separated list of indexes; use `_all` or empty
+            string to perform the operation on all indexes.
+        :arg allow_no_indices: Whether to ignore if a wildcard indexes
+            expression resolves into no concrete indexes. (This includes `_all`
+            string or when no indexes have been specified).
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: Whether specified concrete indices
+            statistics. Default is True.
+        :arg ignore_unavailable: Whether specified concrete indexes
             should be ignored when unavailable (missing or closed).
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1845,29 +1899,30 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Provides store information for shard copies of indices.
+        Provides store information for shard copies of indexes.
 
 
-        :arg index: List of data streams, indices, and aliases used to
+        :arg index: List of data streams, indexes, and aliases used to
             limit the request.
-        :arg allow_no_indices: If false, the request returns an error if
-            any wildcard expression, index alias, or _all value targets only missing
-            or closed indices. This behavior applies even if the request targets
-            other open indices.
+        :arg allow_no_indices: If `false`, the request returns an error
+            if any wildcard expression, index alias, or `_all` value targets only
+            missing or closed indexes. This behavior applies even if the request
+            targets other open indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
-            whether wildcard expressions match hidden data streams. Valid choices
-            are all, closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            whether wildcard expressions match hidden data streams.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: If true, missing or closed indices are
-            not included in the response.
+            statistics. Default is True.
+        :arg ignore_unavailable: If `true`, missing or closed indexes
+            are not included in the response.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg status: List of shard health statuses used to limit the
@@ -1899,26 +1954,27 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Performs the force merge operation on one or more indices.
+        Performs the force merge operation on one or more indexes.
 
 
         :arg index: A comma-separated list of index names; use `_all` or
-            empty string to perform the operation on all indices
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified)
+            empty string to perform the operation on all indexes
+        :arg allow_no_indices: Whether to ignore if a wildcard indexes
+            expression resolves into no concrete indexes. (This includes `_all`
+            string or when no indexes have been specified)
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flush: Specify whether the index should be flushed after
             performing the operation. Default is True.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: Whether specified concrete indices
+            statistics. Default is True.
+        :arg ignore_unavailable: Whether specified concrete indexes
             should be ignored when unavailable (missing or closed)
         :arg max_num_segments: The number of larger segments into which
             smaller segments are merged. Set this parameter to 1 to merge all
@@ -1927,7 +1983,7 @@ class IndicesClient(NamespacedClient):
         :arg only_expunge_deletes: Specify whether the operation should
             only expunge deleted documents
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg primary_only: Specify whether the operation should only
             perform on primary shards. Defaults to false. Default is false.
         :arg source: The URL-encoded request definition. Useful for
@@ -1974,21 +2030,23 @@ class IndicesClient(NamespacedClient):
         :arg copy_settings: whether or not to copy settings from the
             source index. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg task_execution_timeout: Explicit task execution timeout,
-            only useful when wait_for_completion is false, defaults to 1h.
+            only useful when `wait_for_completion` is false, defaults to `1h`.
         :arg timeout: Period to wait for a response. If no response is
             received before the timeout expires, the request fails and returns an
             error.
@@ -2047,21 +2105,23 @@ class IndicesClient(NamespacedClient):
         :arg copy_settings: whether or not to copy settings from the
             source index. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg task_execution_timeout: Explicit task execution timeout,
-            only useful when wait_for_completion is false, defaults to 1h.
+            only useful when `wait_for_completion` is false, defaults to `1h`.
         :arg timeout: Period to wait for a response. If no response is
             received before the timeout expires, the request fails and returns an
             error.
@@ -2120,17 +2180,19 @@ class IndicesClient(NamespacedClient):
             satisfies the specified conditions but does not perform a rollover.
             Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -2172,13 +2234,15 @@ class IndicesClient(NamespacedClient):
             faster.
         :arg body: The data stream definition
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2207,13 +2271,15 @@ class IndicesClient(NamespacedClient):
         :arg name: Comma-separated list of data streams to delete.
             Wildcard (`*`) expressions are supported.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2249,17 +2315,19 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -2302,21 +2370,23 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg flat_settings: Return settings in flat format. Default is
             false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2353,22 +2423,24 @@ class IndicesClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg flat_settings: If true, returns settings in flat format.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg local: If true, the request retrieves information from the
-            local node only. Defaults to false, which means information is retrieved
-            from the master node. Default is false.
+            statistics. Default is True.
+        :arg local: If `true`, the request retrieves information from
+            the local node only. Defaults to false, which means information is
+            retrieved from the cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2407,16 +2479,18 @@ class IndicesClient(NamespacedClient):
         :arg create: If `true`, this request cannot replace or update
             existing index templates. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Operation timeout for
-            connection to master node.
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2468,17 +2542,19 @@ class IndicesClient(NamespacedClient):
             the template is not permanently added or updated in either case; it is
             only used for the simulation. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2508,13 +2584,15 @@ class IndicesClient(NamespacedClient):
             limit the request. Wildcard (`*`) expressions are supported. If omitted,
             all data streams are returned.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2551,23 +2629,25 @@ class IndicesClient(NamespacedClient):
             template for simulation purposes. Default is false.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
-        :arg create: If true, the template passed in the body is only
-            used if no existing templates match the same index patterns. If false,
+        :arg create: If `true`, the template passed in the body is only
+            used if no existing templates match the same index patterns. If `false`,
             the simulation uses the template with the highest priority. Note that
             the template is not permanently added or updated in either case; it is
             only used for the simulation. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2589,25 +2669,27 @@ class IndicesClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Returns information about any matching indices, aliases, and data streams.
+        Returns information about any matching indexes, aliases, and data streams.
 
 
         :arg name: Comma-separated name(s) or index pattern(s) of the
-            indices, aliases, and data streams to resolve. Resources on remote
+            indexes, aliases, and data streams to resolve. Resources on remote
             clusters can be specified using the `<cluster>`:`<name>` syntax.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Type of index that wildcard patterns can
             match. If the request can target data streams, this argument determines
             whether wildcard expressions match hidden data streams. Supports comma-
             separated values, such as `open,hidden`. Valid values are: `all`,
             `open`, `closed`, `hidden`, `none`.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2642,30 +2724,31 @@ class IndicesClient(NamespacedClient):
         Adds a block to an index.
 
 
-        :arg index: A comma separated list of indices to add a block to
-        :arg block: The block to add (one of read, write, read_only or
-            metadata)
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified)
+        :arg index: A comma separated list of indexes to add a block to.
+        :arg block: The block to add (one of `read`, `write`,
+            `read_only` or `metadata`).
+        :arg allow_no_indices: Whether to ignore if a wildcard indexes
+            expression resolves into no concrete indexes. (This includes `_all`
+            string or when no indexes have been specified).
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            concrete indexes that are open, closed or both.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: Whether specified concrete indices
-            should be ignored when unavailable (missing or closed)
+            statistics. Default is True.
+        :arg ignore_unavailable: Whether specified concrete indexes
+            should be ignored when unavailable (missing or closed).
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Specify timeout for connection
-            to master
+            use `cluster_manager_timeout` instead.): Specify timeout for connection
+            to cluster manager.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Explicit operation timeout
@@ -2693,13 +2776,15 @@ class IndicesClient(NamespacedClient):
             the request. Wildcard expressions (`*`) are supported. To target all
             data streams in a cluster, omit this parameter or use `*`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2734,25 +2819,27 @@ class IndicesClient(NamespacedClient):
 
         :arg body: The settings for the alias, such as `routing` or
             `filter`
-        :arg index: Comma-separated list of data streams or indices to
+        :arg index: Comma-separated list of data streams or indexes to
             add. Supports wildcards (`*`). Wildcard patterns that match both data
-            streams and indices return an error.
+            streams and indexes return an error.
         :arg name: Alias to update. If the alias doesn't exist, the
             request creates it. Index alias names support date math.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is

--- a/opensearchpy/client/ingest.py
+++ b/opensearchpy/client/ingest.py
@@ -65,17 +65,19 @@ class IngestClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -109,17 +111,19 @@ class IngestClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -164,17 +168,19 @@ class IngestClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -207,13 +213,15 @@ class IngestClient(NamespacedClient):
         :arg id: Pipeline to test. If you don't specify a `pipeline` in
             the request body, this parameter is required.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg verbose: If `true`, the response includes output data for
@@ -230,7 +238,7 @@ class IngestClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    @query_params("error_trace", "filter_path", "human", "pretty", "s", "source")
     def processor_grok(
         self,
         params: Any = None,
@@ -241,13 +249,16 @@ class IngestClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
+        :arg s: Sort returned patterns by key name. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """

--- a/opensearchpy/client/insights.py
+++ b/opensearchpy/client/insights.py
@@ -18,32 +18,21 @@
 
 from typing import Any
 
-from .utils import SKIP_IN_PATH, NamespacedClient, query_params
+from .utils import NamespacedClient, query_params
 
 
-class RemoteStoreClient(NamespacedClient):
-    @query_params(
-        "cluster_manager_timeout",
-        "error_trace",
-        "filter_path",
-        "human",
-        "pretty",
-        "source",
-        "wait_for_completion",
-    )
-    def restore(
+class InsightsClient(NamespacedClient):
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def top_queries(
         self,
-        body: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Restores from remote store.
+        Retrieves the top queries based on the given metric type (latency, CPU, or
+        memory).
 
 
-        :arg body: Comma-separated list of index IDs
-        :arg cluster_manager_timeout: Operation timeout for connection
-            to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
             errors. Default is false.
         :arg filter_path: Used to reduce the response. This parameter
@@ -56,12 +45,7 @@ class RemoteStoreClient(NamespacedClient):
             response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
-        :arg wait_for_completion: Should this request wait until the
-            operation has completed before returning. Default is false.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
         return self.transport.perform_request(
-            "POST", "/_remotestore/_restore", params=params, headers=headers, body=body
+            "GET", "/_insights/top_queries", params=params, headers=headers
         )

--- a/opensearchpy/client/list.py
+++ b/opensearchpy/client/list.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+# ------------------------------------------------------------------------------------------
+# THIS CODE IS AUTOMATICALLY GENERATED AND MANUAL EDITS WILL BE LOST
+#
+# To contribute, kindly make modifications in the opensearch-py client generator
+# or in the OpenSearch API specification, and run `nox -rs generate`. See DEVELOPER_GUIDE.md
+# and https://github.com/opensearch-project/opensearch-api-specification for details.
+# -----------------------------------------------------------------------------------------+
+
+
+from typing import Any
+
+from .utils import NamespacedClient, _make_path, query_params
+
+
+class ListClient(NamespacedClient):
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def help(
+        self,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Returns help for the List APIs.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        return self.transport.perform_request(
+            "GET", "/_list", params=params, headers=headers
+        )
+
+    @query_params(
+        "bytes",
+        "cluster_manager_timeout",
+        "error_trace",
+        "expand_wildcards",
+        "filter_path",
+        "format",
+        "h",
+        "health",
+        "help",
+        "human",
+        "include_unloaded_segments",
+        "local",
+        "master_timeout",
+        "next_token",
+        "pretty",
+        "pri",
+        "s",
+        "size",
+        "sort",
+        "source",
+        "time",
+        "v",
+    )
+    def indices(
+        self,
+        index: Any = None,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Returns paginated information about indexes including number of primaries and
+        replicas, document counts, disk size.
+
+
+        :arg index: Comma-separated list of data streams, indexes, and
+            aliases used to limit the request. Supports wildcards (`*`). To target
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
+        :arg bytes: The unit used to display byte values. Valid choices
+            are b, g, gb, k, kb, m, mb, p, pb, t, tb.
+        :arg cluster_manager_timeout: Operation timeout for connection
+            to cluster-manager node.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg expand_wildcards: The type of index that wildcard patterns
+            can match.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header, such as
+            `JSON`, `YAML`.
+        :arg h: Comma-separated list of column names to display.
+        :arg health: The health status used to limit returned indexes.
+            By default, the response includes indexes of any health status. Valid
+            choices are green, red, yellow.
+        :arg help: Return help information. Default is false.
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg include_unloaded_segments: If `true`, the response includes
+            information from segments that are not loaded into memory. Default is
+            false.
+        :arg local: Return local information, do not retrieve the state
+            from cluster-manager node. Default is false.
+        :arg master_timeout (Deprecated: To promote inclusive language,
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
+        :arg next_token: Token to retrieve next page of indexes.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg pri: If `true`, the response only includes information from
+            primary shards. Default is false.
+        :arg s: Comma-separated list of column names or column aliases
+            to sort by.
+        :arg size: Maximum number of indexes to be displayed in a page.
+        :arg sort: Defines order in which indexes will be displayed.
+            Accepted values are `asc` and `desc`. If `desc`, most recently created
+            indexes would be displayed first. Valid choices are asc, desc.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        :arg time: The unit used to display time values. Valid choices
+            are d, h, m, micros, ms, nanos, s.
+        :arg v: Verbose mode. Display column headers. Default is false.
+        """
+        return self.transport.perform_request(
+            "GET", _make_path("_list", "indices", index), params=params, headers=headers
+        )
+
+    @query_params(
+        "bytes",
+        "cluster_manager_timeout",
+        "error_trace",
+        "filter_path",
+        "format",
+        "h",
+        "help",
+        "human",
+        "local",
+        "master_timeout",
+        "next_token",
+        "pretty",
+        "s",
+        "size",
+        "sort",
+        "source",
+        "time",
+        "v",
+    )
+    def shards(
+        self,
+        index: Any = None,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Returns paginated details of shard allocation on nodes.
+
+
+        :arg index: A comma-separated list of data streams, indexes, and
+            aliases used to limit the request. Supports wildcards (`*`). To target
+            all data streams and indexes, omit this parameter or use `*` or `_all`.
+        :arg bytes: The unit used to display byte values. Valid choices
+            are b, g, gb, k, kb, m, mb, p, pb, t, tb.
+        :arg cluster_manager_timeout: Operation timeout for connection
+            to cluster-manager node.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header, such as
+            `JSON`, `YAML`.
+        :arg h: Comma-separated list of column names to display.
+        :arg help: Return help information. Default is false.
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg local: Return local information, do not retrieve the state
+            from cluster-manager node. Default is false.
+        :arg master_timeout (Deprecated: To promote inclusive language,
+            use `cluster_manager_timeout` instead.): Operation timeout for
+            connection to cluster-manager node.
+        :arg next_token: Token to retrieve next page of shards.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg s: Comma-separated list of column names or column aliases
+            to sort by.
+        :arg size: Maximum number of shards to be displayed in a page.
+        :arg sort: Defines order in which shards will be displayed.
+            Accepted values are `asc` and `desc`. If `desc`, most recently created
+            shards would be displayed first. Valid choices are asc, desc.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        :arg time: The unit in which to display time values. Valid
+            choices are d, h, m, micros, ms, nanos, s.
+        :arg v: Verbose mode. Display column headers. Default is false.
+        """
+        return self.transport.perform_request(
+            "GET", _make_path("_list", "shards", index), params=params, headers=headers
+        )

--- a/opensearchpy/client/nodes.py
+++ b/opensearchpy/client/nodes.py
@@ -52,18 +52,20 @@ class NodesClient(NamespacedClient):
         Reloads secure settings.
 
 
-        :arg body: An object containing the password for the opensearch
-            keystore
+        :arg body: An object containing the password for the OpenSearch
+            keystore.
         :arg node_id: The names of particular nodes in the cluster to
             target.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -91,6 +93,7 @@ class NodesClient(NamespacedClient):
         self,
         node_id: Any = None,
         metric: Any = None,
+        node_id_or_metric: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -101,17 +104,22 @@ class NodesClient(NamespacedClient):
         :arg node_id: Comma-separated list of node IDs or names used to
             limit returned information.
         :arg metric: Limits the information returned to the specific
-            metrics. Supports a comma-separated list, such as http,ingest.
+            metrics. Supports a comma-separated list, such as `http,ingest`.
+        :arg node_id_or_metric: Limits the information returned to a
+            list of node IDs or specific metrics. Supports a comma-separated list,
+            such as `node1,node2` or `http,ingest`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg flat_settings: If true, returns settings in flat format.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg flat_settings: If `true`, returns settings in flat format.
             Default is false.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -153,31 +161,33 @@ class NodesClient(NamespacedClient):
             limit returned information.
         :arg metric: Limit the information returned to the specified
             metrics
-        :arg index_metric: Limit the information returned for indices
-            metric to the specific index metrics. It can be used only if indices (or
+        :arg index_metric: Limit the information returned for indexes
+            metric to the specific index metrics. It can be used only if indexes (or
             all) metric is specified.
         :arg completion_fields: Comma-separated list or wildcard
-            expressions of fields to include in fielddata and suggest statistics.
+            expressions of fields to include in field data and suggest statistics.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg fielddata_fields: Comma-separated list or wildcard
-            expressions of fields to include in fielddata statistics.
+            expressions of fields to include in field data statistics.
         :arg fields: Comma-separated list or wildcard expressions of
             fields to include in the statistics.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg groups: Comma-separated list of search groups to include in
             the search statistics.
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg include_segment_file_sizes: If true, the call reports the
+            statistics. Default is True.
+        :arg include_segment_file_sizes: If `true`, the call reports the
             aggregated disk usage of each one of the Lucene index files (only
             applies if segment stats are requested). Default is false.
         :arg level: Indicates whether statistics are aggregated at the
             cluster, index, or shard level. Valid choices are cluster, indices,
             shards.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -223,18 +233,20 @@ class NodesClient(NamespacedClient):
         :arg doc_type: The type to sample. Valid choices are block, cpu,
             wait.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_idle_threads: Don't show threads that are in known-
             idle places, such as waiting on a socket select or pulling from an empty
             task queue. Default is True.
         :arg interval: The interval for the second sampling of threads.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg snapshots: Number of samples of thread stacktrace. Default
+            response. Default is false.
+        :arg snapshots: Number of samples of thread stack trace. Default
             is 10.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
@@ -273,13 +285,15 @@ class NodesClient(NamespacedClient):
             metrics. A comma-separated list of the following options: `_all`,
             `rest_actions`.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is

--- a/opensearchpy/client/plugins.py
+++ b/opensearchpy/client/plugins.py
@@ -11,6 +11,8 @@ import warnings
 from typing import Any
 
 from ..plugins.alerting import AlertingClient
+from ..plugins.asynchronous_search import AsynchronousSearchClient
+from ..plugins.flow_framework import FlowFrameworkClient
 from ..plugins.index_management import IndexManagementClient
 from ..plugins.knn import KnnClient
 from ..plugins.ml import MlClient
@@ -18,6 +20,7 @@ from ..plugins.notifications import NotificationsClient
 from ..plugins.observability import ObservabilityClient
 from ..plugins.ppl import PplClient
 from ..plugins.query import QueryClient
+from ..plugins.replication import ReplicationClient
 from ..plugins.rollups import RollupsClient
 from ..plugins.sql import SqlClient
 from ..plugins.transforms import TransformsClient
@@ -26,12 +29,25 @@ from .utils import NamespacedClient
 
 
 class PluginsClient(NamespacedClient):
+    asynchronous_search: Any
     alerting: Any
     index_management: Any
+    knn: Any
+    ml: Any
+    notifications: Any
+    observability: Any
+    ppl: Any
+    query: Any
+    rollups: Any
+    sql: Any
+    transforms: Any
 
     def __init__(self, client: Client) -> None:
         super().__init__(client)
 
+        self.replication = ReplicationClient(client)
+        self.flow_framework = FlowFrameworkClient(client)
+        self.asynchronous_search = AsynchronousSearchClient(client)
         self.alerting = AlertingClient(client)
         self.index_management = IndexManagementClient(client)
         self.knn = KnnClient(client)
@@ -50,13 +66,20 @@ class PluginsClient(NamespacedClient):
         # Issue : https://github.com/opensearch-project/opensearch-py/issues/90#issuecomment-1003396742
 
         plugins = [
-            # "query_workbench",
-            # "reporting",
-            # "notebooks",
+            "replication",
+            "flow_framework",
+            "asynchronous_search",
             "alerting",
-            # "anomaly_detection",
-            # "trace_analytics",
             "index_management",
+            "knn",
+            "ml",
+            "notifications",
+            "observability",
+            "ppl",
+            "query",
+            "rollups",
+            "sql",
+            "transforms",
         ]
         for plugin in plugins:
             if not hasattr(client, plugin):

--- a/opensearchpy/client/search_pipeline.py
+++ b/opensearchpy/client/search_pipeline.py
@@ -45,13 +45,15 @@ class SearchPipelineClient(NamespacedClient):
         :arg cluster_manager_timeout: operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -82,13 +84,15 @@ class SearchPipelineClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Operation timeout.
@@ -127,13 +131,15 @@ class SearchPipelineClient(NamespacedClient):
         :arg cluster_manager_timeout: operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Operation timeout.

--- a/opensearchpy/client/security.py
+++ b/opensearchpy/client/security.py
@@ -35,13 +35,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -61,13 +63,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -95,13 +99,15 @@ class SecurityClient(NamespacedClient):
 
         :arg action_group: The name of the action group to retrieve.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -128,13 +134,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -158,13 +166,15 @@ class SecurityClient(NamespacedClient):
 
         :arg action_group: The name of the action group to delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -195,13 +205,15 @@ class SecurityClient(NamespacedClient):
         :arg action_group: The name of the action group to create or
             replace.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -231,13 +243,15 @@ class SecurityClient(NamespacedClient):
 
         :arg action_group: The name of the action group to update.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -265,13 +279,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -299,13 +315,15 @@ class SecurityClient(NamespacedClient):
 
         :arg username: The name of the user to retrieve.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -330,13 +348,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -360,13 +380,15 @@ class SecurityClient(NamespacedClient):
 
         :arg username: The name of the user to delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -394,13 +416,15 @@ class SecurityClient(NamespacedClient):
 
         :arg username: The name of the user to be created.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -430,13 +454,15 @@ class SecurityClient(NamespacedClient):
 
         :arg username: The name of the user to update.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -464,13 +490,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -497,13 +525,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -528,13 +558,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -555,13 +587,15 @@ class SecurityClient(NamespacedClient):
 
         :arg role: The name of the role to delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -589,13 +623,15 @@ class SecurityClient(NamespacedClient):
 
         :arg role: The name of the role to be created.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -625,13 +661,15 @@ class SecurityClient(NamespacedClient):
 
         :arg role: The name of the role to update.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -659,13 +697,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -692,13 +732,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -723,13 +765,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -753,13 +797,15 @@ class SecurityClient(NamespacedClient):
 
         :arg role: The name of the role whose mapping needs to delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -787,13 +833,15 @@ class SecurityClient(NamespacedClient):
 
         :arg role: The name of the role to create a role mapping for.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -823,13 +871,15 @@ class SecurityClient(NamespacedClient):
 
         :arg role: The name of the role to update role-mapping for.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -857,13 +907,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -891,13 +943,15 @@ class SecurityClient(NamespacedClient):
 
         :arg tenant: The name of the tenant to retrieve.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -922,13 +976,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -949,13 +1005,15 @@ class SecurityClient(NamespacedClient):
 
         :arg tenant: The name of the tenant to delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -983,13 +1041,15 @@ class SecurityClient(NamespacedClient):
 
         :arg tenant: The name of the tenant to be created.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1019,13 +1079,15 @@ class SecurityClient(NamespacedClient):
 
         :arg tenant: The name of the tenant to update.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1053,13 +1115,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1085,13 +1149,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1111,17 +1177,19 @@ class SecurityClient(NamespacedClient):
     ) -> Any:
         """
         Adds or updates the existing configuration using the REST API. Only accessible
-        by admins and users with rest api access and only when put or patch is enabled.
+        by admins and users with REST API access and only when put or patch is enabled.
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1144,19 +1212,21 @@ class SecurityClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        A PATCH call is used to update the existing configuration using the REST API.
-        Only accessible by admins and users with rest api access and only when put or
+        A `PATCH` call is used to update the existing configuration using the REST API.
+        Only accessible by admins and users with REST API access and only when put or
         patch is enabled.
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1183,14 +1253,16 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg show_all: A boolean flag to include/exclude static nodes DN
+            response. Default is false.
+        :arg show_all: A Boolean flag to include/exclude static nodes DN
             from final result.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
@@ -1210,13 +1282,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1235,13 +1309,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1263,13 +1339,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1291,13 +1369,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1316,16 +1396,18 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg mode: A flag to indicate whether service should consider
             security-plugin's status before returning health response. `strict` mode
-            indicates service should check security plugin status.
+            indicates service should check Security plugin status.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1344,13 +1426,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1370,13 +1454,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1403,13 +1489,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1437,13 +1525,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1478,13 +1568,15 @@ class SecurityClient(NamespacedClient):
 
         :arg auth_type: The type of current authentication request.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg verbose: Indicates whether a verbose response should be
@@ -1505,13 +1597,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1530,13 +1624,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1556,13 +1652,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1585,13 +1683,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1611,18 +1711,20 @@ class SecurityClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Creates or replaces the allowlisted APIs. Accessible via Super Admin
+        Creates or replaces the permitted APIs. Accessible using Super Admin
         certificate or REST API permission.
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1650,13 +1752,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1685,13 +1789,15 @@ class SecurityClient(NamespacedClient):
 
         :arg username: The name of the user to be created.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1722,13 +1828,15 @@ class SecurityClient(NamespacedClient):
         :arg cluster_name: The cluster-name to delete from list of
             distinguished names.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1757,13 +1865,15 @@ class SecurityClient(NamespacedClient):
 
         :arg username: The name of the user to delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1789,13 +1899,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1824,13 +1936,15 @@ class SecurityClient(NamespacedClient):
         :arg username: The name of the user for whom an auth token is to
             be vended.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1854,19 +1968,21 @@ class SecurityClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Generates authorization token for the given user. Legacy API.  Not Implemented.
+        Generates authorization token for the given user. Legacy API. Not Implemented.
 
 
         :arg username: The name of the user for whom an auth token is to
             be vended.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1891,13 +2007,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1916,13 +2034,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -1945,14 +2065,16 @@ class SecurityClient(NamespacedClient):
         :arg cluster_name: The cluster-name to retrieve nodes DN setting
             for.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg show_all: A boolean flag to include/exclude static nodes DN
+            response. Default is false.
+        :arg show_all: A Boolean flag to include/exclude static nodes DN
             from final result.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
@@ -1980,13 +2102,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2008,14 +2132,16 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
-        :arg show_dn: A boolean flag to indicate whether all domain
+            response. Default is false.
+        :arg show_dn: A Boolean flag to indicate whether all domain
             names should be returned.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
@@ -2036,13 +2162,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2066,13 +2194,15 @@ class SecurityClient(NamespacedClient):
 
         :arg username: The name of the user to retrieve.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2097,13 +2227,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2122,13 +2254,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2148,13 +2282,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2182,15 +2318,17 @@ class SecurityClient(NamespacedClient):
         super-admins and with rest-api permissions when enabled.
 
 
-        :arg cluster_name: The cluster-name to update nodesDn value.
+        :arg cluster_name: The cluster name to update `nodesDn` value.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2218,13 +2356,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2244,13 +2384,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2272,16 +2414,18 @@ class SecurityClient(NamespacedClient):
         enabled.
 
 
-        :arg cluster_name: The cluster-name to create/update nodesDn
+        :arg cluster_name: The cluster-name to create/update `nodesDn`
             value for.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2311,16 +2455,18 @@ class SecurityClient(NamespacedClient):
         to v7.
 
 
-        :arg accept_invalid: A boolean flag to indicate whether invalid
+        :arg accept_invalid: A Boolean flag to indicate whether invalid
             v6 configuration should be allowed.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2339,13 +2485,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2366,13 +2514,15 @@ class SecurityClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -2401,13 +2551,15 @@ class SecurityClient(NamespacedClient):
         :arg cert_type: The type of certificates (HTTP, TRANSPORT, ALL)
             to retrieve from all nodes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: The maximum duration, in seconds, to be spent to
@@ -2443,13 +2595,15 @@ class SecurityClient(NamespacedClient):
         :arg cert_type: The type of certificates (HTTP, TRANSPORT, ALL)
             to retrieve for a node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: The maximum duration, in seconds, to be spent to

--- a/opensearchpy/client/snapshot.py
+++ b/opensearchpy/client/snapshot.py
@@ -69,17 +69,19 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg wait_for_completion: If `true`, the request returns a
@@ -123,16 +125,18 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -172,31 +176,33 @@ class SnapshotClient(NamespacedClient):
         :arg repository: Comma-separated list of snapshot repository
             names used to limit the request. Wildcard (*) expressions are supported.
         :arg snapshot: Comma-separated list of snapshot names to
-            retrieve. Also accepts wildcards (*). - To get information about all
-            snapshots in a registered repository, use a wildcard (*) or _all. - To
-            get information about any snapshots that are currently running, use
-            _current.
+            retrieve. Also accepts wildcards (`*`). - To get information about all
+            snapshots in a registered repository, use a wildcard (`*`) or `_all`. -
+            To get information about any snapshots that are currently running, use
+            `_current`.
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
-        :arg ignore_unavailable: If false, the request returns an error
-            for any snapshots that are unavailable. Default is false.
+            statistics. Default is True.
+        :arg ignore_unavailable: If `false`, the request returns an
+            error for any snapshots that are unavailable. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node. If no response is received before the timeout
-            expires, the request fails and returns an error.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node. If no response is received before the
+            timeout expires, the request fails and returns an error.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
-        :arg verbose: If true, returns additional information about each
-            snapshot such as the version of OpenSearch which took the snapshot, the
-            start and end times of the snapshot, and the number of shards
+        :arg verbose: If `true`, returns additional information about
+            each snapshot such as the version of OpenSearch which took the snapshot,
+            the start and end times of the snapshot, and the number of shards
             snapshotted.
         """
         for param in (repository, snapshot):
@@ -235,16 +241,18 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Explicit operation timeout
@@ -283,18 +291,20 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg local: Return local information, do not retrieve the state
             from cluster-manager node. Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -329,16 +339,18 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Explicit operation timeout
@@ -384,16 +396,18 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg wait_for_completion: Should this request wait until the
@@ -437,19 +451,21 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_unavailable: Whether to ignore unavailable
-            snapshots, defaults to false which means a SnapshotMissingException is
+            snapshots, defaults to `false` which means a SnapshotMissingException is
             thrown Default is false.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -484,16 +500,18 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Explicit operation timeout
@@ -532,16 +550,18 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Period to wait for a connection
-            to the master node.
+            use `cluster_manager_timeout` instead.): Period to wait for a connection
+            to the cluster-manager node.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response.
@@ -575,7 +595,7 @@ class SnapshotClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Clones indices from one snapshot into another snapshot in the same repository.
+        Clones indexes from one snapshot into another snapshot in the same repository.
 
 
         :arg repository: A repository name
@@ -585,16 +605,18 @@ class SnapshotClient(NamespacedClient):
         :arg cluster_manager_timeout: Operation timeout for connection
             to cluster-manager node.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg master_timeout (Deprecated: To promote inclusive language,
-            use 'cluster_manager_timeout' instead.): Explicit operation timeout for
-            connection to master node
+            use `cluster_manager_timeout` instead.): Explicit operation timeout for
+            connection to cluster-manager node
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """

--- a/opensearchpy/client/tasks.py
+++ b/opensearchpy/client/tasks.py
@@ -69,13 +69,15 @@ class TasksClient(NamespacedClient):
         :arg detailed: If `true`, the response includes detailed
             information about shard recoveries. Default is false.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg group_by: Key used to group tasks in the response. Valid
             choices are nodes, none, parents.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg nodes: Comma-separated list of node IDs or names to limit
             the returned information; use `_local` to return information from the
             node you're connecting to, leave empty to get information from all
@@ -84,7 +86,7 @@ class TasksClient(NamespacedClient):
             information. To return all tasks, omit this parameter or use a value of
             `-1`.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is
@@ -122,16 +124,18 @@ class TasksClient(NamespacedClient):
         :arg actions: Comma-separated list or wildcard expression of
             actions used to limit the request.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg nodes: Comma-separated list of node IDs or names used to
             limit the request.
         :arg parent_task_id: Parent task ID used to limit the tasks.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg wait_for_completion: Should the request block until the
@@ -166,13 +170,15 @@ class TasksClient(NamespacedClient):
 
         :arg task_id: ID of the task.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Period to wait for a response. If no response is

--- a/opensearchpy/client/wlm.py
+++ b/opensearchpy/client/wlm.py
@@ -18,21 +18,19 @@
 
 from typing import Any
 
-from ..client.utils import SKIP_IN_PATH, NamespacedClient, query_params
+from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
-class PplClient(NamespacedClient):
-    @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
-    )
-    async def explain(
+class WlmClient(NamespacedClient):
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def create_query_group(
         self,
         body: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Shows how a query is executed against OpenSearch.
+        Creates a new query group and sets the resource limits for the new query group.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -41,128 +39,122 @@ class PplClient(NamespacedClient):
             takes a comma-separated list of filters. It supports using wildcards to
             match any field or part of a field’s name. You can also exclude fields
             with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
         :arg human: Whether to return human readable values for
             statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
             response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
         if body in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'body'.")
 
-        return await self.transport.perform_request(
-            "POST", "/_plugins/_ppl/_explain", params=params, headers=headers, body=body
+        return self.transport.perform_request(
+            "PUT", "/_wlm/query_group", params=params, headers=headers, body=body
         )
 
-    @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
-    )
-    async def get_stats(
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def delete_query_group(
         self,
+        name: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Collect metrics for the plugin within the interval.
+        Deletes the specified query group.
 
 
+        :arg name: The name of the query group.
         :arg error_trace: Whether to include the stack trace of returned
             errors. Default is false.
         :arg filter_path: Used to reduce the response. This parameter
             takes a comma-separated list of filters. It supports using wildcards to
             match any field or part of a field’s name. You can also exclude fields
             with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
         :arg human: Whether to return human readable values for
             statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
             response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        return await self.transport.perform_request(
-            "GET", "/_plugins/_ppl/stats", params=params, headers=headers
+        if name in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'name'.")
+
+        return self.transport.perform_request(
+            "DELETE",
+            _make_path("_wlm", "query_group", name),
+            params=params,
+            headers=headers,
         )
 
-    @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
-    )
-    async def post_stats(
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def get_query_group(
         self,
+        name: Any = None,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Retrieves the specified query group. If no query group is specified, all query
+        groups in the cluster are retrieved.
+
+
+        :arg name: The name of the query group.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        return self.transport.perform_request(
+            "GET",
+            _make_path("_wlm", "query_group", name),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def update_query_group(
+        self,
+        name: Any,
         body: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        By a stats endpoint, you are able to collect metrics for the plugin within the
-        interval.
+        Updates the specified query group.
 
 
+        :arg name: The name of the query group.
         :arg error_trace: Whether to include the stack trace of returned
             errors. Default is false.
         :arg filter_path: Used to reduce the response. This parameter
             takes a comma-separated list of filters. It supports using wildcards to
             match any field or part of a field’s name. You can also exclude fields
             with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
         :arg human: Whether to return human readable values for
             statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
             response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
+        for param in (name, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
 
-        return await self.transport.perform_request(
-            "POST", "/_plugins/_ppl/stats", params=params, headers=headers, body=body
-        )
-
-    @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
-    )
-    async def query(
-        self,
-        body: Any,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Send a PPL query to the PPL plugin.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
-        return await self.transport.perform_request(
-            "POST", "/_plugins/_ppl", params=params, headers=headers, body=body
+        return self.transport.perform_request(
+            "PUT",
+            _make_path("_wlm", "query_group", name),
+            params=params,
+            headers=headers,
+            body=body,
         )

--- a/opensearchpy/plugins/asynchronous_search.py
+++ b/opensearchpy/plugins/asynchronous_search.py
@@ -18,21 +18,19 @@
 
 from typing import Any
 
-from ..client.utils import SKIP_IN_PATH, NamespacedClient, query_params
+from ..client.utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
-class PplClient(NamespacedClient):
-    @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
-    )
-    async def explain(
+class AsynchronousSearchClient(NamespacedClient):
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def delete(
         self,
-        body: Any,
+        id: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Shows how a query is executed against OpenSearch.
+        Delete asynchronous search.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -41,34 +39,76 @@ class PplClient(NamespacedClient):
             takes a comma-separated list of filters. It supports using wildcards to
             match any field or part of a field’s name. You can also exclude fields
             with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
         :arg human: Whether to return human readable values for
             statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
             response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
+        if id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'id'.")
 
-        return await self.transport.perform_request(
-            "POST", "/_plugins/_ppl/_explain", params=params, headers=headers, body=body
+        return self.transport.perform_request(
+            "DELETE",
+            _make_path("_plugins", "_asynchronous_search", id),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def get(
+        self,
+        id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Get partial responses from asynchronous search.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'id'.")
+
+        return self.transport.perform_request(
+            "GET",
+            _make_path("_plugins", "_asynchronous_search", id),
+            params=params,
+            headers=headers,
         )
 
     @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
+        "error_trace",
+        "filter_path",
+        "human",
+        "index",
+        "keep_alive",
+        "keep_on_completion",
+        "pretty",
+        "source",
+        "wait_for_completion_timeout",
     )
-    async def get_stats(
+    def search(
         self,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Collect metrics for the plugin within the interval.
+        Perform an asynchronous search.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -77,33 +117,37 @@ class PplClient(NamespacedClient):
             takes a comma-separated list of filters. It supports using wildcards to
             match any field or part of a field’s name. You can also exclude fields
             with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
         :arg human: Whether to return human readable values for
             statistics. Default is True.
+        :arg index: The name of the index to be searched.
+        :arg keep_alive: The amount of time that the result is saved in
+            the cluster.
+        :arg keep_on_completion: Whether you want to save the results in
+            the cluster after the search is complete.
         :arg pretty: Whether to pretty format the returned JSON
             response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
+        :arg wait_for_completion_timeout: The amount of time that you
+            plan to wait for the results.
         """
-        return await self.transport.perform_request(
-            "GET", "/_plugins/_ppl/stats", params=params, headers=headers
+        return self.transport.perform_request(
+            "POST",
+            "/_plugins/_asynchronous_search",
+            params=params,
+            headers=headers,
+            body=body,
         )
 
-    @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
-    )
-    async def post_stats(
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def stats(
         self,
-        body: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        By a stats endpoint, you are able to collect metrics for the plugin within the
-        interval.
+        Monitoring of asynchronous searches that are running, completed, and/or
+        persisted.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -112,57 +156,16 @@ class PplClient(NamespacedClient):
             takes a comma-separated list of filters. It supports using wildcards to
             match any field or part of a field’s name. You can also exclude fields
             with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
         :arg human: Whether to return human readable values for
             statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
             response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
-        return await self.transport.perform_request(
-            "POST", "/_plugins/_ppl/stats", params=params, headers=headers, body=body
-        )
-
-    @query_params(
-        "error_trace", "filter_path", "format", "human", "pretty", "sanitize", "source"
-    )
-    async def query(
-        self,
-        body: Any,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Send a PPL query to the PPL plugin.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg format: A short version of the Accept header (for example,
-            `json`, `yaml`).
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg sanitize: Specifies whether to escape special characters in
-            the results. Default is True.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
-        return await self.transport.perform_request(
-            "POST", "/_plugins/_ppl", params=params, headers=headers, body=body
+        return self.transport.perform_request(
+            "GET",
+            "/_plugins/_asynchronous_search/stats",
+            params=params,
+            headers=headers,
         )

--- a/opensearchpy/plugins/flow_framework.py
+++ b/opensearchpy/plugins/flow_framework.py
@@ -21,16 +21,216 @@ from typing import Any
 from ..client.utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
-class ObservabilityClient(NamespacedClient):
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    def create_object(
+class FlowFrameworkClient(NamespacedClient):
+    @query_params(
+        "error_trace",
+        "filter_path",
+        "human",
+        "pretty",
+        "provision",
+        "reprovision",
+        "source",
+        "update_fields",
+        "use_case",
+        "validation",
+    )
+    def create(
         self,
         body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Creates a new observability object.
+        Create a workflow.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        :arg use_case: To use a workflow template, specify it in the
+            `use_case` query parameter when creating a workflow.
+        """
+        return self.transport.perform_request(
+            "POST",
+            "/_plugins/_flow_framework/workflow",
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params(
+        "clear_status", "error_trace", "filter_path", "human", "pretty", "source"
+    )
+    def delete(
+        self,
+        workflow_id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Delete a workflow.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if workflow_id in SKIP_IN_PATH:
+            raise ValueError(
+                "Empty value passed for a required argument 'workflow_id'."
+            )
+
+        return self.transport.perform_request(
+            "DELETE",
+            _make_path("_plugins", "_flow_framework", "workflow", workflow_id),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params(
+        "allow_delete", "error_trace", "filter_path", "human", "pretty", "source"
+    )
+    def deprovision(
+        self,
+        workflow_id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Deprovision workflow's resources when you no longer need it.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if workflow_id in SKIP_IN_PATH:
+            raise ValueError(
+                "Empty value passed for a required argument 'workflow_id'."
+            )
+
+        return self.transport.perform_request(
+            "POST",
+            _make_path(
+                "_plugins", "_flow_framework", "workflow", workflow_id, "_deprovision"
+            ),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def get(
+        self,
+        workflow_id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Get a workflow.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if workflow_id in SKIP_IN_PATH:
+            raise ValueError(
+                "Empty value passed for a required argument 'workflow_id'."
+            )
+
+        return self.transport.perform_request(
+            "GET",
+            _make_path("_plugins", "_flow_framework", "workflow", workflow_id),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("all", "error_trace", "filter_path", "human", "pretty", "source")
+    def get_status(
+        self,
+        workflow_id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Get the provisioning deployment status until it is complete.
+
+
+        :arg all: The all parameter specifies whether the response
+            should return all fields. Default is false.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if workflow_id in SKIP_IN_PATH:
+            raise ValueError(
+                "Empty value passed for a required argument 'workflow_id'."
+            )
+
+        return self.transport.perform_request(
+            "GET",
+            _make_path(
+                "_plugins", "_flow_framework", "workflow", workflow_id, "_status"
+            ),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params(
+        "error_trace", "filter_path", "human", "pretty", "source", "workflow_step"
+    )
+    def get_steps(
+        self,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Get a list of workflow steps.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -47,25 +247,64 @@ class ObservabilityClient(NamespacedClient):
             libraries that do not accept a request body for non-POST requests.
         """
         return self.transport.perform_request(
+            "GET",
+            "/_plugins/_flow_framework/workflow/_steps",
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def provision(
+        self,
+        workflow_id: Any,
+        body: Any = None,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Provisioning a workflow. This API is also executed when the Create or Update
+        Workflow API is called with the provision parameter set to true.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if workflow_id in SKIP_IN_PATH:
+            raise ValueError(
+                "Empty value passed for a required argument 'workflow_id'."
+            )
+
+        return self.transport.perform_request(
             "POST",
-            "/_plugins/_observability/object",
+            _make_path(
+                "_plugins", "_flow_framework", "workflow", workflow_id, "_provision"
+            ),
             params=params,
             headers=headers,
             body=body,
         )
 
     @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    def delete_object(
+    def search(
         self,
-        object_id: Any,
+        body: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Deletes specific observability object specified by ID.
+        Search for workflows by using a query matching a field.
 
 
-        :arg object_id: The ID of the Observability Object.
         :arg error_trace: Whether to include the stack trace of returned
             errors. Default is false.
         :arg filter_path: Used to reduce the response. This parameter
@@ -79,160 +318,76 @@ class ObservabilityClient(NamespacedClient):
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if object_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'object_id'.")
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
 
         return self.transport.perform_request(
-            "DELETE",
-            _make_path("_plugins", "_observability", "object", object_id),
+            "POST",
+            "/_plugins/_flow_framework/workflow/_search",
             params=params,
             headers=headers,
+            body=body,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def search_state(
+        self,
+        body: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Search for workflows by using a query matching a field.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+
+        return self.transport.perform_request(
+            "POST",
+            "/_plugins/_flow_framework/workflow/state/_search",
+            params=params,
+            headers=headers,
+            body=body,
         )
 
     @query_params(
         "error_trace",
         "filter_path",
         "human",
-        "objectId",
-        "objectIdList",
         "pretty",
+        "provision",
+        "reprovision",
         "source",
+        "update_fields",
+        "use_case",
+        "validation",
     )
-    def delete_objects(
+    def update(
         self,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Deletes specific observability objects specified by ID or a list of IDs.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg objectId: The ID of a single Observability Object to
-            delete.
-        :arg objectIdList: A comma-separated list of Observability
-            Object IDs to delete.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        return self.transport.perform_request(
-            "DELETE", "/_plugins/_observability/object", params=params, headers=headers
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    def get_localstats(
-        self,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Retrieves Local Stats of all observability objects.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        return self.transport.perform_request(
-            "GET",
-            "/_plugins/_observability/_local/stats",
-            params=params,
-            headers=headers,
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    def get_object(
-        self,
-        object_id: Any,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Retrieves specific observability object specified by ID.
-
-
-        :arg object_id: The ID of the Observability Object.
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        if object_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'object_id'.")
-
-        return self.transport.perform_request(
-            "GET",
-            _make_path("_plugins", "_observability", "object", object_id),
-            params=params,
-            headers=headers,
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    def list_objects(
-        self,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Retrieves list of all observability objects.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        return self.transport.perform_request(
-            "GET", "/_plugins/_observability/object", params=params, headers=headers
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    def update_object(
-        self,
-        object_id: Any,
+        workflow_id: Any,
         body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Updates an existing observability object.
+        Update a workflow. You can only update a complete workflow if it has not yet
+        been provisioned.
 
 
-        :arg object_id: The ID of the Observability Object.
         :arg error_trace: Whether to include the stack trace of returned
             errors. Default is false.
         :arg filter_path: Used to reduce the response. This parameter
@@ -245,13 +400,17 @@ class ObservabilityClient(NamespacedClient):
             response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
+        :arg use_case: To use a workflow template, specify it in the
+            `use_case` query parameter when creating a workflow.
         """
-        if object_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'object_id'.")
+        if workflow_id in SKIP_IN_PATH:
+            raise ValueError(
+                "Empty value passed for a required argument 'workflow_id'."
+            )
 
         return self.transport.perform_request(
             "PUT",
-            _make_path("_plugins", "_observability", "object", object_id),
+            _make_path("_plugins", "_flow_framework", "workflow", workflow_id),
             params=params,
             headers=headers,
             body=body,

--- a/opensearchpy/plugins/knn.py
+++ b/opensearchpy/plugins/knn.py
@@ -35,13 +35,15 @@ class KnnClient(NamespacedClient):
 
         :arg model_id: The id of the model.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -68,13 +70,15 @@ class KnnClient(NamespacedClient):
 
         :arg model_id: The id of the model.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -147,15 +151,15 @@ class KnnClient(NamespacedClient):
         Use an OpenSearch query to search for models in the index.
 
 
-        :arg _source: True or false to return the _source field or not,
-            or a list of fields to return.
+        :arg _source: Set to `true` or `false` to return the `_source`
+            field or not, or a list of fields to return.
         :arg _source_excludes: List of fields to exclude from the
-            returned _source field.
+            returned `_source` field.
         :arg _source_includes: List of fields to extract and return from
-            the _source field.
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified).
+            the `_source` field.
+        :arg allow_no_indices: Whether to ignore if a wildcard indexes
+            expression resolves into no concrete indexes. (This includes `_all`
+            string or when no indexes have been specified).
         :arg allow_partial_search_results: Indicate if an error should
             be returned if there is a partial search failure or timeout. Default is
             True.
@@ -177,20 +181,21 @@ class KnnClient(NamespacedClient):
         :arg docvalue_fields: Comma-separated list of fields to return
             as the docvalue representation of a field for each hit.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
+            errors. Default is false.
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices are all,
-            closed, hidden, none, open.
+            concrete indexes that are open, closed or both.
         :arg explain: Specify whether to return detailed information
             about score computation as part of a hit.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg from_: Starting offset. Default is 0.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg ignore_throttled: Whether specified concrete, expanded or
-            aliased indices should be ignored when throttled.
-        :arg ignore_unavailable: Whether specified concrete indices
+            aliased indexes should be ignored when throttled.
+        :arg ignore_unavailable: Whether specified concrete indexes
             should be ignored when unavailable (missing or closed).
         :arg lenient: Specify whether format-based query failures (such
             as providing text to a numeric field) should be ignored.
@@ -203,18 +208,18 @@ class KnnClient(NamespacedClient):
             number of shards the search request expands to exceeds the threshold.
             This filter round-trip can limit the number of shards significantly if
             for instance a shard can not match any documents based on its rewrite
-            method ie. if date filters are mandatory to match but the shard bounds
-            and the query are disjoint.
+            method, that is if date filters are mandatory to match but the shard
+            bounds and the query are disjoint.
         :arg preference: Specify the node or shard the operation should
             be performed on. Default is random.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg q: Query in the Lucene query string syntax.
         :arg request_cache: Specify if request cache should be used for
             this request or not, defaults to index level setting.
-        :arg rest_total_hits_as_int: Indicates whether hits.total should
-            be rendered as an integer or an object in the rest search response.
-            Default is false.
+        :arg rest_total_hits_as_int: Indicates whether `hits.total`
+            should be rendered as an integer or an object in the rest search
+            response. Default is false.
         :arg routing: Comma-separated list of specific routing values.
         :arg scroll: Specify how long a consistent view of the index
             should be maintained for scrolled search.
@@ -280,13 +285,15 @@ class KnnClient(NamespacedClient):
         :arg stat: Comma-separated list of stats to retrieve; use `_all`
             or empty string to retrieve all stats.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         :arg timeout: Operation timeout.
@@ -315,14 +322,16 @@ class KnnClient(NamespacedClient):
 
         :arg model_id: The id of the model.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg preference: Preferred node to execute training.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -349,16 +358,18 @@ class KnnClient(NamespacedClient):
         specified indexes.
 
 
-        :arg index: Comma-separated list of indices; use `_all` or empty
-            string to perform the operation on all indices.
+        :arg index: Comma-separated list of indexes; use `_all` or empty
+            string to perform the operation on all indexes.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """

--- a/opensearchpy/plugins/ml.py
+++ b/opensearchpy/plugins/ml.py
@@ -34,13 +34,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -66,13 +68,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -100,13 +104,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -134,13 +140,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -166,13 +174,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -196,13 +206,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -226,13 +238,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -256,13 +270,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -288,13 +304,15 @@ class MlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -306,4 +324,172 @@ class MlClient(NamespacedClient):
             _make_path("_plugins", "_ml", "models", model_id, "_undeploy"),
             params=params,
             headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def create_connector(
+        self,
+        body: Any = None,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Creates a standalone connector.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        return self.transport.perform_request(
+            "POST",
+            "/_plugins/_ml/connectors/_create",
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def delete_agent(
+        self,
+        agent_id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Delete an agent.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if agent_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'agent_id'.")
+
+        return self.transport.perform_request(
+            "DELETE",
+            _make_path("_plugins", "_ml", "agents", agent_id),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def delete_connector(
+        self,
+        connector_id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Deletes a standalone connector.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if connector_id in SKIP_IN_PATH:
+            raise ValueError(
+                "Empty value passed for a required argument 'connector_id'."
+            )
+
+        return self.transport.perform_request(
+            "DELETE",
+            _make_path("_plugins", "_ml", "connectors", connector_id),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def delete_task(
+        self,
+        task_id: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Deletes a task.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if task_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'task_id'.")
+
+        return self.transport.perform_request(
+            "DELETE",
+            _make_path("_plugins", "_ml", "tasks", task_id),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def register_agents(
+        self,
+        body: Any = None,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Register an agent.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        return self.transport.perform_request(
+            "POST",
+            "/_plugins/_ml/agents/_register",
+            params=params,
+            headers=headers,
+            body=body,
         )

--- a/opensearchpy/plugins/notifications.py
+++ b/opensearchpy/plugins/notifications.py
@@ -34,13 +34,15 @@ class NotificationsClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -68,13 +70,15 @@ class NotificationsClient(NamespacedClient):
 
         :arg config_id: The ID of the channel configuration to delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -110,13 +114,15 @@ class NotificationsClient(NamespacedClient):
         :arg config_id_list: A comma-separated list of channel IDs to
             delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -136,13 +142,15 @@ class NotificationsClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -159,6 +167,8 @@ class NotificationsClient(NamespacedClient):
     @query_params(
         "chime.url",
         "chime.url.keyword",
+        "config_id",
+        "config_id_list",
         "config_type",
         "created_time_ms",
         "description",
@@ -211,17 +221,21 @@ class NotificationsClient(NamespacedClient):
         Get multiple channel configurations with filtering.
 
 
+        :arg config_id: Notification configuration ID.
+        :arg config_id_list: Notification configuration IDs.
         :arg config_type: Type of notification configuration. Valid
             choices are chime, email, email_group, microsoft_teams, ses_account,
             slack, smtp_account, sns, webhook.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -244,13 +258,15 @@ class NotificationsClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -270,13 +286,15 @@ class NotificationsClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -303,13 +321,15 @@ class NotificationsClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -336,13 +356,15 @@ class NotificationsClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """

--- a/opensearchpy/plugins/ppl.py
+++ b/opensearchpy/plugins/ppl.py
@@ -36,15 +36,17 @@ class PplClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg sanitize: Specifies whether to escape special characters in
             the results. Default is True.
         :arg source: The URL-encoded request definition. Useful for
@@ -70,15 +72,17 @@ class PplClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg sanitize: Specifies whether to escape special characters in
             the results. Default is True.
         :arg source: The URL-encoded request definition. Useful for
@@ -103,15 +107,17 @@ class PplClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg sanitize: Specifies whether to escape special characters in
             the results. Default is True.
         :arg source: The URL-encoded request definition. Useful for
@@ -138,15 +144,17 @@ class PplClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg sanitize: Specifies whether to escape special characters in
             the results. Default is True.
         :arg source: The URL-encoded request definition. Useful for

--- a/opensearchpy/plugins/query.py
+++ b/opensearchpy/plugins/query.py
@@ -35,13 +35,15 @@ class QueryClient(NamespacedClient):
 
         :arg datasource_name: The Name of the DataSource to delete.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -70,13 +72,15 @@ class QueryClient(NamespacedClient):
 
         :arg datasource_name: The Name of the DataSource to retrieve.
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -104,13 +108,15 @@ class QueryClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -133,13 +139,15 @@ class QueryClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -159,13 +167,15 @@ class QueryClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """

--- a/opensearchpy/plugins/replication.py
+++ b/opensearchpy/plugins/replication.py
@@ -21,16 +21,47 @@ from typing import Any
 from ..client.utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
-class NotificationsClient(NamespacedClient):
+class ReplicationClient(NamespacedClient):
     @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def create_config(
+    def autofollow_stats(
+        self,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Gets information about auto-follow activity and any replication rules
+        configured on the specified cluster.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        return self.transport.perform_request(
+            "GET",
+            "/_plugins/_replication/autofollow_stats",
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def create_replication_rule(
         self,
         body: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Create channel configuration.
+        Automatically starts replication on indexes matching a specified pattern.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -49,275 +80,23 @@ class NotificationsClient(NamespacedClient):
         if body in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'body'.")
 
-        return await self.transport.perform_request(
+        return self.transport.perform_request(
             "POST",
-            "/_plugins/_notifications/configs",
+            "/_plugins/_replication/_autofollow",
             params=params,
             headers=headers,
             body=body,
         )
 
     @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def delete_config(
+    def delete_replication_rule(
         self,
-        config_id: Any,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Delete a channel configuration.
-
-
-        :arg config_id: The ID of the channel configuration to delete.
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        if config_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'config_id'.")
-
-        return await self.transport.perform_request(
-            "DELETE",
-            _make_path("_plugins", "_notifications", "configs", config_id),
-            params=params,
-            headers=headers,
-        )
-
-    @query_params(
-        "config_id",
-        "config_id_list",
-        "error_trace",
-        "filter_path",
-        "human",
-        "pretty",
-        "source",
-    )
-    async def delete_configs(
-        self,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Delete multiple channel configurations.
-
-
-        :arg config_id: The ID of the channel configuration to delete.
-        :arg config_id_list: A comma-separated list of channel IDs to
-            delete.
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        return await self.transport.perform_request(
-            "DELETE", "/_plugins/_notifications/configs", params=params, headers=headers
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def get_config(
-        self,
-        config_id: Any,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Get a specific channel configuration.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        if config_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'config_id'.")
-
-        return await self.transport.perform_request(
-            "GET",
-            _make_path("_plugins", "_notifications", "configs", config_id),
-            params=params,
-            headers=headers,
-        )
-
-    @query_params(
-        "chime.url",
-        "chime.url.keyword",
-        "config_id",
-        "config_id_list",
-        "config_type",
-        "created_time_ms",
-        "description",
-        "description.keyword",
-        "email.email_account_id",
-        "email.email_group_id_list",
-        "email.recipient_list.recipient",
-        "email.recipient_list.recipient.keyword",
-        "email_group.recipient_list.recipient",
-        "email_group.recipient_list.recipient.keyword",
-        "error_trace",
-        "filter_path",
-        "human",
-        "is_enabled",
-        "last_updated_time_ms",
-        "microsoft_teams.url",
-        "microsoft_teams.url.keyword",
-        "name",
-        "name.keyword",
-        "pretty",
-        "query",
-        "ses_account.from_address",
-        "ses_account.from_address.keyword",
-        "ses_account.region",
-        "ses_account.role_arn",
-        "ses_account.role_arn.keyword",
-        "slack.url",
-        "slack.url.keyword",
-        "smtp_account.from_address",
-        "smtp_account.from_address.keyword",
-        "smtp_account.host",
-        "smtp_account.host.keyword",
-        "smtp_account.method",
-        "sns.role_arn",
-        "sns.role_arn.keyword",
-        "sns.topic_arn",
-        "sns.topic_arn.keyword",
-        "source",
-        "text_query",
-        "webhook.url",
-        "webhook.url.keyword",
-    )
-    async def get_configs(
-        self,
-        body: Any = None,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Get multiple channel configurations with filtering.
-
-
-        :arg config_id: Notification configuration ID.
-        :arg config_id_list: Notification configuration IDs.
-        :arg config_type: Type of notification configuration. Valid
-            choices are chime, email, email_group, microsoft_teams, ses_account,
-            slack, smtp_account, sns, webhook.
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        return await self.transport.perform_request(
-            "GET",
-            "/_plugins/_notifications/configs",
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def list_features(
-        self,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        List supported channel configurations.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        return await self.transport.perform_request(
-            "GET", "/_plugins/_notifications/features", params=params, headers=headers
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def send_test(
-        self,
-        config_id: Any,
-        params: Any = None,
-        headers: Any = None,
-    ) -> Any:
-        """
-        Send a test notification.
-
-
-        :arg error_trace: Whether to include the stack trace of returned
-            errors. Default is false.
-        :arg filter_path: Used to reduce the response. This parameter
-            takes a comma-separated list of filters. It supports using wildcards to
-            match any field or part of a field’s name. You can also exclude fields
-            with "-".
-        :arg human: Whether to return human readable values for
-            statistics. Default is True.
-        :arg pretty: Whether to pretty format the returned JSON
-            response. Default is false.
-        :arg source: The URL-encoded request definition. Useful for
-            libraries that do not accept a request body for non-POST requests.
-        """
-        if config_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'config_id'.")
-
-        return await self.transport.perform_request(
-            "GET",
-            _make_path("_plugins", "_notifications", "feature", "test", config_id),
-            params=params,
-            headers=headers,
-        )
-
-    @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def update_config(
-        self,
-        config_id: Any,
         body: Any,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        Update channel configuration.
+        Deletes the specified replication rule.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -333,26 +112,25 @@ class NotificationsClient(NamespacedClient):
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        for param in (config_id, body):
-            if param in SKIP_IN_PATH:
-                raise ValueError("Empty value passed for a required argument.")
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
 
-        return await self.transport.perform_request(
-            "PUT",
-            _make_path("_plugins", "_notifications", "configs", config_id),
+        return self.transport.perform_request(
+            "DELETE",
+            "/_plugins/_replication/_autofollow",
             params=params,
             headers=headers,
             body=body,
         )
 
     @query_params("error_trace", "filter_path", "human", "pretty", "source")
-    async def list_channels(
+    def follower_stats(
         self,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
         """
-        List created notification channels.
+        Gets information about follower (syncing) indexes on a specified cluster.
 
 
         :arg error_trace: Whether to include the stack trace of returned
@@ -368,6 +146,268 @@ class NotificationsClient(NamespacedClient):
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        return await self.transport.perform_request(
-            "GET", "/_plugins/_notifications/channels", params=params, headers=headers
+        return self.transport.perform_request(
+            "GET",
+            "/_plugins/_replication/follower_stats",
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def leader_stats(
+        self,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Gets information about replicated leader indexes on a specified cluster.
+
+
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        return self.transport.perform_request(
+            "GET", "/_plugins/_replication/leader_stats", params=params, headers=headers
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def pause(
+        self,
+        index: Any,
+        body: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Pauses replication of the leader index.
+
+
+        :arg index: Name of the data stream, index, or index alias to
+            perform bulk actions on.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        for param in (index, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return self.transport.perform_request(
+            "POST",
+            _make_path("_plugins", "_replication", index, "_pause"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def resume(
+        self,
+        index: Any,
+        body: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Resumes replication of the leader index.
+
+
+        :arg index: Name of the data stream, index, or index alias to
+            perform bulk actions on.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        for param in (index, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return self.transport.perform_request(
+            "POST",
+            _make_path("_plugins", "_replication", index, "_resume"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def start(
+        self,
+        index: Any,
+        body: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Initiate replication of an index from the leader cluster to the follower
+        cluster.
+
+
+        :arg index: Name of the data stream, index, or index alias to
+            perform bulk actions on.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        for param in (index, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return self.transport.perform_request(
+            "PUT",
+            _make_path("_plugins", "_replication", index, "_start"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def status(
+        self,
+        index: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Gets the status of index replication.
+
+
+        :arg index: Name of the data stream, index, or index alias to
+            perform bulk actions on.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        if index in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'index'.")
+
+        return self.transport.perform_request(
+            "GET",
+            _make_path("_plugins", "_replication", index, "_status"),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def stop(
+        self,
+        index: Any,
+        body: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Terminates replication and converts the follower index to a standard index.
+
+
+        :arg index: Name of the data stream, index, or index alias to
+            perform bulk actions on.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        for param in (index, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return self.transport.perform_request(
+            "POST",
+            _make_path("_plugins", "_replication", index, "_stop"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params("error_trace", "filter_path", "human", "pretty", "source")
+    def update_settings(
+        self,
+        index: Any,
+        body: Any,
+        params: Any = None,
+        headers: Any = None,
+    ) -> Any:
+        """
+        Updates settings on the follower index.
+
+
+        :arg index: Name of the data stream, index, or index alias to
+            perform bulk actions on.
+        :arg error_trace: Whether to include the stack trace of returned
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg human: Whether to return human readable values for
+            statistics. Default is True.
+        :arg pretty: Whether to pretty format the returned JSON
+            response. Default is false.
+        :arg source: The URL-encoded request definition. Useful for
+            libraries that do not accept a request body for non-POST requests.
+        """
+        for param in (index, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return self.transport.perform_request(
+            "PUT",
+            _make_path("_plugins", "_replication", index, "_update"),
+            params=params,
+            headers=headers,
+            body=body,
         )

--- a/opensearchpy/plugins/rollups.py
+++ b/opensearchpy/plugins/rollups.py
@@ -35,13 +35,15 @@ class RollupsClient(NamespacedClient):
 
         :arg id: Rollup to access
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -68,13 +70,15 @@ class RollupsClient(NamespacedClient):
 
         :arg id: Rollup to access
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -101,13 +105,15 @@ class RollupsClient(NamespacedClient):
 
         :arg id: Rollup to access
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -143,17 +149,19 @@ class RollupsClient(NamespacedClient):
 
         :arg id: Rollup to access
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg if_primary_term: Only perform the operation if the document
             has this primary term.
         :arg if_seq_no: Only perform the operation if the document has
             this sequence number.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -181,13 +189,15 @@ class RollupsClient(NamespacedClient):
 
         :arg id: Rollup to access
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -214,13 +224,15 @@ class RollupsClient(NamespacedClient):
 
         :arg id: Rollup to access
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """

--- a/opensearchpy/plugins/sql.py
+++ b/opensearchpy/plugins/sql.py
@@ -18,7 +18,7 @@
 
 from typing import Any
 
-from ..client.utils import SKIP_IN_PATH, NamespacedClient, query_params
+from ..client.utils import NamespacedClient, query_params
 
 
 class SqlClient(NamespacedClient):
@@ -27,7 +27,7 @@ class SqlClient(NamespacedClient):
     )
     def close(
         self,
-        body: Any,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -36,23 +36,22 @@ class SqlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg sanitize: Specifies whether to escape special characters in
             the results Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
         return self.transport.perform_request(
             "POST", "/_plugins/_sql/close", params=params, headers=headers, body=body
         )
@@ -62,7 +61,7 @@ class SqlClient(NamespacedClient):
     )
     def explain(
         self,
-        body: Any,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -71,23 +70,22 @@ class SqlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg sanitize: Specifies whether to escape special characters in
             the results Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
         return self.transport.perform_request(
             "POST", "/_plugins/_sql/_explain", params=params, headers=headers, body=body
         )
@@ -105,15 +103,17 @@ class SqlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg sanitize: Specifies whether to escape special characters in
             the results Default is True.
         :arg source: The URL-encoded request definition. Useful for
@@ -128,7 +128,7 @@ class SqlClient(NamespacedClient):
     )
     def post_stats(
         self,
-        body: Any,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -138,23 +138,22 @@ class SqlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg sanitize: Specifies whether to escape special characters in
             the results Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
         return self.transport.perform_request(
             "POST", "/_plugins/_sql/stats", params=params, headers=headers, body=body
         )
@@ -164,7 +163,7 @@ class SqlClient(NamespacedClient):
     )
     def query(
         self,
-        body: Any,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -173,23 +172,22 @@ class SqlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg sanitize: Specifies whether to escape special characters in
             the results Default is True.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
         return self.transport.perform_request(
             "POST", "/_plugins/_sql", params=params, headers=headers, body=body
         )
@@ -197,7 +195,7 @@ class SqlClient(NamespacedClient):
     @query_params("error_trace", "filter_path", "format", "human", "pretty", "source")
     def settings(
         self,
-        body: Any,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -206,21 +204,20 @@ class SqlClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
-        :arg format: A short version of the Accept header, e.g. json,
-            yaml.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
+        :arg format: A short version of the Accept header (for example,
+            `json`, `yaml`).
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
         return self.transport.perform_request(
             "PUT",
             "/_plugins/_query/settings",

--- a/opensearchpy/plugins/transforms.py
+++ b/opensearchpy/plugins/transforms.py
@@ -35,13 +35,15 @@ class TransformsClient(NamespacedClient):
 
         :arg id: Transform to delete
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -68,13 +70,15 @@ class TransformsClient(NamespacedClient):
 
         :arg id: Transform to explain
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -101,13 +105,15 @@ class TransformsClient(NamespacedClient):
 
         :arg id: Transform to access
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -124,6 +130,7 @@ class TransformsClient(NamespacedClient):
     @query_params("error_trace", "filter_path", "human", "pretty", "source")
     def preview(
         self,
+        body: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -132,18 +139,24 @@ class TransformsClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
         return self.transport.perform_request(
-            "GET", "/_plugins/_transform/_preview", params=params, headers=headers
+            "POST",
+            "/_plugins/_transform/_preview",
+            params=params,
+            headers=headers,
+            body=body,
         )
 
     @query_params(
@@ -163,23 +176,25 @@ class TransformsClient(NamespacedClient):
         headers: Any = None,
     ) -> Any:
         """
-        Create an index transform, or update a transform if if_seq_no and
-        if_primary_term are provided.
+        Create an index transform, or update a transform if `if_seq_no` and
+        `if_primary_term` are provided.
 
 
         :arg id: Transform to create/update
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg if_primary_term: Only perform the operation if the document
             has this primary term.
         :arg if_seq_no: Only perform the operation if the document has
             this sequence number.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -216,14 +231,16 @@ class TransformsClient(NamespacedClient):
 
 
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg from_: The starting transform to return. Default is `0`.
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg search: The search term to use to filter results.
         :arg size: Specifies the number of transforms to return. Default
             is `10`.
@@ -254,13 +271,15 @@ class TransformsClient(NamespacedClient):
 
         :arg id: Transform to start
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """
@@ -287,13 +306,15 @@ class TransformsClient(NamespacedClient):
 
         :arg id: Transform to stop
         :arg error_trace: Whether to include the stack trace of returned
-            errors.
-        :arg filter_path: Comma-separated list of filters used to reduce
-            the response.
+            errors. Default is false.
+        :arg filter_path: Used to reduce the response. This parameter
+            takes a comma-separated list of filters. It supports using wildcards to
+            match any field or part of a field’s name. You can also exclude fields
+            with "-".
         :arg human: Whether to return human readable values for
-            statistics.
+            statistics. Default is True.
         :arg pretty: Whether to pretty format the returned JSON
-            response.
+            response. Default is false.
         :arg source: The URL-encoded request definition. Useful for
             libraries that do not accept a request body for non-POST requests.
         """

--- a/test_opensearchpy/test_client/test_overrides.py
+++ b/test_opensearchpy/test_client/test_overrides.py
@@ -98,6 +98,16 @@ class TestOverriddenUrlTargets(OpenSearchTestCase):
         self.client.cluster.stats(node_id="test-node")
         self.assert_url_called("GET", "/_cluster/stats/nodes/test-node")
 
+        self.client.cluster.stats(node_id="test-node", metric="indices")
+        self.assert_url_called("GET", "/_cluster/stats/indices/nodes/test-node")
+
+        self.client.cluster.stats(
+            node_id="test-node", metric="indices", index_metric="analysis"
+        )
+        self.assert_url_called(
+            "GET", "/_cluster/stats/indices/analysis/nodes/test-node"
+        )
+
     def test_indices_put_mapping(self) -> None:
         self.client.indices.put_mapping(body={})
         self.assert_url_called("PUT", "/_all/_mapping")

--- a/utils/templates/overrides/cluster/stats
+++ b/utils/templates/overrides/cluster/stats
@@ -1,5 +1,12 @@
 {% extends "base" %}
+{% block func_params %}
+        node_id: Any = None,
+        params: Any = None,
+        headers: Any = None,
+        metric: Any = None,
+        index_metric: Any = None,
+{% endblock %}
 {% block request %}
-        return await self.transport.perform_request("{{ api.method }}", "/_cluster/stats" if node_id in SKIP_IN_PATH else _make_path("_cluster", "stats", "nodes", node_id), params=params, headers=headers)
+        return await self.transport.perform_request("{{ api.method }}", "/_cluster/stats" if node_id in SKIP_IN_PATH else _make_path("_cluster", "stats", metric, index_metric, "nodes", node_id), params=params, headers=headers)
 {% endblock%}
 


### PR DESCRIPTION
### Description

The `/_cluster/stats` endpoint exists now in all its glorious variations up to `/_cluster/stats/indices/analysis/nodes/test-node` which includes a metric (new), an index metric (new), and a node id (old). The generator added the metric and index metric in order, added a patch that swaps them to the end of the list to preserve backwards compatibility.

Adds `insights`, `list` and `wlm` APIs amongst others from spec.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
