### PR TITLE
Explicit proxy support in RequestsHttpConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Small refactor of AWS Signer classes for both sync and async clients ([866](https://github.com/opensearch-project/opensearch-py/pull/866))
 - Small refactor to fix overwriting the module files when generating apis ([874](https://github.com/opensearch-project/opensearch-py/pull/874))
 - Fixed a "type ignore" lint error
+- Added support for explicit proxy to RequestsHttpConnection ([908](https://github.com/opensearch-project/opensearch-py/pull/908))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/opensearchpy/connection/http_requests.py
+++ b/opensearchpy/connection/http_requests.py
@@ -27,7 +27,7 @@
 
 import time
 import warnings
-from typing import Any, Collection, Mapping, Optional, Union
+from typing import Any, Collection, Mapping, MutableMapping, Optional, Union
 
 try:
     import requests
@@ -74,6 +74,7 @@ class RequestsHttpConnection(Connection):
     :arg metrics: metrics is an instance of a subclass of the
         :class:`~opensearchpy.Metrics` class, used for collecting
         and reporting metrics related to the client's operations;
+    :arg proxies: optional dictionary mapping protocol to the URL of the proxy.
     """
 
     def __init__(
@@ -92,6 +93,7 @@ class RequestsHttpConnection(Connection):
         opaque_id: Any = None,
         pool_maxsize: Any = None,
         metrics: Metrics = MetricsNone(),
+        proxies: Optional[MutableMapping[str, str]] = None,
         **kwargs: Any,
     ) -> None:
         self.metrics = metrics
@@ -131,6 +133,8 @@ class RequestsHttpConnection(Connection):
             elif isinstance(http_auth, string_types):
                 http_auth = tuple(http_auth.split(":", 1))  # type: ignore
             self.session.auth = http_auth
+
+        self.session.proxies = proxies or {}
 
         self.base_url = f"{self.host}{self.url_prefix}"
         self.session.verify = verify_certs

--- a/test_opensearchpy/test_connection/test_requests_http_connection.py
+++ b/test_opensearchpy/test_connection/test_requests_http_connection.py
@@ -222,6 +222,10 @@ class TestRequestsHttpConnection(TestCase):
         con = RequestsHttpConnection(http_auth=["username", "secret"])
         self.assertEqual(("username", "secret"), con.session.auth)
 
+    def test_proxies(self) -> None:
+        con = RequestsHttpConnection(proxies={"http": "http://localhost:8118"})
+        self.assertEqual({"http": "http://localhost:8118"}, con.session.proxies)
+
     def test_repr(self) -> None:
         con = self._get_mock_connection({"host": "opensearchpy.com", "port": 443})
         self.assertEqual(


### PR DESCRIPTION
### Description

This PR allows specifying an explicit proxy to the underlying `requests.Session`, overriding environment configuration.
This is useful when a specific proxy is required to access OpenSearch but nothing else (such as local tunnels).

#### Workaround

I've been using a very small/clean subclass across different projects for this, however I think it's clean and useful enough to be pushed to the main upstream class 😄 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
