### PR TITLE
Fix Async request signer (issue #924)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Moved client tests to dedicated files to ensure they are run ([944](https://github.com/opensearch-project/opensearch-py/pull/944))
+- Fix Async request signer ([932](https://github.com/opensearch-project/opensearch-py/pull/932))
+
 ### Security
 ### Dependencies
 - Bumps `aiohttp` from >=3.9.4,<4 to >=3.10.11,<4 ([#920](https://github.com/opensearch-project/opensearch-py/pull/920))

--- a/opensearchpy/connection/http_async.py
+++ b/opensearchpy/connection/http_async.py
@@ -13,7 +13,17 @@ import asyncio
 import os
 import ssl
 import warnings
-from typing import Any, Collection, Mapping, Optional, Union
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import yarl
 
@@ -39,7 +49,15 @@ class AsyncHttpConnection(AIOHttpConnection):
         self,
         host: str = "localhost",
         port: Optional[int] = None,
-        http_auth: Any = None,
+        http_auth: Optional[
+            Union[
+                Tuple[str, str],
+                List[str],
+                str,
+                bytes,
+                Callable[[str, str, Optional[bytes], Dict[Any, Any]], Dict[Any, Any]],
+            ]
+        ] = None,
         use_ssl: bool = False,
         verify_certs: Any = VERIFY_CERTS_DEFAULT,
         ssl_show_warn: Any = SSL_SHOW_WARN_DEFAULT,
@@ -205,7 +223,9 @@ class AsyncHttpConnection(AIOHttpConnection):
         if callable(self._http_auth):
             req_headers = {
                 **req_headers,
-                **self._http_auth(method, url, query_string, body),
+                **self._http_auth(
+                    method=method, url=url, body=body, headers=req_headers
+                ),
             }
 
         start = self.loop.time()

--- a/opensearchpy/connection/http_async.py
+++ b/opensearchpy/connection/http_async.py
@@ -221,9 +221,12 @@ class AsyncHttpConnection(AIOHttpConnection):
             self._http_auth if isinstance(self._http_auth, aiohttp.BasicAuth) else None
         )
         if callable(self._http_auth):
-            req_headers = self._http_auth(
-                method=method, url=url, body=body, headers=req_headers
-            )
+            req_headers = {
+                **req_headers,
+                **self._http_auth(
+                    method=method, url=url, body=body, headers=req_headers
+                ),
+            }
 
         start = self.loop.time()
         try:

--- a/opensearchpy/connection/http_async.py
+++ b/opensearchpy/connection/http_async.py
@@ -221,12 +221,9 @@ class AsyncHttpConnection(AIOHttpConnection):
             self._http_auth if isinstance(self._http_auth, aiohttp.BasicAuth) else None
         )
         if callable(self._http_auth):
-            req_headers = {
-                **req_headers,
-                **self._http_auth(
-                    method=method, url=url, body=body, headers=req_headers
-                ),
-            }
+            req_headers = self._http_auth(
+                method=method, url=url, body=body, headers=req_headers
+            )
 
         start = self.loop.time()
         try:

--- a/test_opensearchpy/test_async/test_http_connection.py
+++ b/test_opensearchpy/test_async/test_http_connection.py
@@ -140,6 +140,7 @@ class TestAsyncHttpConnection:
             auth=None,
             headers={
                 "Test": "PASSED",
+                "a-header": "a-value",
             },
             timeout=aiohttp.ClientTimeout(
                 total=10,

--- a/test_opensearchpy/test_async/test_http_connection.py
+++ b/test_opensearchpy/test_async/test_http_connection.py
@@ -73,9 +73,9 @@ class TestAsyncHttpConnection:
 
     def test_auth_as_callable(self) -> None:
         def auth_fn(
-            _method: str, _url: str, _body: Optional[bytes], headers: Dict[str, str]
+            _method: str, _url: str, _body: Optional[bytes], _headers: Dict[str, str]
         ) -> Dict[str, str]:
-            return headers
+            return {}
 
         c = AsyncHttpConnection(http_auth=auth_fn)
         assert callable(c._http_auth)

--- a/test_opensearchpy/test_async/test_http_connection.py
+++ b/test_opensearchpy/test_async/test_http_connection.py
@@ -25,7 +25,7 @@
 #  under the License.
 
 
-from typing import Any
+from typing import Any, Dict, Optional
 from unittest import mock
 
 import pytest
@@ -72,8 +72,10 @@ class TestAsyncHttpConnection:
         assert c._http_auth.password, "password"
 
     def test_auth_as_callable(self) -> None:
-        def auth_fn() -> None:
-            pass
+        def auth_fn(
+            _method: str, _url: str, _body: Optional[bytes], headers: Dict[str, str]
+        ) -> Dict[str, str]:
+            return headers
 
         c = AsyncHttpConnection(http_auth=auth_fn)
         assert callable(c._http_auth)
@@ -108,17 +110,29 @@ class TestAsyncHttpConnection:
     @pytest.mark.asyncio  # type: ignore
     @mock.patch("aiohttp.ClientSession.request")
     async def test_callable_in_request_session(self, mock_request: Any) -> None:
+        calls = []
+
         def auth_fn(*args: Any, **kwargs: Any) -> Any:
-            return {
-                "Test": "PASSED",
-            }
+            calls.append((args, kwargs))
+            return {"Test": "PASSED"}
 
         mock_request.return_value = TestAsyncHttpConnection.MockResponse()
 
         c = AsyncHttpConnection(http_auth=auth_fn, loop=get_running_loop())
-        c.headers = {}
+        c.headers = {"a-header": "a-value"}
         await c.perform_request("post", "/test")
 
+        assert calls == [
+            (
+                tuple(),
+                {
+                    "body": None,
+                    "headers": {"a-header": "a-value"},
+                    "method": "post",
+                    "url": "http://localhost:9200/test",
+                },
+            )
+        ]
         mock_request.assert_called_with(
             "post",
             yarl.URL("http://localhost:9200/test", encoded=True),


### PR DESCRIPTION
### Description
Fixes the mismatch between the call args of _http_auth() in AsyncHttpConnection and the implementations.

### Issues Resolved
Closes #924

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
