### PR TITLE
Fix UnboundLocalError in scan when a scroll page has hits but no _shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Fix `UnicodeEncodeError` on surrogate/emoji characters in bulk chunk sizing by passing `surrogatepass` error handler ([#1086](https://github.com/opensearch-project/opensearch-py/pull/1086))
+- Fix `UnboundLocalError` in `scan()`/`async_scan()` when a scroll response has hits but no `_shards` ([#1091](https://github.com/opensearch-project/opensearch-py/pull/1091))
 ### Security
 - Refresh `samples/` and `benchmarks/` poetry locks and pin fixed transitive floors to clear all outstanding dependency CVE findings: aiohttp `>=3.14.1` (CVE-2026-54273..54280 et al.), urllib3 `>=2.7.0` (CVE-2025-50181/-50182/-66418/-66471, CVE-2026-21441/-44431/-44432), requests `>=2.33.0` (CVE-2024-47081, CVE-2026-25645), and idna `>=3.18` (CVE-2026-45409) ([#1082](https://github.com/opensearch-project/opensearch-py/pull/1082))
 ### Dependencies

--- a/opensearchpy/_async/helpers/actions.py
+++ b/opensearchpy/_async/helpers/actions.py
@@ -402,25 +402,25 @@ async def async_scan(
                 shards_skipped = _shards.get("skipped", 0)
                 shards_total = _shards.get("total", 0)
 
-            # check if we have any errors
-            if (shards_successful + shards_skipped) < shards_total:
-                shards_message = "Scroll request has only succeeded on %d (+%d skipped) shards out of %d."
-                logger.warning(
-                    shards_message,
-                    shards_successful,
-                    shards_skipped,
-                    shards_total,
-                )
-                if raise_on_error:
-                    raise ScanError(
-                        scroll_id,
-                        shards_message
-                        % (
-                            shards_successful,
-                            shards_skipped,
-                            shards_total,
-                        ),
+                # check if we have any errors
+                if (shards_successful + shards_skipped) < shards_total:
+                    shards_message = "Scroll request has only succeeded on %d (+%d skipped) shards out of %d."
+                    logger.warning(
+                        shards_message,
+                        shards_successful,
+                        shards_skipped,
+                        shards_total,
                     )
+                    if raise_on_error:
+                        raise ScanError(
+                            scroll_id,
+                            shards_message
+                            % (
+                                shards_successful,
+                                shards_skipped,
+                                shards_total,
+                            ),
+                        )
             resp = await client.scroll(
                 body={"scroll_id": scroll_id, "scroll": scroll}, **scroll_kwargs
             )

--- a/opensearchpy/helpers/actions.py
+++ b/opensearchpy/helpers/actions.py
@@ -596,25 +596,25 @@ def scan(
                 shards_skipped = _shards.get("skipped", 0)
                 shards_total = _shards.get("total", 0)
 
-            # check if we have any errors
-            if (shards_successful + shards_skipped) < shards_total:
-                shards_message = "Scroll request has only succeeded on %d (+%d skipped) shards out of %d."
-                logger.warning(
-                    shards_message,
-                    shards_successful,
-                    shards_skipped,
-                    shards_total,
-                )
-                if raise_on_error:
-                    raise ScanError(
-                        scroll_id,
-                        shards_message
-                        % (
-                            shards_successful,
-                            shards_skipped,
-                            shards_total,
-                        ),
+                # check if we have any errors
+                if (shards_successful + shards_skipped) < shards_total:
+                    shards_message = "Scroll request has only succeeded on %d (+%d skipped) shards out of %d."
+                    logger.warning(
+                        shards_message,
+                        shards_successful,
+                        shards_skipped,
+                        shards_total,
                     )
+                    if raise_on_error:
+                        raise ScanError(
+                            scroll_id,
+                            shards_message
+                            % (
+                                shards_successful,
+                                shards_skipped,
+                                shards_total,
+                            ),
+                        )
 
             resp = client.scroll(
                 body={"scroll_id": scroll_id, "scroll": scroll}, **scroll_kwargs

--- a/test_opensearchpy/test_async/test_helpers/test_actions.py
+++ b/test_opensearchpy/test_async/test_helpers/test_actions.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from _pytest.mark.structures import MarkDecorator
+
+from opensearchpy._async.helpers.actions import async_scan
+from opensearchpy.helpers import ScanError
+
+pytestmark: MarkDecorator = pytest.mark.asyncio
+
+
+async def test_async_scan_with_missing_shards_key() -> None:
+    """
+    A response with hits but no '_shards' key must not raise (regression for
+    UnboundLocalError referencing shards_successful before assignment).
+    """
+    client = MagicMock()
+    client.search = AsyncMock(
+        return_value={"_scroll_id": "dummy_scroll_id", "hits": {"hits": [{"_id": "1"}]}}
+    )
+    client.scroll = AsyncMock(
+        return_value={"_scroll_id": "dummy_scroll_id", "hits": {"hits": []}}
+    )
+    client.clear_scroll = AsyncMock(return_value={})
+
+    result = [hit async for hit in async_scan(client, query={})]
+    assert result == [{"_id": "1"}]
+
+
+async def test_async_scan_shard_failure_raises_scan_error() -> None:
+    """
+    A page whose '_shards' report fewer successful than total triggers the
+    shard-failure check (which now runs inside the ``if _shards:`` guard).
+    """
+    client = MagicMock()
+    client.search = AsyncMock(
+        return_value={
+            "_scroll_id": "dummy_scroll_id",
+            "_shards": {"successful": 1, "skipped": 0, "total": 5, "failed": 4},
+            "hits": {"hits": [{"_id": "1"}]},
+        }
+    )
+    client.clear_scroll = AsyncMock(return_value={})
+
+    with pytest.raises(ScanError):
+        [hit async for hit in async_scan(client, query={})]

--- a/test_opensearchpy/test_helpers/test_actions.py
+++ b/test_opensearchpy/test_helpers/test_actions.py
@@ -299,3 +299,49 @@ class TestScanFunction(TestCase):
         # The test should pass without raising a KeyError
         scan_result = list(helpers.scan(client, query={"query": {"match_all": {}}}))
         assert scan_result == [], "Expected empty results when 'hits' key is missing"
+
+    @mock.patch("opensearchpy.OpenSearch.clear_scroll")
+    @mock.patch("opensearchpy.OpenSearch.scroll")
+    @mock.patch("opensearchpy.OpenSearch.search")
+    def test_scan_with_missing_shards_key(
+        self, mock_search: Mock, mock_scroll: Mock, mock_clear_scroll: Mock
+    ) -> None:
+        """
+        A response with hits but no '_shards' key must not raise (regression for
+        UnboundLocalError referencing shards_successful before assignment).
+        """
+        mock_search.return_value = {
+            "_scroll_id": "dummy_scroll_id",
+            "hits": {"hits": [{"_id": "1", "_source": {}}]},
+        }
+        mock_scroll.side_effect = [
+            {"_scroll_id": "dummy_scroll_id", "hits": {"hits": []}}
+        ]
+        mock_clear_scroll.return_value = None
+
+        client = OpenSearch()
+
+        scan_result = list(helpers.scan(client, query={"query": {"match_all": {}}}))
+        assert scan_result == [{"_id": "1", "_source": {}}]
+
+    @mock.patch("opensearchpy.OpenSearch.clear_scroll")
+    @mock.patch("opensearchpy.OpenSearch.scroll")
+    @mock.patch("opensearchpy.OpenSearch.search")
+    def test_scan_shard_failure_raises_scan_error(
+        self, mock_search: Mock, mock_scroll: Mock, mock_clear_scroll: Mock
+    ) -> None:
+        """
+        A page whose '_shards' report fewer successful than total triggers the
+        shard-failure check (which now runs inside the ``if _shards:`` guard).
+        """
+        mock_search.return_value = {
+            "_scroll_id": "dummy_scroll_id",
+            "_shards": {"successful": 1, "skipped": 0, "total": 5, "failed": 4},
+            "hits": {"hits": [{"_id": "1"}]},
+        }
+        mock_clear_scroll.return_value = None
+
+        client = OpenSearch()
+
+        with self.assertRaises(helpers.ScanError):
+            list(helpers.scan(client, query={"query": {"match_all": {}}}))


### PR DESCRIPTION
### Description

`scan()` (and `async_scan()`) raises `UnboundLocalError` when a scroll response contains hits but no `_shards` key.

The shard-failure check reads `shards_successful` / `shards_skipped` / `shards_total`, but those are only assigned inside the `if _shards:` guard added in #616 — while the check that uses them sits *outside* the guard:

```python
if _shards:
    shards_successful = _shards.get("successful", 0)
    shards_skipped = _shards.get("skipped", 0)
    shards_total = _shards.get("total", 0)

# check if we have any errors        <-- outside the guard
if (shards_successful + shards_skipped) < shards_total:
    ...
```

So when a scroll page has hits but omits `_shards`, the three names are unbound and the check raises `UnboundLocalError: local variable 'shards_successful' referenced before assignment`. This happens with OpenSearch-compatible / proxied / serverless endpoints that don't return `_shards`, and with mocked clients.

#616 added the `if _shards:` guard specifically because `_shards` can be absent — but it only guarded the assignment, not the use (and its test used `_shards: {}` with no `hits`, so the loop body never ran and the check was never exercised).

### Issues Resolved

`scan()` crashes with `UnboundLocalError` on responses that have hits but no `_shards`.

### Solution

Move the shard-failure check inside the `if _shards:` guard, completing #616's intent — when shard info is absent, skip the check and yield the hits. Applied to both the sync (`opensearchpy/helpers/actions.py`) and async (`opensearchpy/_async/helpers/actions.py`) implementations. Adds a regression test (`test_scan_with_missing_shards_key`).

Reproduced against `opensearch-py==3.2.0`: before the fix, `list(helpers.scan(client, query={}))` raises `UnboundLocalError` when the response has hits and no `_shards`; after, it yields the hits.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.
