### PR TITLE
Fix IPv6 host normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed parsing bracketed IPv6 URLs passed as hosts ([#910](https://github.com/opensearch-project/opensearch-py/issues/910))
 ### Security
 ### Dependencies
 

--- a/opensearchpy/client/utils.py
+++ b/opensearchpy/client/utils.py
@@ -60,7 +60,10 @@ def _normalize_hosts(hosts: Any) -> Any:
                 host = f"//{host}"  # type: ignore
 
             parsed_url = urlparse(host)
-            h = {"host": parsed_url.hostname}
+            parsed_hostname = parsed_url.hostname
+            if parsed_hostname and ":" in parsed_hostname:
+                parsed_hostname = f"[{parsed_hostname}]"
+            h = {"host": parsed_hostname}
 
             if parsed_url.port:
                 h["port"] = parsed_url.port

--- a/opensearchpy/connection/base.py
+++ b/opensearchpy/connection/base.py
@@ -118,7 +118,9 @@ class Connection:
         self.scheme = scheme
         self.hostname = host
         self.port = port
-        if ":" in host:  # IPv6
+        if host.startswith("[") and host.endswith("]"):
+            self.host = f"{scheme}://{host}"
+        elif ":" in host:  # IPv6
             self.host = f"{scheme}://[{host}]"
         else:
             self.host = f"{scheme}://{host}"

--- a/test_opensearchpy/test_client/test_normalize_hosts.py
+++ b/test_opensearchpy/test_client/test_normalize_hosts.py
@@ -47,6 +47,12 @@ class TestNormalizeHosts(TestCase):
             _normalize_hosts(["opensearch.org:42", "user:secre%5D@opensearch.org"]),
         )
 
+    def test_ipv6_url_host_preserves_brackets(self) -> None:
+        self.assertEqual(
+            [{"host": "[fdbd:dc05:1a:10c::53]", "port": 9292}],
+            _normalize_hosts(["http://[fdbd:dc05:1a:10c::53]:9292"]),
+        )
+
     def test_strings_are_parsed_for_scheme(self) -> None:
         self.assertEqual(
             [

--- a/test_opensearchpy/test_connection/test_base_connection.py
+++ b/test_opensearchpy/test_connection/test_base_connection.py
@@ -90,6 +90,7 @@ class TestBaseConnection(TestCase):
     def test_ipv6_host_and_port(self) -> None:
         for kwargs, expected_host in [
             ({"host": "::1"}, "http://[::1]:9200"),
+            ({"host": "[::1]"}, "http://[::1]:9200"),
             ({"host": "::1", "port": 443}, "http://[::1]:443"),
             ({"host": "::1", "use_ssl": True}, "https://[::1]:9200"),
             ({"host": "127.0.0.1", "port": 1234}, "http://127.0.0.1:1234"),


### PR DESCRIPTION
## Summary

Fixes #910.

This PR adds regression coverage for bracketed IPv6 URLs passed as hosts and updates host normalization/connection URL construction so those hosts keep valid IPv6 URL brackets.

## Changes

- Added regression coverage for `_normalize_hosts([http://[...]:port])`
- Preserved brackets around IPv6 hosts parsed from URL strings
- Avoided double-wrapping already bracketed IPv6 hosts in `Connection`
- Added a changelog entry
- No new dependencies
- No public API changes

## Testing

Ran:

```bash
python -m pytest test_opensearchpy/test_client/test_normalize_hosts.py::TestNormalizeHosts::test_ipv6_url_host_preserves_brackets -q
python -m pytest test_opensearchpy/test_connection/test_base_connection.py::TestBaseConnection::test_ipv6_host_and_port -q
python -m pytest test_opensearchpy/test_client/test_normalize_hosts.py -q
python -m pytest test_opensearchpy/test_connection/test_base_connection.py -q
python -m black --check opensearchpy/client/utils.py opensearchpy/connection/base.py test_opensearchpy/test_client/test_normalize_hosts.py test_opensearchpy/test_connection/test_base_connection.py
git diff --check HEAD~1..HEAD
```

Also ran a no-network constructor smoke check for `OpenSearch([http://[fdbd:dc05:1a:10c::53]:9292])`.

## Scope Notes

- Kept the fix limited to IPv6 host parsing/URL construction.
- Did not run Docker-backed integration tests.
- Did not add dependencies or change public APIs.