### PR TITLE
Fix UnicodeEncodeError on surrogate/emoji characters in bulk chunk sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix `UnicodeEncodeError` on surrogate/emoji characters in bulk chunk sizing by passing `surrogatepass` error handler ([#1086](https://github.com/opensearch-project/opensearch-py/pull/1086))
 ### Security
 ### Dependencies
 - Refresh `benchmarks/` poetry lock to pick up aiohttp 3.13.5, urllib3 2.6.3, requests 2.33.1, pygments 2.20.0 (clears Mend CVE findings) ([#1046](https://github.com/opensearch-project/opensearch-py/pull/1046))

--- a/opensearchpy/helpers/actions.py
+++ b/opensearchpy/helpers/actions.py
@@ -120,11 +120,12 @@ class _ActionChunker:
         raw_data, raw_action = data, action
         action = self.serializer.dumps(action)
         # +1 to account for the trailing new line character
-        cur_size = len(action.encode("utf-8")) + 1
+        # surrogatepass matches the rest of the client (transport.py, http_requests.py, etc.)
+        cur_size = len(action.encode("utf-8", "surrogatepass")) + 1
 
         if data is not None:
             data = self.serializer.dumps(data)
-            cur_size += len(data.encode("utf-8")) + 1
+            cur_size += len(data.encode("utf-8", "surrogatepass")) + 1
 
         # full chunk, send it and start a new one
         if self.bulk_actions and (


### PR DESCRIPTION
Fixes #975

**Problem:** `_BulkIndexer.feed()` encodes serialized strings with plain `encode('utf-8')` to measure byte length for chunk sizing. When data contains surrogate characters (unpaired surrogates from broken emoji, AWS Neptune replication data, etc.) this raises `UnicodeEncodeError: surrogates not allowed`.

**Fix:** Pass `'surrogatepass'` as the errors argument — consistent with the rest of the client: `transport.py`, `http_requests.py`, `http_urllib3.py`, and `http_async.py` all already use `surrogatepass` for the same reason. One-line change in each of the two encode calls.