### PR TITLE
Bump opensearch protobufs - 1.2.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `actions/upload-artifact` from 5 to 6 ([#989](https://github.com/opensearch-project/opensearch-py/pull/989))
 - Bump `actions/download-artifact` from 6 to 7 ([#988](https://github.com/opensearch-project/opensearch-py/pull/988))
 - Bump `peter-evans/create-pull-request` from 7 to 8 ([#990](https://github.com/opensearch-project/opensearch-py/pull/990))
+- Bump `opensearch-protobufs` from 0.19.0 to 1.2.0 ([#1000](https://github.com/opensearch-project/opensearch-py/pull/1000))
+
 
 ## [3.1.0]
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ install_requires = [
     "Events",
     # License: Apache 2.0
     # gRPC transport client libraries
-    "opensearch-protobufs==0.19.0",
+    "opensearch-protobufs==1.2.0",
 ]
 tests_require = [
     "requests>=2.0.0, <3.0.0",


### PR DESCRIPTION
### Description
Bump opensearch-protobufs schema to maintain compatibility with breaking changes in 3.5 schema.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
