### PR TITLE
Fix AWSV4Signer.sign() not passing headers to AWSRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed `AWSV4Signer.sign()` not passing custom headers to `AWSRequest`, causing `x-amz-*` headers to be excluded from SigV4 signature ([#1034](https://github.com/opensearch-project/opensearch-py/issues/1034))
 - Fixed the `linkchecker` CI step ([#987](https://github.com/opensearch-project/opensearch-py/pull/987))
 ### Security
 ### Dependencies

--- a/opensearchpy/helpers/signer.py
+++ b/opensearchpy/helpers/signer.py
@@ -48,7 +48,9 @@ class AWSV4Signer:
         signature_host = self._fetch_url(url, headers or dict())
 
         # create an AWS request object and sign it using SigV4Auth
-        aws_request = AWSRequest(method=method.upper(), url=signature_host, data=body)
+        aws_request = AWSRequest(
+            method=method.upper(), url=signature_host, data=body, headers=headers or {}
+        )
 
         # credentials objects expose access_key, secret_key and token attributes
         # via @property annotations that call _refresh() on every access,

--- a/test_opensearchpy/test_async/test_signer.py
+++ b/test_opensearchpy/test_async/test_signer.py
@@ -90,9 +90,13 @@ class TestAsyncSigner:
         ) as mock_aws_request:
             auth = AWSV4SignerAsyncAuth(self.mock_session(), region, service)
             auth("GET", "http://localhost/?foo=bar", headers={"host": "otherhost:443"})
-            mock_aws_request.assert_called_with(
-                method="GET", url="http://otherhost:443/?foo=bar", data=None
-            )
+            mock_aws_request.assert_called_once()
+            call_kwargs = mock_aws_request.call_args[1]
+            assert call_kwargs["method"] == "GET"
+            assert call_kwargs["url"] == "http://otherhost:443/?foo=bar"
+            assert call_kwargs["data"] is None
+            assert "host" in call_kwargs["headers"]
+            assert call_kwargs["headers"]["host"] == "otherhost:443"
 
 
 class TestAsyncSignerWithFrozenCredentials(TestAsyncSigner):

--- a/test_opensearchpy/test_connection/test_requests_http_connection.py
+++ b/test_opensearchpy/test_connection/test_requests_http_connection.py
@@ -479,9 +479,36 @@ class TestRequestsHttpConnection(TestCase):
             ).prepare()
             auth(prepared_request)
 
-            mock_aws_request.assert_called_with(
-                method="GET", url="http://otherhost:443/?foo=bar", data=None
-            )
+            mock_aws_request.assert_called_once()
+            call_kwargs = mock_aws_request.call_args[1]
+            self.assertEqual(call_kwargs["method"], "GET")
+            self.assertEqual(call_kwargs["url"], "http://otherhost:443/?foo=bar")
+            self.assertIsNone(call_kwargs["data"])
+            self.assertIn("host", call_kwargs["headers"])
+            self.assertEqual(call_kwargs["headers"]["host"], "otherhost:443")
+
+    def test_aws_signer_signs_custom_headers(self) -> None:
+        region = "us-west-2"
+        service = "aoss"
+
+        import requests
+
+        from opensearchpy.helpers.signer import RequestsAWSV4SignerAuth
+
+        auth = RequestsAWSV4SignerAuth(self.mock_session(), region, service)
+        prepared_request = requests.Request(
+            "GET",
+            "http://localhost",
+            headers={
+                "x-amz-aoss-collection-id": "col-id",
+                "x-amz-aoss-collection-name": "col-name",
+            },
+        ).prepare()
+        auth(prepared_request)
+
+        auth_header = prepared_request.headers["Authorization"]
+        self.assertIn("x-amz-aoss-collection-id", auth_header)
+        self.assertIn("x-amz-aoss-collection-name", auth_header)
 
     def test_aws_signer_as_http_auth(self) -> None:
         region = "us-west-2"


### PR DESCRIPTION
### Description
`AWSV4Signer.sign()` accepts a `headers` parameter but does not forward it to `AWSRequest`. This causes custom `x-amz-*` headers to be excluded from the SigV4 `SignedHeaders`, violating the AWS SigV4 spec.

One-line fix: pass `headers=headers or {}` to `AWSRequest()` in `opensearchpy/helpers/signer.py`.

Fixes #1034

### Issues Resolved

- [#1034] AWSV4Signer.sign() does not pass custom headers to AWSRequest for SigV4 signing

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented in the CHANGELOG
- [x] Commits are signed with a DCO signature
