### PR TITLE
fix: upgrade urllib3 to 2.7.0 to fix CVE-2026-9375

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ packages = [
     if package == MODULE_DIR or package.startswith(MODULE_DIR + ".")
 ]
 install_requires = [
-    'urllib3>=1.26.19,<1.27 ; python_version < "3.10"',
-    'urllib3>=1.26.19,!=2.2.0,!=2.2.1,<3 ; python_version >= "3.10"',
+    'urllib3>=1.26.20,<1.27 ; python_version < "3.10"',
+    'urllib3>=2.7.0,<3 ; python_version >= "3.10"',
     "requests>=2.32.0, <3.0.0",
     "python-dateutil",
     "certifi>=2024.07.04",


### PR DESCRIPTION
### Description
- Updated urllib3 requirement to >=2.7.0 for Python >=3.10
- Updated urllib3 requirement to >=1.26.20 for Python <3.10
- CVE-2026-9375 is a high-severity decompression bomb vulnerability in urllib3 2.6.3 when using Brotli support with streaming API
- urllib3 2.7.0 fixes bypassed decompression-bomb safeguards in three independent code paths in response.py
- Verified opensearch-py imports successfully with urllib3 2.7.0

### Issues Resolved
Fix to https://github.com/opensearch-project/opensearch-py/issues/1081

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
