### PR TITLE
ci: fix mypy type ignore for untyped decorator in tests

### DIFF
--- a/test_opensearchpy/test_async/test_aiohttp.py
+++ b/test_opensearchpy/test_async/test_aiohttp.py
@@ -40,7 +40,7 @@ class TestAIOHttp:
         assert client.transport.connection_class == AsyncHttpConnection
         assert client.transport.pool_maxsize == 42
 
-    @pytest.mark.parametrize(  # type: ignore[misc]
+    @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
         "connection_class", [AIOHttpConnection, AsyncHttpConnection]
     )
     async def test_default_limit(self, connection_class: Type[AsyncConnection]) -> None:
@@ -57,7 +57,7 @@ class TestAIOHttp:
             == 10
         )
 
-    @pytest.mark.parametrize(  # type: ignore[misc]
+    @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
         "connection_class", [AIOHttpConnection, AsyncHttpConnection]
     )
     async def test_custom_limit(self, connection_class: Type[AsyncConnection]) -> None:

--- a/test_opensearchpy/test_helpers/test_query.py
+++ b/test_opensearchpy/test_helpers/test_query.py
@@ -566,7 +566,7 @@ def test_script_score() -> None:
     assert q.to_dict() == d
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     "minimum_should_match",
     [1, -1, "1", "-1", "50%", "-50%", "1<50%"],
 )


### PR DESCRIPTION
### Description
It's seems that the CI lint step, currently failed with these errors:

```
nox > mypy --strict setup.py noxfile.py opensearchpy/ test_opensearchpy/ utils/ samples/ benchmarks/ docs/
test_opensearchpy/test_helpers/test_query.py:569: error: Unused "type: ignore" comment  [unused-ignore]
test_opensearchpy/test_helpers/test_query.py:569: error: Untyped decorator makes function "test_bool_with_minimum_should_match_as_int_or_string" untyped  [untyped-decorator]
test_opensearchpy/test_helpers/test_query.py:569: note: Error code "untyped-decorator" not covered by "type: ignore" comment
test_opensearchpy/test_async/test_aiohttp.py:43: error: Unused "type: ignore" comment  [unused-ignore]
test_opensearchpy/test_async/test_aiohttp.py:43: error: Untyped decorator makes function "test_default_limit" untyped  [untyped-decorator]
test_opensearchpy/test_async/test_aiohttp.py:43: note: Error code "untyped-decorator" not covered by "type: ignore" comment
test_opensearchpy/test_async/test_aiohttp.py:60: error: Unused "type: ignore" comment  [unused-ignore]
test_opensearchpy/test_async/test_aiohttp.py:60: error: Untyped decorator makes function "test_custom_limit" untyped  [untyped-decorator]
test_opensearchpy/test_async/test_aiohttp.py:60: note: Error code "untyped-decorator" not covered by "type: ignore" comment
Found 6 errors in 2 files (checked 290 source files)
nox > Command mypy --strict setup.py noxfile.py opensearchpy/ test_opensearchpy/ utils/ samples/ benchmarks/ docs/ failed with exit code 1
nox > Session lint-3.10 failed.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
