### PR TITLE
Lifecycle integration tests.

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -101,7 +101,11 @@ test_opensearchpy/test_connection.py::TestRequestsConnection::test_no_http_compr
 test_opensearchpy/test_async/test_connection.py::TestAIOHttpConnection::test_no_http_compression PASSED [100%]
 ```
 
-Note that integration tests require docker to be installed and running, and downloads quite a bit of data from over the internet and hence take few minutes to complete.
+```
+./.ci/run-tests false 2.16.0 test_indices_lifecycle
+```
+
+Note that integration tests require docker to be installed and running, and downloads quite a bit of data from the internet and hence take few minutes to complete.
 
 ## Linter
 

--- a/samples/hello/hello_async.py
+++ b/samples/hello/hello_async.py
@@ -18,9 +18,9 @@ from opensearchpy import AsyncOpenSearch
 
 async def main() -> None:
     """
-    an example showing how to create an asynchronous connection
+    An example showing how to create an asynchronous connection
     to OpenSearch, create an index, index a document and
-    search to return the document
+    search to return the document.
     """
     # connect to OpenSearch
     host = "localhost"

--- a/samples/hello/unicode.py
+++ b/samples/hello/unicode.py
@@ -41,52 +41,22 @@ def main() -> None:
     info = client.info()
     print(f"Welcome to {info['version']['distribution']} {info['version']['number']}!")
 
-    # create an index
+    index_name = "кино"
+    index_create_result = client.indices.create(index=index_name)
+    print(index_create_result)
 
-    index_name = "test-index"
+    document = {"название": "Солярис", "автор": "Андрей Тарковский", "год": "2011"}
+    id = "соларис@2011"
+    doc_insert_result = client.index(
+        index=index_name, body=document, id=id, refresh=True
+    )
+    print(doc_insert_result)
 
-    index_body = {"settings": {"index": {"number_of_shards": 4}}}
+    doc_delete_result = client.delete(index=index_name, id=id)
+    print(doc_delete_result)
 
-    response = client.indices.create(index_name, body=index_body)
-
-    print(response)
-
-    # add a document to the index
-
-    document = {"title": "Moneyball", "director": "Bennett Miller", "year": "2011"}
-
-    doc_id = "1"
-
-    response = client.index(index=index_name, body=document, id=doc_id, refresh=True)
-
-    print(response)
-
-    # search for a document
-
-    user_query = "miller"
-
-    query = {
-        "size": 5,
-        "query": {
-            "multi_match": {"query": user_query, "fields": ["title^2", "director"]}
-        },
-    }
-
-    response = client.search(body=query, index=index_name)
-
-    print(response)
-
-    # delete the document
-
-    response = client.delete(index=index_name, id=doc_id)
-
-    print(response)
-
-    # delete the index
-
-    response = client.indices.delete(index=index_name)
-
-    print(response)
+    index_delete_result = client.indices.delete(index=index_name)
+    print(index_delete_result)
 
 
 if __name__ == "__main__":

--- a/samples/hello/unicode_async.py
+++ b/samples/hello/unicode_async.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+
+import asyncio
+import os
+
+from opensearchpy import AsyncOpenSearch
+
+
+async def main() -> None:
+    """
+    An example showing how to create an asynchronous connection
+    to OpenSearch, create an index, index a document and
+    search to return the document.
+    """
+    # connect to OpenSearch
+    host = "localhost"
+    port = 9200
+    auth = (
+        "admin",
+        os.getenv("OPENSEARCH_PASSWORD", "admin"),
+    )  # For testing only. Don't store credentials in code.
+
+    client = AsyncOpenSearch(
+        hosts=[{"host": host, "port": port}],
+        http_auth=auth,
+        use_ssl=True,
+        verify_certs=False,
+        ssl_show_warn=False,
+    )
+
+    try:
+        info = await client.info()
+        print(
+            f"Welcome to {info['version']['distribution']} {info['version']['number']}!"
+        )
+
+        index_name = "кино"
+        index_create_result = await client.indices.create(index=index_name)
+        print(index_create_result)
+
+        document = {"название": "Солярис", "автор": "Андрей Тарковский", "год": "2011"}
+        id = "соларис@2011"
+        doc_insert_result = await client.index(
+            index=index_name, body=document, id=id, refresh=True
+        )
+        print(doc_insert_result)
+
+        doc_delete_result = await client.delete(index=index_name, id=id)
+        print(doc_delete_result)
+
+        index_delete_result = await client.indices.delete(index=index_name)
+        print(index_delete_result)
+
+    finally:
+        await client.close()
+
+
+if __name__ == "__main__":
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main())
+    loop.close()

--- a/test_opensearchpy/test_async/test_server/test_clients.py
+++ b/test_opensearchpy/test_async/test_server/test_clients.py
@@ -30,7 +30,20 @@ from typing import Any
 import pytest
 from _pytest.mark.structures import MarkDecorator
 
+from opensearchpy.exceptions import RequestError
+
 pytestmark: MarkDecorator = pytest.mark.asyncio
+
+
+class TestSpecialCharacters:
+    async def test_index_with_slash(self, async_client: Any) -> None:
+        index_name = "movies/shmovies"
+        with pytest.raises(RequestError) as e:
+            await async_client.indices.create(index=index_name)
+        assert (
+            str(e.value)
+            == "RequestError(400, 'invalid_index_name_exception', 'Invalid index name [movies/shmovies], must not contain the following characters [ , \", *, \\\\, <, |, ,, >, /, ?]')"
+        )
 
 
 class TestUnicode:

--- a/test_opensearchpy/test_async/test_server/test_clients.py
+++ b/test_opensearchpy/test_async/test_server/test_clients.py
@@ -34,6 +34,53 @@ pytestmark: MarkDecorator = pytest.mark.asyncio
 
 
 class TestUnicode:
+    async def test_indices_lifecycle_english(self, async_client: Any) -> None:
+        index_name = "movies"
+
+        index_create_result = await async_client.indices.create(index=index_name)
+        assert index_create_result["acknowledged"] is True
+        assert index_name == index_create_result["index"]
+
+        document = {"name": "Solaris", "director": "Andrei Tartakovsky", "year": "2011"}
+        id = "solaris@2011"
+        doc_insert_result = await async_client.index(
+            index=index_name, body=document, id=id, refresh=True
+        )
+        assert "created" == doc_insert_result["result"]
+        assert index_name == doc_insert_result["_index"]
+        assert id == doc_insert_result["_id"]
+
+        doc_delete_result = await async_client.delete(index=index_name, id=id)
+        assert "deleted" == doc_delete_result["result"]
+        assert index_name == doc_delete_result["_index"]
+        assert id == doc_delete_result["_id"]
+
+        index_delete_result = await async_client.indices.delete(index=index_name)
+        assert index_delete_result["acknowledged"] is True
+
+    async def test_indices_lifecycle_russian(self, async_client: Any) -> None:
+        index_name = "кино"
+        index_create_result = await async_client.indices.create(index=index_name)
+        assert index_create_result["acknowledged"] is True
+        assert index_name == index_create_result["index"]
+
+        document = {"название": "Солярис", "автор": "Андрей Тарковский", "год": "2011"}
+        id = "соларис@2011"
+        doc_insert_result = await async_client.index(
+            index=index_name, body=document, id=id, refresh=True
+        )
+        assert "created" == doc_insert_result["result"]
+        assert index_name == doc_insert_result["_index"]
+        assert id == doc_insert_result["_id"]
+
+        doc_delete_result = await async_client.delete(index=index_name, id=id)
+        assert "deleted" == doc_delete_result["result"]
+        assert index_name == doc_delete_result["_index"]
+        assert id == doc_delete_result["_id"]
+
+        index_delete_result = await async_client.indices.delete(index=index_name)
+        assert index_delete_result["acknowledged"] is True
+
     async def test_indices_analyze(self, async_client: Any) -> None:
         await async_client.indices.analyze(body='{"text": "привет"}')
 

--- a/test_opensearchpy/test_server/test_clients.py
+++ b/test_opensearchpy/test_server/test_clients.py
@@ -29,6 +29,53 @@ from . import OpenSearchTestCase
 
 
 class TestUnicode(OpenSearchTestCase):
+    def test_indices_lifecycle_english(self) -> None:
+        index_name = "movies"
+
+        index_create_result = self.client.indices.create(index=index_name)
+        self.assertTrue(index_create_result["acknowledged"])
+        self.assertEqual(index_name, index_create_result["index"])
+
+        document = {"name": "Solaris", "director": "Andrei Tartakovsky", "year": "2011"}
+        id = "solaris@2011"
+        doc_insert_result = self.client.index(
+            index=index_name, body=document, id=id, refresh=True
+        )
+        self.assertEqual("created", doc_insert_result["result"])
+        self.assertEqual(index_name, doc_insert_result["_index"])
+        self.assertEqual(id, doc_insert_result["_id"])
+
+        doc_delete_result = self.client.delete(index=index_name, id=id)
+        self.assertEqual("deleted", doc_delete_result["result"])
+        self.assertEqual(index_name, doc_delete_result["_index"])
+        self.assertEqual(id, doc_delete_result["_id"])
+
+        index_delete_result = self.client.indices.delete(index=index_name)
+        self.assertTrue(index_delete_result["acknowledged"])
+
+    def test_indices_lifecycle_russian(self) -> None:
+        index_name = "кино"
+        index_create_result = self.client.indices.create(index=index_name)
+        self.assertTrue(index_create_result["acknowledged"])
+        self.assertEqual(index_name, index_create_result["index"])
+
+        document = {"название": "Солярис", "автор": "Андрей Тарковский", "год": "2011"}
+        id = "соларис@2011"
+        doc_insert_result = self.client.index(
+            index=index_name, body=document, id=id, refresh=True
+        )
+        self.assertEqual("created", doc_insert_result["result"])
+        self.assertEqual(index_name, doc_insert_result["_index"])
+        self.assertEqual(id, doc_insert_result["_id"])
+
+        doc_delete_result = self.client.delete(index=index_name, id=id)
+        self.assertEqual("deleted", doc_delete_result["result"])
+        self.assertEqual(index_name, doc_delete_result["_index"])
+        self.assertEqual(id, doc_delete_result["_id"])
+
+        index_delete_result = self.client.indices.delete(index=index_name)
+        self.assertTrue(index_delete_result["acknowledged"])
+
     def test_indices_analyze(self) -> None:
         self.client.indices.analyze(body='{"text": "привет"}')
 

--- a/test_opensearchpy/test_server/test_clients.py
+++ b/test_opensearchpy/test_server/test_clients.py
@@ -25,7 +25,22 @@
 #  under the License.
 
 
+import pytest
+
+from opensearchpy.exceptions import RequestError
+
 from . import OpenSearchTestCase
+
+
+class TestSpecialCharacters(OpenSearchTestCase):
+    def test_index_with_slash(self) -> None:
+        index_name = "movies/shmovies"
+        with pytest.raises(RequestError) as e:
+            self.client.indices.create(index=index_name)
+        self.assertEqual(
+            str(e.value),
+            "RequestError(400, 'invalid_index_name_exception', 'Invalid index name [movies/shmovies], must not contain the following characters [ , \", *, \\\\, <, |, ,, >, /, ?]')",
+        )
 
 
 class TestUnicode(OpenSearchTestCase):


### PR DESCRIPTION
### Description

For #848. 

Adds samples and integration tests for the lifecycle of an index and document with a unicode name and id.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
