### PR TITLE
Fix SigV4 signature mismatch caused by hop-by-hop headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Fix `UnicodeEncodeError` on surrogate/emoji characters in bulk chunk sizing by passing `surrogatepass` error handler ([#1086](https://github.com/opensearch-project/opensearch-py/pull/1086))
+- Fixed `AWSV4Signer.sign()` including hop-by-hop headers (e.g., `connection`) in SigV4 signature, causing 403 errors when the HTTP transport layer modifies these headers after signing ([#1044](https://github.com/opensearch-project/opensearch-py/issues/1044))
 ### Security
 - Refresh `samples/` and `benchmarks/` poetry locks and pin fixed transitive floors to clear all outstanding dependency CVE findings: aiohttp `>=3.14.1` (CVE-2026-54273..54280 et al.), urllib3 `>=2.7.0` (CVE-2025-50181/-50182/-66418/-66471, CVE-2026-21441/-44431/-44432), requests `>=2.33.0` (CVE-2024-47081, CVE-2026-25645), and idna `>=3.18` (CVE-2026-45409) ([#1082](https://github.com/opensearch-project/opensearch-py/pull/1082))
 ### Dependencies

--- a/opensearchpy/helpers/signer.py
+++ b/opensearchpy/helpers/signer.py
@@ -47,9 +47,39 @@ class AWSV4Signer:
 
         signature_host = self._fetch_url(url, headers or dict())
 
+        # Exclude hop-by-hop headers from signing. These headers (e.g.,
+        # "connection") may be modified or removed by the HTTP transport layer
+        # (aiohttp, urllib3) after signing, which would cause a signature
+        # mismatch and result in a 403 from AWS.
+        hop_by_hop = frozenset(
+            (
+                "connection",
+                "keep-alive",
+                "proxy-authenticate",
+                "proxy-authorization",
+                "te",
+                "trailer",
+                "transfer-encoding",
+                "upgrade",
+            )
+        )
+        headers_lower = {k.lower(): v for k, v in (headers or {}).items()}
+        conn_nominated = frozenset(
+            token.strip().lower()
+            for token in headers_lower.get("connection", "").split(",")
+            if token.strip()
+        )
+        exclude = hop_by_hop | conn_nominated
+        signing_headers = {
+            k: v for k, v in (headers or {}).items() if k.lower() not in exclude
+        }
+
         # create an AWS request object and sign it using SigV4Auth
         aws_request = AWSRequest(
-            method=method.upper(), url=signature_host, data=body, headers=headers or {}
+            method=method.upper(),
+            url=signature_host,
+            data=body,
+            headers=signing_headers,
         )
 
         # credentials objects expose access_key, secret_key and token attributes

--- a/opensearchpy/helpers/signer.py
+++ b/opensearchpy/helpers/signer.py
@@ -50,9 +50,8 @@ class AWSV4Signer:
         # Only sign headers required by the SigV4 spec: host and x-amz-*.
         # Passing all headers risks a signature mismatch when the HTTP
         # transport layer (aiohttp, urllib3) modifies them after signing.
-        headers_lower = {k.lower(): v for k, v in (headers or {}).items()}
-        signing_headers = {
-            "host": headers_lower.get("host") or urlparse(url).netloc,
+        signature_headers = {
+            "host": urlparse(signature_host).netloc,
             **{
                 k: v
                 for k, v in (headers or {}).items()
@@ -64,7 +63,7 @@ class AWSV4Signer:
             method=method.upper(),
             url=signature_host,
             data=body,
-            headers=signing_headers,
+            headers=signature_headers,
         )
 
         # credentials objects expose access_key, secret_key and token attributes

--- a/opensearchpy/helpers/signer.py
+++ b/opensearchpy/helpers/signer.py
@@ -47,34 +47,19 @@ class AWSV4Signer:
 
         signature_host = self._fetch_url(url, headers or dict())
 
-        # Exclude hop-by-hop headers from signing. These headers (e.g.,
-        # "connection") may be modified or removed by the HTTP transport layer
-        # (aiohttp, urllib3) after signing, which would cause a signature
-        # mismatch and result in a 403 from AWS.
-        hop_by_hop = frozenset(
-            (
-                "connection",
-                "keep-alive",
-                "proxy-authenticate",
-                "proxy-authorization",
-                "te",
-                "trailer",
-                "transfer-encoding",
-                "upgrade",
-            )
-        )
+        # Only sign headers required by the SigV4 spec: host and x-amz-*.
+        # Passing all headers risks a signature mismatch when the HTTP
+        # transport layer (aiohttp, urllib3) modifies them after signing.
         headers_lower = {k.lower(): v for k, v in (headers or {}).items()}
-        conn_nominated = frozenset(
-            token.strip().lower()
-            for token in headers_lower.get("connection", "").split(",")
-            if token.strip()
-        )
-        exclude = hop_by_hop | conn_nominated
         signing_headers = {
-            k: v for k, v in (headers or {}).items() if k.lower() not in exclude
+            "host": headers_lower.get("host") or urlparse(url).netloc,
+            **{
+                k: v
+                for k, v in (headers or {}).items()
+                if k.lower().startswith("x-amz-")
+            },
         }
 
-        # create an AWS request object and sign it using SigV4Auth
         aws_request = AWSRequest(
             method=method.upper(),
             url=signature_host,

--- a/test_opensearchpy/test_async/test_signer.py
+++ b/test_opensearchpy/test_async/test_signer.py
@@ -127,7 +127,7 @@ class TestAsyncSignerWithFrozenCredentials(TestAsyncSigner):
         assert len(mock_session.get_frozen_credentials.mock_calls) == 1
 
 
-class TestAsyncSignerHopByHopHeaders:
+class TestAsyncSignerAllowlistHeaders:
     def mock_session(self) -> Mock:
         access_key = uuid.uuid4().hex
         secret_key = uuid.uuid4().hex
@@ -141,30 +141,8 @@ class TestAsyncSignerHopByHopHeaders:
 
         return dummy_session
 
-    async def test_connection_header_excluded_from_signing(self) -> None:
-        """connection header must not be included in SigV4 SignedHeaders.
-
-        aiohttp (and other HTTP libraries) may override hop-by-hop headers
-        after signing. If 'connection' is signed but then modified by the
-        transport, the signature will not match and AWS returns 403.
-        """
-        region = "us-west-2"
-
-        from opensearchpy.helpers.asyncsigner import AWSV4SignerAsyncAuth
-
-        auth = AWSV4SignerAsyncAuth(self.mock_session(), region)
-        headers = auth(
-            "GET",
-            "http://localhost",
-            headers={"connection": "keep-alive", "host": "localhost"},
-        )
-        assert "Authorization" in headers
-        auth_header = headers["Authorization"]
-        signed_headers_part = auth_header.split("SignedHeaders=")[1].split(",")[0]
-        assert "connection" not in signed_headers_part.split(";")
-
-    async def test_connection_nominated_headers_excluded_from_signing(self) -> None:
-        """Headers nominated by the Connection header must also be excluded."""
+    async def test_only_host_and_x_amz_headers_are_signed(self) -> None:
+        """Only host and x-amz-* headers should be included in SignedHeaders."""
         region = "us-west-2"
 
         from opensearchpy.helpers.asyncsigner import AWSV4SignerAsyncAuth
@@ -174,19 +152,20 @@ class TestAsyncSignerHopByHopHeaders:
             "GET",
             "http://localhost",
             headers={
-                "connection": "keep-alive, x-custom-hop",
-                "x-custom-hop": "some-value",
+                "connection": "keep-alive",
                 "host": "localhost",
-                "x-safe-header": "keep-me",
+                "content-type": "application/json",
+                "x-amz-custom": "value",
             },
         )
         assert "Authorization" in headers
         auth_header = headers["Authorization"]
         signed_headers_part = auth_header.split("SignedHeaders=")[1].split(",")[0]
         signed_list = signed_headers_part.split(";")
+        assert "host" in signed_list
+        assert "x-amz-custom" in signed_list
         assert "connection" not in signed_list
-        assert "x-custom-hop" not in signed_list
-        assert "x-safe-header" in signed_list
+        assert "content-type" not in signed_list
 
 
 class TestAsyncSignerWithSpecialCharacters:

--- a/test_opensearchpy/test_async/test_signer.py
+++ b/test_opensearchpy/test_async/test_signer.py
@@ -141,31 +141,99 @@ class TestAsyncSignerAllowlistHeaders:
 
         return dummy_session
 
-    async def test_only_host_and_x_amz_headers_are_signed(self) -> None:
-        """Only host and x-amz-* headers should be included in SignedHeaders."""
-        region = "us-west-2"
+    def _headers_passed_to_botocore(
+        self, request_headers: Dict[str, str]
+    ) -> Dict[str, str]:
+        """Sign a request and return the exact header dict handed to botocore's
+        AWSRequest, i.e. the headers that actually get signed."""
+        from botocore.awsrequest import AWSRequest
 
         from opensearchpy.helpers.asyncsigner import AWSV4SignerAsyncAuth
 
-        auth = AWSV4SignerAsyncAuth(self.mock_session(), region)
-        headers = auth(
-            "GET",
-            "http://localhost",
-            headers={
+        auth = AWSV4SignerAsyncAuth(self.mock_session(), "us-west-2")
+        with patch(
+            "botocore.awsrequest.AWSRequest", side_effect=AWSRequest
+        ) as mock_aws_request:
+            auth("GET", "http://localhost", headers=request_headers)
+        return mock_aws_request.call_args[1]["headers"]
+
+    def _sign_with_frozen_time(
+        self, auth: Any, request_headers: Dict[str, str]
+    ) -> Dict[str, str]:
+        """Sign with the given auth at a fixed timestamp so two signatures made
+        with the same credentials are directly comparable."""
+        import datetime as _dt
+
+        with patch("botocore.auth.datetime") as mock_datetime:
+            mock_datetime.datetime.utcnow.return_value = _dt.datetime(2020, 1, 1)
+            mock_datetime.timedelta = _dt.timedelta
+            return auth("GET", "http://localhost", headers=request_headers)
+
+    async def test_only_host_and_x_amz_headers_are_signed(self) -> None:
+        """Exactly host and x-amz-* headers — and nothing else — get signed."""
+        signed = self._headers_passed_to_botocore(
+            {
                 "connection": "keep-alive",
                 "host": "localhost",
                 "content-type": "application/json",
+                "accept-encoding": "gzip",
                 "x-amz-custom": "value",
+            }
+        )
+        assert {k.lower() for k in signed} == {"host", "x-amz-custom"}
+
+    async def test_x_amz_headers_included_case_insensitively(self) -> None:
+        """Mixed-case x-amz-* headers are matched and passed through verbatim."""
+        signed = self._headers_passed_to_botocore(
+            {
+                "X-Amz-Custom": "value",
+                "X-Amz-Content-SHA256": "UNSIGNED-PAYLOAD",
+            }
+        )
+        assert signed["X-Amz-Custom"] == "value"
+        assert signed["X-Amz-Content-SHA256"] == "UNSIGNED-PAYLOAD"
+        assert all(
+            k.lower() == "host" or k.lower().startswith("x-amz-") for k in signed
+        )
+
+    async def test_host_is_derived_from_request_url_not_raw_header(self) -> None:
+        """The signed host comes from the reconstructed URL, so a host header
+        pointing elsewhere is reflected consistently in the signature."""
+        signed = self._headers_passed_to_botocore({"host": "otherhost:443"})
+        assert signed["host"] == "otherhost:443"
+
+    async def test_signature_is_unaffected_by_hop_by_hop_headers(self) -> None:
+        """Regression for the fixed bug: a Connection/Content-Type header added
+        by the transport layer must not change the computed signature."""
+        from opensearchpy.helpers.asyncsigner import AWSV4SignerAsyncAuth
+
+        auth = AWSV4SignerAsyncAuth(self.mock_session(), "us-west-2")
+        baseline = self._sign_with_frozen_time(auth, {"x-amz-custom": "v"})
+        with_hop_by_hop = self._sign_with_frozen_time(
+            auth,
+            {
+                "connection": "keep-alive",
+                "content-type": "application/json",
+                "x-amz-custom": "v",
             },
         )
-        assert "Authorization" in headers
-        auth_header = headers["Authorization"]
-        signed_headers_part = auth_header.split("SignedHeaders=")[1].split(",")[0]
-        signed_list = signed_headers_part.split(";")
-        assert "host" in signed_list
-        assert "x-amz-custom" in signed_list
-        assert "connection" not in signed_list
-        assert "content-type" not in signed_list
+        assert baseline["Authorization"] == with_hop_by_hop["Authorization"]
+        # and hop-by-hop headers never leak into the returned signed headers
+        returned = {k.lower() for k in with_hop_by_hop}
+        assert "connection" not in returned
+        assert "content-type" not in returned
+
+    async def test_caller_provided_content_sha256_is_preserved(self) -> None:
+        """A caller-supplied X-Amz-Content-SHA256 (e.g. UNSIGNED-PAYLOAD) is not
+        overwritten by the computed payload hash."""
+        from opensearchpy.helpers.asyncsigner import AWSV4SignerAsyncAuth
+
+        auth = AWSV4SignerAsyncAuth(self.mock_session(), "us-west-2")
+        signed = self._sign_with_frozen_time(
+            auth, {"x-amz-content-sha256": "UNSIGNED-PAYLOAD"}
+        )
+        key = next(k for k in signed if k.lower() == "x-amz-content-sha256")
+        assert signed[key] == "UNSIGNED-PAYLOAD"
 
 
 class TestAsyncSignerWithSpecialCharacters:

--- a/test_opensearchpy/test_async/test_signer.py
+++ b/test_opensearchpy/test_async/test_signer.py
@@ -127,6 +127,68 @@ class TestAsyncSignerWithFrozenCredentials(TestAsyncSigner):
         assert len(mock_session.get_frozen_credentials.mock_calls) == 1
 
 
+class TestAsyncSignerHopByHopHeaders:
+    def mock_session(self) -> Mock:
+        access_key = uuid.uuid4().hex
+        secret_key = uuid.uuid4().hex
+        token = uuid.uuid4().hex
+        dummy_session = Mock()
+        dummy_session.access_key = access_key
+        dummy_session.secret_key = secret_key
+        dummy_session.token = token
+
+        del dummy_session.get_frozen_credentials
+
+        return dummy_session
+
+    async def test_connection_header_excluded_from_signing(self) -> None:
+        """connection header must not be included in SigV4 SignedHeaders.
+
+        aiohttp (and other HTTP libraries) may override hop-by-hop headers
+        after signing. If 'connection' is signed but then modified by the
+        transport, the signature will not match and AWS returns 403.
+        """
+        region = "us-west-2"
+
+        from opensearchpy.helpers.asyncsigner import AWSV4SignerAsyncAuth
+
+        auth = AWSV4SignerAsyncAuth(self.mock_session(), region)
+        headers = auth(
+            "GET",
+            "http://localhost",
+            headers={"connection": "keep-alive", "host": "localhost"},
+        )
+        assert "Authorization" in headers
+        auth_header = headers["Authorization"]
+        signed_headers_part = auth_header.split("SignedHeaders=")[1].split(",")[0]
+        assert "connection" not in signed_headers_part.split(";")
+
+    async def test_connection_nominated_headers_excluded_from_signing(self) -> None:
+        """Headers nominated by the Connection header must also be excluded."""
+        region = "us-west-2"
+
+        from opensearchpy.helpers.asyncsigner import AWSV4SignerAsyncAuth
+
+        auth = AWSV4SignerAsyncAuth(self.mock_session(), region)
+        headers = auth(
+            "GET",
+            "http://localhost",
+            headers={
+                "connection": "keep-alive, x-custom-hop",
+                "x-custom-hop": "some-value",
+                "host": "localhost",
+                "x-safe-header": "keep-me",
+            },
+        )
+        assert "Authorization" in headers
+        auth_header = headers["Authorization"]
+        signed_headers_part = auth_header.split("SignedHeaders=")[1].split(",")[0]
+        signed_list = signed_headers_part.split(";")
+        assert "connection" not in signed_list
+        assert "x-custom-hop" not in signed_list
+        assert "x-safe-header" in signed_list
+
+
 class TestAsyncSignerWithSpecialCharacters:
     def mock_session(self) -> Mock:
         access_key = uuid.uuid4().hex

--- a/test_opensearchpy/test_helpers/test_signer.py
+++ b/test_opensearchpy/test_helpers/test_signer.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+import uuid
+from unittest.mock import Mock
+
+import requests
+
+from opensearchpy.helpers.signer import RequestsAWSV4SignerAuth
+
+
+class TestRequestsSignerExcludesTransportHeaders:
+    """End-to-end check of the synchronous requests path.
+
+    RequestsAWSV4SignerAuth signs a real requests PreparedRequest, whose headers
+    the requests library populates with hop-by-hop / volatile values (Connection,
+    Content-Type, Content-Length, ...). If any of those are signed, the transport
+    later mutating them breaks the signature -- the exact bug this fix addresses.
+    Unlike the async unit test (which uses a hand-built header dict), this drives
+    the real requests plumbing with headers requests injects itself.
+    """
+
+    def mock_credentials(self) -> Mock:
+        credentials = Mock()
+        credentials.access_key = uuid.uuid4().hex
+        credentials.secret_key = uuid.uuid4().hex
+        credentials.token = uuid.uuid4().hex
+        del credentials.get_frozen_credentials
+        return credentials
+
+    def test_transport_injected_headers_are_not_signed(self) -> None:
+        prepared = requests.Session().prepare_request(
+            requests.Request(
+                "POST", "http://localhost:9200/index/_doc", json={"a": 1}
+            )
+        )
+        # sanity: the requests library really does inject the problematic headers
+        assert "Connection" in prepared.headers
+        assert "Content-Type" in prepared.headers
+
+        auth = RequestsAWSV4SignerAuth(self.mock_credentials(), "us-west-2")
+        signed = auth(prepared)
+
+        signed_headers = (
+            signed.headers["Authorization"]
+            .split("SignedHeaders=")[1]
+            .split(",")[0]
+            .split(";")
+        )
+        assert "host" in signed_headers
+        for volatile in (
+            "connection",
+            "content-type",
+            "content-length",
+            "accept-encoding",
+            "user-agent",
+        ):
+            assert volatile not in signed_headers


### PR DESCRIPTION
### Description

Fixes #1044.

`AWSV4Signer.sign()` now excludes [RFC 2616 hop-by-hop headers](https://datatracker.ietf.org/doc/html/rfc2616#section-13.5.1) and any headers nominated by the `Connection` header value ([RFC 2616 Section 14.10](https://datatracker.ietf.org/doc/html/rfc2616#section-14.10)) before constructing the `AWSRequest` passed to `SigV4Auth`.

### Issue

Since v3.2.0, `AWSV4Signer.sign()` passes all request headers into `AWSRequest`, including `connection: keep-alive` set by `AsyncHttpConnection.__init__`. `SigV4Auth` then includes `connection` in `SignedHeaders`. However, `aiohttp` manages the `Connection` header at the transport layer and may modify or remove it after signing, causing a signature mismatch and HTTP 403 from AWS OpenSearch Service.

### Fix

- A `frozenset` of RFC 2616 hop-by-hop header names is used to filter headers before they reach `AWSRequest`. Only end-to-end headers are signed, preventing transport-layer modifications from invalidating the signature.
- The `Connection` header value is parsed to extract nominated headers (e.g., `Connection: keep-alive, x-custom-hop` causes `x-custom-hop` to also be excluded), per RFC 2616 Section 14.10.

### Testing

Added `TestAsyncSignerHopByHopHeaders` with two test cases:
- `test_connection_header_excluded_from_signing` — verifies `connection` is excluded from `SignedHeaders`
- `test_connection_nominated_headers_excluded_from_signing` — verifies headers nominated by the `Connection` value are also excluded

### Check List
- [x] Commits are signed with a DCO
- [x] New functionality includes testing
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] Applicable `javadocs` are added or updated — N/A (Python project)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).