### PR TITLE
fix: coerce OpenSearch string values when comparing analysis settings in Index.save()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed `Index.save()` raising `IllegalOperation` on open indices when the analysis configuration already matched but OpenSearch returned numeric/boolean values as strings ([#882](https://github.com/opensearch-project/opensearch-py/issues/882))
 - Fix `UnicodeEncodeError` on surrogate/emoji characters in bulk chunk sizing by passing `surrogatepass` error handler ([#1086](https://github.com/opensearch-project/opensearch-py/pull/1086))
 ### Security
 - Refresh `samples/` and `benchmarks/` poetry locks and pin fixed transitive floors to clear all outstanding dependency CVE findings: aiohttp `>=3.14.1` (CVE-2026-54273..54280 et al.), urllib3 `>=2.7.0` (CVE-2025-50181/-50182/-66418/-66471, CVE-2026-21441/-44431/-44432), requests `>=2.33.0` (CVE-2024-47081, CVE-2026-25645), and idna `>=3.18` (CVE-2026-45409) ([#1082](https://github.com/opensearch-project/opensearch-py/pull/1082))

--- a/opensearchpy/helpers/index.py
+++ b/opensearchpy/helpers/index.py
@@ -37,6 +37,36 @@ from .update_by_query import UpdateByQuery
 from .utils import merge
 
 
+def _coerce_from_string(value: Any) -> Any:
+    """
+    Recursively convert string values in OpenSearch settings responses back to
+    their native Python types.
+
+    OpenSearch serialises numeric and boolean analysis settings as strings when
+    returning index settings (e.g. ``'false'`` instead of ``False``,
+    ``'3'`` instead of ``3``).  This normalisation step makes the in-memory
+    Python representation comparable to what comes back from the server.
+    """
+    if isinstance(value, dict):
+        return {k: _coerce_from_string(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_coerce_from_string(item) for item in value]
+    if isinstance(value, str):
+        if value.lower() == "true":
+            return True
+        if value.lower() == "false":
+            return False
+        try:
+            return int(value)
+        except ValueError:
+            pass
+        try:
+            return float(value)
+        except ValueError:
+            pass
+    return value
+
+
 class IndexTemplate:
     def __init__(
         self,
@@ -346,7 +376,9 @@ class Index:
                 # compare analysis definition, if all analysis objects are
                 # already defined as requested, skip analysis update and
                 # proceed, otherwise raise IllegalOperation
-                existing_analysis = current_settings.get("analysis", {})
+                existing_analysis = _coerce_from_string(
+                    current_settings.get("analysis", {})
+                )
                 if any(
                     existing_analysis.get(section, {}).get(k, None)
                     != analysis[section][k]

--- a/test_opensearchpy/test_helpers/test_index.py
+++ b/test_opensearchpy/test_helpers/test_index.py
@@ -195,3 +195,64 @@ def test_index_template_save_result(mock_client: Any) -> None:
     it: Any = IndexTemplate("test-template", "test-*")
 
     assert it.save(using="mock") == mock_client.indices.put_template()
+
+
+def test_save_does_not_raise_on_matching_analysis_with_string_typed_server_values(
+    mock_client: Any,
+) -> None:
+    """
+    Regression test for https://github.com/opensearch-project/opensearch-py/issues/882.
+
+    OpenSearch returns analysis settings values as strings (e.g. ``'3'`` for the
+    integer ``3``, ``'false'`` for the boolean ``False``).  Index.save() must not
+    raise IllegalOperation when those string-typed server values logically match
+    the Python-typed values defined in the index settings.
+    """
+    from opensearchpy.exceptions import IllegalOperation
+
+    i: Any = Index("test-index", using="mock")
+    i.settings(
+        analysis={
+            "filter": {
+                "my_shingles": {
+                    "type": "shingle",
+                    "min_shingle_size": 2,
+                    "max_shingle_size": 3,
+                    "output_unigrams": False,
+                }
+            }
+        }
+    )
+
+    # OpenSearch returns all numeric/boolean values as strings.
+    mock_client.indices.exists.return_value = True
+    mock_client.indices.get_settings.return_value = {
+        "test-index": {
+            "settings": {
+                "index": {
+                    "analysis": {
+                        "filter": {
+                            "my_shingles": {
+                                "type": "shingle",
+                                "min_shingle_size": "2",
+                                "max_shingle_size": "3",
+                                "output_unigrams": "false",
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    mock_client.cluster.state.return_value = {
+        "metadata": {"indices": {"test-index": {"state": "open"}}}
+    }
+
+    # Before the fix this raised IllegalOperation because "2" != 2 etc.
+    try:
+        i.save(using="mock")
+    except IllegalOperation:
+        raise AssertionError(
+            "Index.save() raised IllegalOperation even though the analysis "
+            "configuration already matches (types differed only as str vs int/bool)"
+        )


### PR DESCRIPTION
## Summary

Fixes #882

### Root cause

`Index.save()` compares the user-defined analysis section against the existing index analysis returned by OpenSearch to decide whether the index needs to be closed for an update. OpenSearch serialises **all** analysis settings values as strings in the `GET /<index>/_settings` response, even when the original values were integers or booleans:

```python
# What OpenSearch returns:
{"filter": {"my_shingles": {"type": "shingle", "min_shingle_size": "2", "output_unigrams": "false"}}}

# What the user defined in Python:
{"filter": {"my_shingles": {"type": "shingle", "min_shingle_size": 2, "output_unigrams": False}}}
```

Because `"2" != 2` and `"false" != False`, the comparison always reported a mismatch, causing `save()` to always raise `IllegalOperation` on open indices â€” even when the analysis configuration was already exactly as requested.

### Fix

Added a `_coerce_from_string()` helper that recursively walks the dict returned by OpenSearch and converts string values back to native Python types (`True`/`False` for boolean strings, `int` for integer strings, `float` for float strings). The existing analysis dict is normalised through this helper before the comparison.

The pattern matches what the adjacent settings comparison already does for flat scalar settings (`if current_settings[k] == str(v)`), but generalised to handle nested analysis structures.

### Changes

- `opensearchpy/helpers/index.py` â€” add `_coerce_from_string()`, apply it to `existing_analysis` before the equality check in `Index.save()`
- `test_opensearchpy/test_helpers/test_index.py` â€” regression test that reproduces the bug (string-typed server response vs. typed Python definition) and passes with the fix

### Test plan

- [x] `test_save_does_not_raise_on_matching_analysis_with_string_typed_server_values` â€” mocks the client to return string-typed settings (as OpenSearch does), asserts that `save()` does not raise `IllegalOperation` when the analysis already matches
- [x] All 15 existing index helper unit tests continue to pass
