### PR TITLE
Fixed test client initialization in fetching to ensure tests run locally

### DIFF
--- a/test_opensearchpy/run_tests.py
+++ b/test_opensearchpy/run_tests.py
@@ -68,7 +68,10 @@ def fetch_opensearch_repo() -> None:
 
     # find out the sha of the running client
     try:
-        client = get_client()
+        client = get_client(
+            verify_certs=False,
+            http_auth=("admin", environ.get("OPENSEARCH_PASSWORD", "admin"))
+        )
         sha = client.info()["version"]["build_hash"]
     except (SkipTest, KeyError):
         print("No running opensearch >1.X server...")


### PR DESCRIPTION
### Description
It fixes the same problem as in #267 in the same way, but this time it was caused by `fetch_opensearch_repo`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
