### PR TITLE
fix(docs): use keyword arguments in security API examples

### DIFF
--- a/guides/plugins/security.md
+++ b/guides/plugins/security.md
@@ -26,7 +26,7 @@ role_content = {
   ],
 }
 
-response = client.security.create_role(role_name, body=role_content)
+response = client.security.create_role(role=role_name, body=role_content)
 print(response)
 ```
 
@@ -35,7 +35,7 @@ print(response)
 ```python
 role_name = "test-role"
 
-response = client.security.get_role(role_name)
+response = client.security.get_role(role=role_name)
 print(response)
 ```
 
@@ -54,6 +54,6 @@ print(response)
 ```python
 user_name = "test-user"
 
-response = client.security.get_user(user_name)
+response = client.security.get_user(username=user_name)
 print(response)
 ```


### PR DESCRIPTION
### Description
Update create_role, get_role, and get_user examples to pass arguments as keyword args (role=, username=) instead of positional.

### Issues Resolved
#1003

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
