### PR TITLE
Fix AttributeError in _raise_error on a non-object JSON error body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Fix `UnicodeEncodeError` on surrogate/emoji characters in bulk chunk sizing by passing `surrogatepass` error handler ([#1086](https://github.com/opensearch-project/opensearch-py/pull/1086))
+- Fix `AttributeError` in `_raise_error` on a non-object JSON error body (masks the HTTP status behind a proxy/LB) ([#1092](https://github.com/opensearch-project/opensearch-py/pull/1092))
 ### Security
 - Refresh `samples/` and `benchmarks/` poetry locks and pin fixed transitive floors to clear all outstanding dependency CVE findings: aiohttp `>=3.14.1` (CVE-2026-54273..54280 et al.), urllib3 `>=2.7.0` (CVE-2025-50181/-50182/-66418/-66471, CVE-2026-21441/-44431/-44432), requests `>=2.33.0` (CVE-2024-47081, CVE-2026-25645), and idna `>=3.18` (CVE-2026-45409) ([#1082](https://github.com/opensearch-project/opensearch-py/pull/1082))
 ### Dependencies

--- a/opensearchpy/connection/base.py
+++ b/opensearchpy/connection/base.py
@@ -306,9 +306,10 @@ class Connection:
             )
             if raw_data and content_type == "application/json":
                 additional_info = json.loads(raw_data)
-                error_message = additional_info.get("error", error_message)
-                if isinstance(error_message, dict) and "type" in error_message:
-                    error_message = error_message["type"]
+                if isinstance(additional_info, dict):
+                    error_message = additional_info.get("error", error_message)
+                    if isinstance(error_message, dict) and "type" in error_message:
+                        error_message = error_message["type"]
         except (ValueError, TypeError) as err:
             logger.warning("Undecodable raw error response from server: %s", err)
 

--- a/test_opensearchpy/test_connection/test_base_connection.py
+++ b/test_opensearchpy/test_connection/test_base_connection.py
@@ -42,6 +42,7 @@ from pytest import raises
 
 from opensearchpy import OpenSearch, serializer
 from opensearchpy.connection import connections
+from opensearchpy.exceptions import TransportError
 
 
 class TestBaseConnection(TestCase):
@@ -52,6 +53,25 @@ class TestBaseConnection(TestCase):
             con._raise_warnings([])
 
         self.assertEqual(w, [])
+
+    def test_raise_error_handles_non_dict_json_body(self) -> None:
+        # A non-object JSON error body (array/string/number/bool/null) with a JSON
+        # content-type must still raise a TransportError carrying the status code,
+        # not an uncaught AttributeError. Regression for the missing
+        # isinstance(additional_info, dict) guard in _raise_error.
+        con = Connection()
+        for body in ("[1, 2, 3]", '"a string"', "42", "true", "null"):
+            with raises(TransportError) as excinfo:
+                con._raise_error(400, body, "application/json")
+            self.assertEqual(excinfo.value.status_code, 400)
+            self.assertEqual(excinfo.value.error, body)
+
+        # a dict body still has its error type extracted
+        with raises(TransportError) as excinfo:
+            con._raise_error(
+                400, '{"error": {"type": "x_exception"}}', "application/json"
+            )
+        self.assertEqual(excinfo.value.error, "x_exception")
 
     def test_raises_warnings(self) -> None:
         con = Connection()


### PR DESCRIPTION
### Description

`_raise_error` raises an uncaught `AttributeError` when the server's error body is valid JSON but not an object (a JSON array, string, number, boolean, or `null`) with a JSON content-type.

```python
error_message = raw_data
additional_info = None
try:
    ...
    if raw_data and content_type == "application/json":
        additional_info = json.loads(raw_data)
        error_message = additional_info.get("error", error_message)   # assumes a dict
        ...
except (ValueError, TypeError) as err:
    logger.warning("Undecodable raw error response from server: %s", err)
```

If the body parses to a non-dict, `.get()` raises `AttributeError`, which is **not** in the `except (ValueError, TypeError)` guard. So instead of a clean `TransportError` carrying the HTTP status, the caller gets a cryptic `AttributeError: 'list' object has no attribute 'get'` that **masks the status code**. This happens when a reverse proxy / load balancer / API gateway in front of OpenSearch returns its own JSON error body (e.g. `"Service Unavailable"` or `["error"]`).

Reproduced against `opensearch-py==3.2.0`:

```
[1,2,3]  -> AttributeError: 'list' object has no attribute 'get'
"a str"  -> AttributeError: 'str' object has no attribute 'get'
42       -> AttributeError: 'int' object has no attribute 'get'
true     -> AttributeError: 'bool' object has no attribute 'get'
null     -> AttributeError: 'NoneType' object has no attribute 'get'
```

### Issues Resolved

`_raise_error` crashing with `AttributeError` (masking the HTTP status) on a non-object JSON error body.

### Solution

Guard the error extraction with `isinstance(additional_info, dict)` — the `try`/`except` already exists to gracefully fall back to the raw body; this extends that to non-object JSON. A non-object body now falls back to the raw body as the message and raises a proper `TransportError` carrying the status code; a dict body still has its `error`/`type` extracted. `_raise_error` lives in the shared `connection/base.py`, so this covers both the sync and async connections. Adds a regression test.

After the fix:

```
[1,2,3]                            -> RequestError(400, '[1,2,3]')
{"error":{"type":"x_exception"}}   -> RequestError(400, 'x_exception')   # unchanged
```

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.
