### PR TITLE
fix(signer): Include X-Amz-Content-SHA256 in SignedHeaders (#1038)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        opensearch_version: [  '2.18.0', '2.19.4', '3.3.2' ]
+        opensearch_version: [  '2.18.0', '2.19.5', '3.6.0' ]
         secured: [ "true", "false" ]
         
     steps:

--- a/.github/workflows/unified-release.yml
+++ b/.github/workflows/unified-release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack_version: ["3.1.0"]
+        stack_version: ["3.2.0"]
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Fixed `AWSV4Signer.sign()` not passing custom headers to `AWSRequest`, causing `x-amz-*` headers to be excluded from SigV4 signature ([#1034](https://github.com/opensearch-project/opensearch-py/issues/1034))
+- Fixed `AWSV4Signer.sign()` not setting `X-Amz-Content-SHA256` before `SigV4Auth.add_auth()`, causing the header to be absent from `SignedHeaders` in the `Authorization` header. The fix uses a guarded assignment that preserves caller-provided values (e.g., `UNSIGNED-PAYLOAD`, precomputed hashes) ([#1038](https://github.com/opensearch-project/opensearch-py/issues/1038))
 - Fixed the `linkchecker` CI step ([#987](https://github.com/opensearch-project/opensearch-py/pull/987))
 ### Security
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+### Updated APIs
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+### Dependencies
+
+## [3.2.0]
+### Added
 - Add dependency on opensearch-protobufs to provide client libraries for gRPC transport ([#977](https://github.com/opensearch-project/opensearch-py/pull/977))
 - Add ML Commons plugin documentation ([#992](https://github.com/opensearch-project/opensearch-py/pull/992))
 ### Updated APIs
@@ -12,7 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Fixed `AWSV4Signer.sign()` not passing custom headers to `AWSRequest`, causing `x-amz-*` headers to be excluded from SigV4 signature ([#1034](https://github.com/opensearch-project/opensearch-py/issues/1034))
-- Fixed `AWSV4Signer.sign()` not setting `X-Amz-Content-SHA256` before `SigV4Auth.add_auth()`, causing the header to be absent from `SignedHeaders` in the `Authorization` header. The fix uses a guarded assignment that preserves caller-provided values (e.g., `UNSIGNED-PAYLOAD`, precomputed hashes) ([#1038](https://github.com/opensearch-project/opensearch-py/issues/1038))
+- Fixed `AWSV4Signer.sign()` not setting `X-Amz-Content-SHA256` before `SigV4Auth.add_auth()`, causing the header to be absent from `SignedHeaders` in the `Authorization` header. The fix uses a guarded assignment that preserves caller-provided values (e.g., `UNSIGNED-PAYLOAD`, precomputed hashes) ([#1038](https://github.com/opensearch-project/opensearch-py/issues/1038), [#1039](https://github.com/opensearch-project/opensearch-py/pull/1039))
 - Fixed the `linkchecker` CI step ([#987](https://github.com/opensearch-project/opensearch-py/pull/987))
 ### Security
 ### Dependencies

--- a/opensearchpy/_version.py
+++ b/opensearchpy/_version.py
@@ -24,4 +24,4 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-__versionstr__: str = "3.1.0"
+__versionstr__: str = "3.2.0"

--- a/opensearchpy/helpers/signer.py
+++ b/opensearchpy/helpers/signer.py
@@ -72,7 +72,9 @@ class AWSV4Signer:
         # Per the SigV4 spec, x-amz-* headers must be signed. Preserve any
         # caller-provided value (e.g., UNSIGNED-PAYLOAD or precomputed hashes).
         if "X-Amz-Content-SHA256" not in aws_request.headers:
-            aws_request.headers["X-Amz-Content-SHA256"] = sig_v4_auth.payload(aws_request)
+            aws_request.headers["X-Amz-Content-SHA256"] = sig_v4_auth.payload(
+                aws_request
+            )
 
         sig_v4_auth.add_auth(aws_request)
 

--- a/opensearchpy/helpers/signer.py
+++ b/opensearchpy/helpers/signer.py
@@ -67,13 +67,16 @@ class AWSV4Signer:
         )
 
         sig_v4_auth = SigV4Auth(credentials, self.service, self.region)
+
+        # Set X-Amz-Content-SHA256 before signing so it is included in SignedHeaders.
+        # Per the SigV4 spec, x-amz-* headers must be signed. Preserve any
+        # caller-provided value (e.g., UNSIGNED-PAYLOAD or precomputed hashes).
+        if "X-Amz-Content-SHA256" not in aws_request.headers:
+            aws_request.headers["X-Amz-Content-SHA256"] = sig_v4_auth.payload(aws_request)
+
         sig_v4_auth.add_auth(aws_request)
 
-        # copy the headers from AWS request object into the prepared_request
-        headers = dict(aws_request.headers.items())
-        headers["X-Amz-Content-SHA256"] = sig_v4_auth.payload(aws_request)
-
-        return headers
+        return dict(aws_request.headers.items())
 
     @staticmethod
     def _fetch_url(url: str, headers: Optional[Dict[str, str]]) -> str:

--- a/test_opensearchpy/test_connection/test_requests_http_connection.py
+++ b/test_opensearchpy/test_connection/test_requests_http_connection.py
@@ -546,6 +546,42 @@ class TestRequestsHttpConnection(TestCase):
         self.assertIn("X-Amz-Date", prepared_request.headers)
         self.assertIn("X-Amz-Security-Token", prepared_request.headers)
 
+    def test_aws_signer_signs_content_sha256(self) -> None:
+        region = "us-west-2"
+
+        import requests
+
+        from opensearchpy.helpers.signer import RequestsAWSV4SignerAuth
+
+        auth = RequestsAWSV4SignerAuth(self.mock_session(), region)
+        prepared_request = requests.Request("GET", "http://localhost").prepare()
+        auth(prepared_request)
+
+        self.assertIn("X-Amz-Content-SHA256", prepared_request.headers)
+        auth_header = prepared_request.headers["Authorization"]
+        signed_headers = auth_header.split("SignedHeaders=")[1].split(",")[0]
+        self.assertIn("x-amz-content-sha256", signed_headers)
+
+    def test_aws_signer_preserves_caller_content_sha256(self) -> None:
+        import requests
+
+        from opensearchpy.helpers.signer import RequestsAWSV4SignerAuth
+
+        auth = RequestsAWSV4SignerAuth(self.mock_session(), "us-west-2")
+        prepared_request = requests.Request(
+            "GET",
+            "http://localhost",
+            headers={"X-Amz-Content-SHA256": "UNSIGNED-PAYLOAD"},
+        ).prepare()
+        auth(prepared_request)
+
+        self.assertEqual(
+            prepared_request.headers["X-Amz-Content-SHA256"], "UNSIGNED-PAYLOAD"
+        )
+        auth_header = prepared_request.headers["Authorization"]
+        signed_headers = auth_header.split("SignedHeaders=")[1].split(",")[0]
+        self.assertIn("x-amz-content-sha256", signed_headers)
+
     @patch("opensearchpy.helpers.signer.AWSV4Signer.sign")
     def test_aws_signer_signs_with_query_string(self, mock_sign: Any) -> None:
         region = "us-west-1"


### PR DESCRIPTION
### Description

`AWSV4Signer.sign()` does not set `X-Amz-Content-SHA256` on the `AWSRequest` before calling `SigV4Auth.add_auth()`. Because plain `SigV4Auth` (unlike `S3SigV4Auth`) never injects this header, it is absent from `SignedHeaders`, violating the [AWS SigV4 spec](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html) which requires all `x-amz-*` headers to be signed.

The fix adds a guarded assignment before `add_auth()` that preserves caller-provided values (e.g., `UNSIGNED-PAYLOAD`).

### Issues Resolved

Closes #1038


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
