### PR TITLE
fix: annotate YAML_TEST_SPECS to fix mypy --strict CI failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed `mypy --strict` failure on `test_rest_api_spec.py` by annotating `YAML_TEST_SPECS` as `List[Any]`, unblocking the `lint` and `generate` CI checks ([#1080](https://github.com/opensearch-project/opensearch-py/pull/1080))
 ### Security
 ### Dependencies
 - Refresh `benchmarks/` poetry lock to pick up aiohttp 3.13.5, urllib3 2.6.3, requests 2.33.1, pygments 2.20.0 (clears Mend CVE findings) ([#1046](https://github.com/opensearch-project/opensearch-py/pull/1046))

--- a/test_opensearchpy/test_server/test_rest_api_spec.py
+++ b/test_opensearchpy/test_server/test_rest_api_spec.py
@@ -36,7 +36,7 @@ import os
 import re
 import warnings
 import zipfile
-from typing import Any
+from typing import Any, List
 
 import pytest
 import urllib3
@@ -481,7 +481,7 @@ def sync_runner(sync_client: Any) -> Any:
     return YamlRunner(sync_client)
 
 
-YAML_TEST_SPECS = []
+YAML_TEST_SPECS: List[Any] = []
 
 client = get_client()
 


### PR DESCRIPTION
### Description

`mypy --strict` (run by the `lint` and `generate` CI checks) now flags the bare `YAML_TEST_SPECS = []` in `test_opensearchpy/test_server/test_rest_api_spec.py`:

```
test_opensearchpy/test_server/test_rest_api_spec.py:484: error: Need type annotation for "YAML_TEST_SPECS" (hint: "YAML_TEST_SPECS: list[<type>] = ...")  [var-annotated]
```

This is a tree-wide CI breakage (the line is unchanged on `main`) surfacing because CI installs unpinned tooling, and it is currently failing the `lint` and `generate` checks on every open PR (e.g. #1058).

This annotates the variable as `List[Any]` (the list holds `pytest.param(...)` results) to unblock CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.