### PR TITLE
Adding Dependabot configuration to bump github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,12 @@ updates:
     labels:
       - "dependabot"
       - "dependencies"
+  - directory: /
+    open-pull-requests-limit: 3
+    package-ecosystem: github-actions
+    schedule:
+      interval: weekly
+    labels:
+      - "dependabot"
+      - "dependencies"
 version: 2


### PR DESCRIPTION
### Description
Add Dependabot configuration to keep github-actions up-to-date.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
