### PR TITLE
[Backport] Move io.grpc to optional dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,9 +60,6 @@ install_requires = [
     "python-dateutil",
     "certifi>=2024.07.04",
     "Events",
-    # License: Apache 2.0
-    # gRPC transport client libraries
-    "opensearch-protobufs==0.19.0",
 ]
 tests_require = [
     "requests>=2.0.0, <3.0.0",
@@ -122,5 +119,6 @@ setup(
         "docs": docs_require + async_require,
         "async": async_require,
         "kerberos": ["requests_kerberos"],
+        "grpc": ["opensearch-protobufs==0.19.0"],
     },
 )


### PR DESCRIPTION
### Description
Backport:
https://github.com/opensearch-project/opensearch-py/pull/1042

### Issues Resolved
https://github.com/opensearch-project/opensearch-py/issues/1040

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
