### PR TITLE
feat: allow to set a signature host for tunnel usage with async client

### DIFF
--- a/test_opensearchpy/test_async/test_signer.py
+++ b/test_opensearchpy/test_async/test_signer.py
@@ -143,6 +143,7 @@ class TestAsyncSignerWithSpecialCharacters:
                 url: str,
                 query_string: Optional[str] = None,
                 body: Optional[Union[str, bytes]] = None,
+                headers: Optional[Dict[str, str]] = None,
             ) -> Dict[str, str]:
                 nonlocal signed_url
                 signed_url = url


### PR DESCRIPTION
### Description
When creating an Async client, you can now pass a custom 'host' header that will be used for signing the AWS request, if using AWS authentication. This allows accessing OpenSearch via SSH/SSM tunnel, since when doing so the local port of OS would be, most of the time, 443 which is protected.

### Issues Resolved
Closes #184 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
