### PR TITLE
made custom headers be available to async aws signer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Added option to pass custom headers to 'AWSV4SignerAsyncAuth' ([863](https://github.com/opensearch-project/opensearch-py/pull/863))
 ### Updated APIs
 ### Changed
 ### Deprecated

--- a/opensearchpy/helpers/asyncsigner.py
+++ b/opensearchpy/helpers/asyncsigner.py
@@ -56,7 +56,7 @@ class AWSV4SignerAsyncAuth:
         from botocore.auth import SigV4Auth
         from botocore.awsrequest import AWSRequest
 
-        signature_host = self._fetch_url(url, headers or dict())  # type: ignore
+        signature_host = self._fetch_url(url, headers or dict())
 
         # create an AWS request object and sign it using SigV4Auth
         aws_request = AWSRequest(
@@ -86,25 +86,25 @@ class AWSV4SignerAsyncAuth:
         # copy the headers from AWS request object into the prepared_request
         return dict(aws_request.headers.items())
 
-    def _fetch_url(self, url, headers):  # type: ignore
+    def _fetch_url(self, url: str, headers: Optional[Dict[str, str]]) -> str:
         """
         This is a util method that helps in reconstructing the request url.
         :param prepared_request: unsigned request
         :return: reconstructed url
         """
-        url = urlparse(url)
-        path = url.path or "/"
+        parsed_url = urlparse(url)
+        path = parsed_url.path or "/"
 
         # fetch the query string if present in the request
         querystring = ""
-        if url.query:
+        if parsed_url.query:
             querystring = "?" + urlencode(
-                parse_qs(url.query, keep_blank_values=True), doseq=True
+                parse_qs(parsed_url.query, keep_blank_values=True), doseq=True
             )
 
         # fetch the host information from headers
-        headers = {key.lower(): value for key, value in headers.items()}
-        location = headers.get("host") or url.netloc
+        headers = {key.lower(): value for key, value in (headers or dict()).items()}
+        location = headers.get("host") or parsed_url.netloc
 
         # construct the url and return
-        return url.scheme + "://" + location + path + querystring
+        return parsed_url.scheme + "://" + location + path + querystring

--- a/opensearchpy/helpers/signer.py
+++ b/opensearchpy/helpers/signer.py
@@ -92,14 +92,14 @@ class RequestsAWSV4SignerAuth(requests.auth.AuthBase):
         prepared_request.headers.update(
             self.signer.sign(
                 prepared_request.method,
-                self._fetch_url(prepared_request),  # type: ignore
+                self._fetch_url(prepared_request),
                 prepared_request.body,
             )
         )
 
         return prepared_request
 
-    def _fetch_url(self, prepared_request):  # type: ignore
+    def _fetch_url(self, prepared_request: requests.PreparedRequest) -> str:
         """
         This is a util method that helps in reconstructing the request url.
         :param prepared_request: unsigned request
@@ -112,7 +112,7 @@ class RequestsAWSV4SignerAuth(requests.auth.AuthBase):
         querystring = ""
         if url.query:
             querystring = "?" + urlencode(
-                parse_qs(url.query, keep_blank_values=True), doseq=True
+                parse_qs(url.query, keep_blank_values=True), doseq=True  # type: ignore
             )
 
         # fetch the host information from headers
@@ -122,7 +122,7 @@ class RequestsAWSV4SignerAuth(requests.auth.AuthBase):
         location = headers.get("host") or url.netloc
 
         # construct the url and return
-        return url.scheme + "://" + location + path + querystring
+        return url.scheme + "://" + location + path + querystring  # type: ignore
 
 
 # Deprecated: use RequestsAWSV4SignerAuth

--- a/test_opensearchpy/test_async/test_signer.py
+++ b/test_opensearchpy/test_async/test_signer.py
@@ -143,6 +143,7 @@ class TestAsyncSignerWithSpecialCharacters:
                 url: str,
                 query_string: Optional[str] = None,
                 body: Optional[Union[str, bytes]] = None,
+                headers: Optional[Dict[str, str]] = None,
             ) -> Dict[str, str]:
                 nonlocal signed_url
                 signed_url = url

--- a/test_opensearchpy/test_async/test_signer.py
+++ b/test_opensearchpy/test_async/test_signer.py
@@ -77,6 +77,20 @@ class TestAsyncSigner:
         assert "X-Amz-Security-Token" in headers
         assert "X-Amz-Content-SHA256" in headers
 
+    async def test_aws_signer_async_fetch_url_with_querystring(self) -> None:
+        region = "us-west-2"
+        service = "aoss"
+
+        from opensearchpy.helpers.asyncsigner import AWSV4SignerAsyncAuth
+
+        auth = AWSV4SignerAsyncAuth(self.mock_session(), region, service)
+
+        signature_host = auth._fetch_url(
+            "http://localhost/?foo=bar", headers={"host": "otherhost"}
+        )
+
+        assert signature_host == "http://otherhost/?foo=bar"
+
 
 class TestAsyncSignerWithFrozenCredentials(TestAsyncSigner):
     def mock_session(self, disable_get_frozen: bool = True) -> Mock:

--- a/test_opensearchpy/test_connection/test_requests_http_connection.py
+++ b/test_opensearchpy/test_connection/test_requests_http_connection.py
@@ -457,6 +457,23 @@ class TestRequestsHttpConnection(TestCase):
 
         return dummy_session
 
+    def test_aws_signer_fetch_url_with_querystring(self) -> None:
+        region = "us-west-2"
+
+        import requests
+
+        from opensearchpy.helpers.signer import RequestsAWSV4SignerAuth
+
+        auth = RequestsAWSV4SignerAuth(self.mock_session(), region)
+
+        prepared_request = requests.Request(
+            "GET", "http://localhost/?foo=bar", headers={"host": "otherhost:443"}
+        ).prepare()
+
+        signature_host = auth._fetch_url(prepared_request)
+
+        assert signature_host == "http://otherhost:443/?foo=bar"
+
     def test_aws_signer_as_http_auth(self) -> None:
         region = "us-west-2"
 


### PR DESCRIPTION
### Description
When creating an Async client, you can now pass a custom 'host' header that will be used for signing the AWS request, if using AWS authentication. This allows accessing OpenSearch via SSH/SSM tunnel, since when doing so the local port of OS would be, most of the time, 443 which is protected.

### Issues Resolved
Closes #184 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
