### PR TITLE
Move io.grpc to optional dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,9 +60,6 @@ install_requires = [
     "python-dateutil",
     "certifi>=2024.07.04",
     "Events",
-    # License: Apache 2.0
-    # gRPC transport client libraries
-    "opensearch-protobufs==1.2.0",
 ]
 tests_require = [
     "requests>=2.0.0, <3.0.0",
@@ -121,6 +118,7 @@ setup(
         "develop": tests_require + docs_require + generate_require,
         "docs": docs_require + async_require,
         "async": async_require,
+        "grpc": ["opensearch-protobufs==1.2.0"],
         "kerberos": ["requests_kerberos"],
     },
 )


### PR DESCRIPTION
### Description
Move io.grpc dependency to extras_require.
Users will avoid downloading io.grpc package by default and must explicitly request these dependencies:
```
pip install opensearch-py[grpc]
```

### Issues Resolved
https://github.com/opensearch-project/opensearch-py/issues/1040

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
