### PR TITLE
Fix failing integration tests with unreleased versions of OpenSearch

### DIFF
--- a/.github/workflows/integration-unreleased.yml
+++ b/.github/workflows/integration-unreleased.yml
@@ -11,7 +11,7 @@ jobs:
         entry:
           - { branch: "1.x", java-version: "11" }
           - { branch: "2.x", java-version: "17" }
-          - { branch: "main", java-version: "17" }
+          - { branch: "main", java-version: "21" }
 
     steps:
       - name: Checkout OpenSearch


### PR DESCRIPTION
### Description
Change JDK version to 21 for main branch.

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-py/issues/904

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
