### PR TITLE
Remove dependency on Events package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Security
 ### Dependencies
 - Refresh `benchmarks/` poetry lock to pick up aiohttp 3.13.5, urllib3 2.6.3, requests 2.33.1, pygments 2.20.0 (clears Mend CVE findings) ([#1046](https://github.com/opensearch-project/opensearch-py/pull/1046))
+- Removed dependency on [Events](https://pypi.org/project/Events/)
 
 ## [3.2.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Security
 ### Dependencies
 - Refresh `benchmarks/` poetry lock to pick up aiohttp 3.13.5, urllib3 2.6.3, requests 2.33.1, pygments 2.20.0 (clears Mend CVE findings) ([#1046](https://github.com/opensearch-project/opensearch-py/pull/1046))
-- Removed dependency on [Events](https://pypi.org/project/Events/)
+- Removed dependency on [Events](https://pypi.org/project/Events/) ([#1060](https://github.com/opensearch-project/opensearch-py/pull/1060))
 
 ## [3.2.0]
 ### Added

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,6 @@ sphinx_rtd_theme
 jinja2
 pytz
 deepmerge
-Events
 setuptools==71.1.0
 
 numpy; python_version<="3.12"

--- a/opensearchpy/metrics/metrics_events.py
+++ b/opensearchpy/metrics/metrics_events.py
@@ -10,8 +10,6 @@
 import time
 from typing import Optional
 
-from events import Events
-
 from opensearchpy.metrics.metrics import Metrics
 
 
@@ -35,17 +33,12 @@ class MetricsEvents(Metrics):
         return self._service_time
 
     def __init__(self) -> None:
-        self.events = Events()
         self._start_time: Optional[float] = None
         self._end_time: Optional[float] = None
         self._service_time: Optional[float] = None
 
-        # Subscribe to the request_start and request_end events
-        self.events.request_start += self._on_request_start
-        self.events.request_end += self._on_request_end
-
     def request_start(self) -> None:
-        self.events.request_start()
+        self._on_request_start()
 
     def _on_request_start(self) -> None:
         self._start_time = time.perf_counter()
@@ -53,7 +46,7 @@ class MetricsEvents(Metrics):
         self._service_time = None
 
     def request_end(self) -> None:
-        self.events.request_end()
+        self._on_request_end()
 
     def _on_request_end(self) -> None:
         self._end_time = time.perf_counter()

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ install_requires = [
     "requests>=2.32.0, <3.0.0",
     "python-dateutil",
     "certifi>=2024.07.04",
-    "Events",
 ]
 tests_require = [
     "requests>=2.0.0, <3.0.0",


### PR DESCRIPTION
### Description

Remove dependency on [Events](https://pypi.org/project/Events/) package to eliminate frequent module name collisions when `opensearch-py` is integrated into existing codebases which already have a module named `events`.

The usage of Events from #716 amounted to calling two functions in `opensearchpy.metrics.metrics_events.MetricsEvents`, so removing the indirection from Events was simple. This change has no effect on the public or private API of `opensearchpy.metrics.metrics_events.MetricsEvents`.

### Issues Resolved

Fixes #756

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
