### PR TITLE
Bumps aiohttp from >=3.9.4,<4 to >=3.10.11,<4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 ### Security
 ### Dependencies
+- Bumps `aiohttp` from >=3.9.4,<4 to >=3.10.11,<4 ([#919](https://github.com/opensearch-project/opensearch-py/pull/919))
+
 
 ## [3.0.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 ### Security
 ### Dependencies
-- Bumps `aiohttp` from >=3.9.4,<4 to >=3.10.11,<4 ([#919](https://github.com/opensearch-project/opensearch-py/pull/919))
+- Bumps `aiohttp` from >=3.9.4,<4 to >=3.10.11,<4 ([#920](https://github.com/opensearch-project/opensearch-py/pull/920))
 
 
 ## [3.0.0]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -20,6 +20,6 @@ black>=24.3.0
 twine
 
 # Requirements for testing [async] extra
-aiohttp>=3.9.4, <4
+aiohttp>=3.10.11, <4
 pytest-asyncio<=0.25.1
 unasync

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ tests_require = [
     "pytest-mock<4.0.0",
 ]
 
-async_require = ["aiohttp>=3.9.4,<4"]
+async_require = ["aiohttp>=3.10.11,<4"]
 
 docs_require = ["sphinx", "sphinx_rtd_theme", "myst_parser", "sphinx_copybutton"]
 generate_require = ["black>=24.3.0", "jinja2"]


### PR DESCRIPTION
### Description
Bumps `aiohttp` from `>=3.9.4,<4` to `>=3.10.11,<4` to fix CVE issue.

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-py/issues/852

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
