### PR TITLE
Add gRPC ML streaming support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Add gRPC translation layer with `BulkRequestProtoBuilder` and `ResponseConverter` for bulk operations ([#1058](https://github.com/opensearch-project/opensearch-py/pull/1058))
 - Add gRPC transport for bulk operations with `OpenSearchGrpc` client and `GrpcTransport` ([#1078](https://github.com/opensearch-project/opensearch-py/pull/1078))
+- Add gRPC ML streaming translation layer for ML Commons `PredictModelStream` / `ExecuteAgentStream` APIs ([#1096](https://github.com/opensearch-project/opensearch-py/pull/1096))
 ### Updated APIs
 ### Changed
 ### Deprecated

--- a/opensearch_grpc/grpc_transport.py
+++ b/opensearch_grpc/grpc_transport.py
@@ -20,11 +20,27 @@ Usage:
 """
 
 import re
-from typing import Any, Callable, Collection, Mapping, Optional, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Iterator,
+    Mapping,
+    Optional,
+    Union,
+)
 
 import grpc
-from opensearch.protobufs.services import document_service_pb2_grpc
+from opensearch.protobufs.services import (
+    document_service_pb2_grpc,
+    ml_service_pb2_grpc,
+)
 
+from opensearch_grpc.ml_translation import (
+    MlExecuteAgentStreamRequestBuilder,
+    MlPredictModelStreamRequestBuilder,
+    MlStreamResponseConverter,
+)
 from opensearch_grpc.translation import BulkRequestProtoBuilder, ResponseConverter
 from opensearchpy.exceptions import (
     AuthenticationException,
@@ -74,6 +90,7 @@ class GrpcTransport(Transport):
         self._document_stub = document_service_pb2_grpc.DocumentServiceStub(
             self._channel
         )
+        self._ml_stub = ml_service_pb2_grpc.MLServiceStub(self._channel)
 
     def perform_request(
         self,
@@ -183,6 +200,54 @@ class GrpcTransport(Transport):
 
         return ResponseConverter._convert_bulk_items(response)
 
+    # ─── ML gRPC Streaming ──────────────────────────────────
+
+    def predict_model_stream(
+        self,
+        model_id: str,
+        body: Optional[Mapping[str, Any]] = None,
+    ) -> Iterator[Any]:
+        """Predict a model in streaming mode via MLService.PredictModelStream.
+
+        :arg model_id: the deployed model id.
+        :arg body: REST-style body, e.g. ``{"parameters": {"messages": [...]}}``.
+        """
+        request = MlPredictModelStreamRequestBuilder.from_body(
+            model_id=model_id,
+            body=dict(body) if body else None,
+        ).build()
+        return self._stream(self._ml_stub.PredictModelStream, request)
+
+    def execute_agent_stream(
+        self,
+        agent_id: str,
+        body: Optional[Mapping[str, Any]] = None,
+    ) -> Iterator[Any]:
+        """Execute an agent in streaming mode via MLService.ExecuteAgentStream.
+
+        :arg agent_id: the agent id.
+        :arg body: REST-style body, e.g. ``{"parameters": {"question": "..."}}``.
+        """
+        request = MlExecuteAgentStreamRequestBuilder.from_body(
+            agent_id=agent_id,
+            body=dict(body) if body else None,
+        ).build()
+        return self._stream(self._ml_stub.ExecuteAgentStream, request)
+
+    def _stream(self, rpc: Callable[[Any], Any], request: Any) -> Iterator[Any]:
+        """Iterate a server-streaming RPC, converting each chunk to a dict.
+
+        gRPC errors surface while the stream is consumed, so the conversion
+        happens inside the generator and ``grpc.RpcError`` is mapped to the same
+        opensearch-py exceptions the REST client raises.
+        """
+        self._ensure_channel_connected()
+        try:
+            for response in rpc(request):
+                yield MlStreamResponseConverter.from_predict_response(response)
+        except grpc.RpcError as e:
+            self._raise_grpc_error(e)
+
     def _raise_grpc_error(self, error: grpc.RpcError) -> None:
         """Convert grpc.RpcError to opensearch-py exceptions.
 
@@ -283,6 +348,7 @@ class GrpcTransport(Transport):
         self._document_stub = document_service_pb2_grpc.DocumentServiceStub(
             self._channel
         )
+        self._ml_stub = ml_service_pb2_grpc.MLServiceStub(self._channel)
 
     def close(self) -> None:
         """Close gRPC channel and REST connections."""

--- a/opensearch_grpc/ml_translation.py
+++ b/opensearch_grpc/ml_translation.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""
+ml_translation.py — gRPC Translation Layer for ML streaming APIs
+
+MlPredictModelStreamRequestBuilder  — Python dict → MlPredictModelStreamRequest
+MlExecuteAgentStreamRequestBuilder  — Python dict → MlExecuteAgentStreamRequest
+MlStreamResponseConverter           — Protobuf PredictResponse → Python dict
+
+This module only converts individual messages; opening and iterating the
+server stream is the transport layer's responsibility.
+"""
+
+from typing import Any, Dict, Optional
+
+from opensearch.protobufs.schemas.common_pb2 import (
+    Messages,
+    MlExecuteAgentStreamRequest,
+    MLExecuteAgentStreamRequestBody,
+    MlPredictModelStreamRequest,
+    MLPredictModelStreamRequestBody,
+    Parameters,
+    PredictResponse,
+)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# REQUEST BUILDERS — Python client dict → Protobuf request
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _build_parameters(parameters: Dict[str, Any]) -> Parameters:
+    """Build a Parameters protobuf from a Python dict.
+
+    Supported keys (all optional):
+        messages: list of {"role": str, "content": str}
+        inputs: str
+        question: str
+        x_llm_interface / llm_interface: str
+    """
+    params = Parameters()
+    messages = parameters.get("messages")
+    if messages:
+        for msg in messages:
+            m = Messages()
+            if msg.get("role") is not None:
+                m.role = msg["role"]
+            if msg.get("content") is not None:
+                m.content = msg["content"]
+            params.messages.append(m)
+    if parameters.get("inputs") is not None:
+        params.inputs = parameters["inputs"]
+    if parameters.get("question") is not None:
+        params.question = parameters["question"]
+    llm_interface = parameters.get("x_llm_interface", parameters.get("llm_interface"))
+    if llm_interface is not None:
+        params.x_llm_interface = llm_interface
+    return params
+
+
+class MlPredictModelStreamRequestBuilder:
+    """Converts a Python dict into a protobuf MlPredictModelStreamRequest.
+
+    Usage:
+        req = MlPredictModelStreamRequestBuilder(
+            model_id="my-model",
+            parameters={"messages": [{"role": "user", "content": "Hello"}]},
+        ).build()
+    """
+
+    def __init__(
+        self,
+        model_id: str,
+        parameters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self._model_id = model_id
+        self._parameters = parameters
+
+    def build(self) -> MlPredictModelStreamRequest:
+        """Build the protobuf MlPredictModelStreamRequest."""
+        request = MlPredictModelStreamRequest()
+        request.model_id = self._model_id
+
+        if self._parameters is not None:
+            body = MLPredictModelStreamRequestBody()
+            body.parameters.CopyFrom(_build_parameters(self._parameters))
+            request.ml_predict_model_stream_request_body.CopyFrom(body)
+
+        return request
+
+    @classmethod
+    def from_body(
+        cls,
+        model_id: str,
+        body: Optional[Dict[str, Any]] = None,
+    ) -> "MlPredictModelStreamRequestBuilder":
+        """Create a builder from a REST-style body ``{"parameters": {...}}``.
+
+        Mirrors: ``client.predict(model_id=..., body={"parameters": {...}})``
+        """
+        body = body or {}
+        return cls(
+            model_id=model_id,
+            parameters=body.get("parameters"),
+        )
+
+
+class MlExecuteAgentStreamRequestBuilder:
+    """Converts a Python dict into a protobuf MlExecuteAgentStreamRequest.
+
+    Usage:
+        req = MlExecuteAgentStreamRequestBuilder(
+            agent_id="my-agent",
+            parameters={"question": "What is OpenSearch?"},
+        ).build()
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        parameters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self._agent_id = agent_id
+        self._parameters = parameters
+
+    def build(self) -> MlExecuteAgentStreamRequest:
+        """Build the protobuf MlExecuteAgentStreamRequest."""
+        request = MlExecuteAgentStreamRequest()
+        request.agent_id = self._agent_id
+
+        if self._parameters is not None:
+            body = MLExecuteAgentStreamRequestBody()
+            body.parameters.CopyFrom(_build_parameters(self._parameters))
+            request.ml_execute_agent_stream_request_body.CopyFrom(body)
+
+        return request
+
+    @classmethod
+    def from_body(
+        cls,
+        agent_id: str,
+        body: Optional[Dict[str, Any]] = None,
+    ) -> "MlExecuteAgentStreamRequestBuilder":
+        """Create a builder from a REST-style body ``{"parameters": {...}}``.
+
+        Mirrors: ``client.agents.execute(agent_id=..., body={"parameters": {...}})``
+        """
+        body = body or {}
+        return cls(
+            agent_id=agent_id,
+            parameters=body.get("parameters"),
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# RESPONSE CONVERTER — Protobuf PredictResponse → Python client dict
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class MlStreamResponseConverter:
+    """Converts a streamed protobuf ``PredictResponse`` chunk to a Python dict.
+
+    The server streams ``PredictResponse`` messages; each is converted back to
+    the ``inference_results`` structure the REST ML predict API returns:
+
+        {
+            "status": "running",
+            "inference_results": [
+                {"output": [{"name": "response",
+                             "dataAsMap": {"content": "...", "is_last": False}}]}
+            ]
+        }
+    """
+
+    @staticmethod
+    def from_predict_response(response: PredictResponse) -> Dict[str, Any]:
+        """Convert one protobuf ``PredictResponse`` → opensearch-py dict."""
+        result: Dict[str, Any] = {}
+
+        if response.HasField("status"):
+            result["status"] = _status_to_str(response.status)
+
+        if response.inference_results:
+            inference_results = []
+            for ir in response.inference_results:
+                outputs = [
+                    MlStreamResponseConverter._convert_output(o) for o in ir.output
+                ]
+                inference_results.append({"output": outputs})
+            result["inference_results"] = inference_results
+
+        return result
+
+    @staticmethod
+    def _convert_output(output: Any) -> Dict[str, Any]:
+        """Convert a single ``Output`` message to a dict."""
+        item: Dict[str, Any] = {}
+        if output.HasField("name"):
+            item["name"] = output.name
+        if output.HasField("result"):
+            item["result"] = output.result
+        if output.HasField("data_as_map"):
+            data_as_map: Dict[str, Any] = {}
+            if output.data_as_map.HasField("content"):
+                data_as_map["content"] = output.data_as_map.content
+            if output.data_as_map.HasField("is_last"):
+                data_as_map["is_last"] = output.data_as_map.is_last
+            item["dataAsMap"] = data_as_map
+        return item
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# INTERNAL HELPERS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _status_to_str(status: int) -> str:
+    """Map the ``Status`` enum to a lowercase REST-style string."""
+    mapping = {
+        0: "unspecified",
+        1: "cancelled",
+        2: "completed",
+        3: "completed_with_error",
+        4: "created",
+        5: "failed",
+        6: "running",
+    }
+    return mapping.get(status, "unspecified")

--- a/opensearchpy/client/grpc_client.py
+++ b/opensearchpy/client/grpc_client.py
@@ -17,19 +17,23 @@
 # -----------------------------------------------------------------------------------------+
 
 
-from typing import Any
+from typing import TYPE_CHECKING, Any, Iterator, cast
 
 from ..exceptions import ImproperlyConfigured
 from . import OpenSearch
 
+if TYPE_CHECKING:
+    from opensearch_grpc.grpc_transport import GrpcTransport
+
 
 class OpenSearchGrpc(OpenSearch):
     """
-    OpenSearch client with gRPC transport for bulk document operations.
+    OpenSearch client with gRPC transport for bulk and ML streaming operations.
 
     Extends the standard OpenSearch client with gRPC channel management.
-    Bulk requests are routed over gRPC for better performance; all other
-    operations fall through to REST automatically.
+    Bulk requests are routed over gRPC for better performance; ML prediction
+    and agent execution can be streamed over gRPC; all other operations fall
+    through to REST automatically.
 
     Usage::
 
@@ -42,6 +46,20 @@ class OpenSearchGrpc(OpenSearch):
 
         # Bulk goes over gRPC automatically
         client.bulk(body=[...])
+
+        # ML prediction stream over gRPC
+        for chunk in client.predict_model_stream(
+            model_id='my-model',
+            body={'parameters': {'messages': [{'role': 'user', 'content': 'Hi'}]}},
+        ):
+            print(chunk)
+
+        # ML agent execution stream over gRPC
+        for chunk in client.execute_agent_stream(
+            agent_id='my-agent',
+            body={'parameters': {'question': 'How many indices are in my cluster?'}},
+        ):
+            print(chunk)
 
         # Everything else uses REST
         client.search(index='my-index', body={'query': {'match_all': {}}})
@@ -92,3 +110,33 @@ class OpenSearchGrpc(OpenSearch):
             kwargs["grpc_hosts"] = grpc_hosts
 
         super().__init__(hosts, transport_class=GrpcTransport, **kwargs)
+
+    def predict_model_stream(
+        self,
+        *,
+        model_id: Any,
+        body: Any = None,
+    ) -> Iterator[Any]:
+        """
+        Predict a model in streaming mode over gRPC.
+
+        :arg model_id: the deployed model id.
+        :arg body: request body, e.g. ``{"parameters": {"messages": [...]}}``.
+        """
+        transport = cast("GrpcTransport", self.transport)
+        return transport.predict_model_stream(model_id=model_id, body=body)
+
+    def execute_agent_stream(
+        self,
+        *,
+        agent_id: Any,
+        body: Any = None,
+    ) -> Iterator[Any]:
+        """
+        Execute an agent in streaming mode over gRPC.
+
+        :arg agent_id: the agent id.
+        :arg body: request body, e.g. ``{"parameters": {"question": "..."}}``.
+        """
+        transport = cast("GrpcTransport", self.transport)
+        return transport.execute_agent_stream(agent_id=agent_id, body=body)

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ tests_require = [
     "pytz",
     "botocore",
     "pytest-mock<4.0.0",
-    "opensearch-protobufs==1.4.0",
+    "opensearch-protobufs==1.6.0",
 ]
 
 async_require = ["aiohttp>=3.12.14,<4"]
@@ -118,7 +118,7 @@ setup(
         "develop": tests_require + docs_require + generate_require,
         "docs": docs_require + async_require,
         "async": async_require,
-        "grpc": ["opensearch-protobufs==1.4.0"],
+        "grpc": ["opensearch-protobufs==1.6.0"],
         "kerberos": ["requests_kerberos"],
     },
 )

--- a/test_opensearchpy/test_ml_stream_transport.py
+++ b/test_opensearchpy/test_ml_stream_transport.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+# mypy: ignore-errors
+
+"""
+test_ml_stream_transport.py — Unit Tests for ML gRPC Streaming Transport
+
+Tests that GrpcTransport.predict_model_stream / execute_agent_stream open the
+server stream, convert each chunk, and map gRPC errors — and that the
+OpenSearchGrpc client methods delegate to the transport. The gRPC stub is
+mocked, so no running server is needed.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import grpc
+from opensearch.protobufs.schemas.common_pb2 import (
+    STATUS_RUNNING,
+    DataAsMap,
+    InferenceResults,
+    Output,
+    PredictResponse,
+)
+
+from opensearch_grpc.grpc_transport import GrpcTransport
+from opensearchpy.client.grpc_client import OpenSearchGrpc
+from opensearchpy.exceptions import NotFoundError
+
+
+def _running_chunk(content: str, is_last: bool) -> PredictResponse:
+    """Build a data_as_map streaming chunk like the ML server emits."""
+    return PredictResponse(
+        status=STATUS_RUNNING,
+        inference_results=[
+            InferenceResults(
+                output=[
+                    Output(
+                        name="response",
+                        data_as_map=DataAsMap(content=content, is_last=is_last),
+                    )
+                ]
+            )
+        ],
+    )
+
+
+class _StreamRpcError(grpc.RpcError):
+    """A grpc.RpcError raised while iterating a server stream."""
+
+    def __init__(self, code, details):
+        self._code = code
+        self._details = details
+
+    def code(self):
+        return self._code
+
+    def details(self):
+        return self._details
+
+
+class TestGrpcStreamingMethods(TestCase):
+    """GrpcTransport streaming methods open, convert, and map errors."""
+
+    def _get_transport(self) -> GrpcTransport:
+        return GrpcTransport(
+            [{"host": "localhost", "port": 9200}],
+            grpc_hosts=[{"host": "localhost", "port": 9400}],
+        )
+
+    def test_predict_model_stream_yields_converted_chunks(self) -> None:
+        """PredictModelStream chunks are converted to opensearch-py dicts."""
+        t = self._get_transport()
+        t._ml_stub.PredictModelStream = MagicMock(
+            return_value=iter(
+                [_running_chunk("Hel", False), _running_chunk("lo", True)]
+            )
+        )
+
+        chunks = list(
+            t.predict_model_stream(
+                model_id="m",
+                body={"parameters": {"messages": [{"role": "user", "content": "Hi"}]}},
+            )
+        )
+
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual(chunks[0]["status"], "running")
+        self.assertEqual(
+            chunks[0]["inference_results"][0]["output"][0]["dataAsMap"]["content"],
+            "Hel",
+        )
+        self.assertTrue(
+            chunks[1]["inference_results"][0]["output"][0]["dataAsMap"]["is_last"]
+        )
+        # The request carried the model id and parameters through to the stub.
+        sent = t._ml_stub.PredictModelStream.call_args.args[0]
+        self.assertEqual(sent.model_id, "m")
+        t.close()
+
+    def test_execute_agent_stream_yields_converted_chunks(self) -> None:
+        """ExecuteAgentStream chunks are converted to opensearch-py dicts."""
+        t = self._get_transport()
+        t._ml_stub.ExecuteAgentStream = MagicMock(
+            return_value=iter([_running_chunk("answer", True)])
+        )
+
+        chunks = list(
+            t.execute_agent_stream(
+                agent_id="a", body={"parameters": {"question": "What is OpenSearch?"}}
+            )
+        )
+
+        self.assertEqual(len(chunks), 1)
+        sent = t._ml_stub.ExecuteAgentStream.call_args.args[0]
+        self.assertEqual(sent.agent_id, "a")
+        t.close()
+
+    def test_stream_without_body(self) -> None:
+        """A None body still opens the stream with just the id."""
+        t = self._get_transport()
+        t._ml_stub.PredictModelStream = MagicMock(return_value=iter([]))
+
+        chunks = list(t.predict_model_stream(model_id="m"))
+
+        self.assertEqual(chunks, [])
+        sent = t._ml_stub.PredictModelStream.call_args.args[0]
+        self.assertFalse(sent.HasField("ml_predict_model_stream_request_body"))
+        t.close()
+
+    def test_stream_error_maps_to_opensearch_exception(self) -> None:
+        """A gRPC error raised mid-stream maps to an opensearch-py exception."""
+        t = self._get_transport()
+
+        def _raise(_request):
+            raise _StreamRpcError(grpc.StatusCode.NOT_FOUND, "Failed to find model")
+
+        t._ml_stub.PredictModelStream = MagicMock(side_effect=_raise)
+
+        with self.assertRaises(NotFoundError):
+            list(t.predict_model_stream(model_id="missing"))
+        t.close()
+
+
+class TestOpenSearchGrpcStreamingDelegation(TestCase):
+    """OpenSearchGrpc streaming methods delegate to the transport."""
+
+    def _get_client(self) -> OpenSearchGrpc:
+        return OpenSearchGrpc(
+            hosts=[{"host": "localhost", "port": 9200}],
+            grpc_hosts=[{"host": "localhost", "port": 9400}],
+        )
+
+    def test_predict_model_stream_delegates(self) -> None:
+        client = self._get_client()
+        with patch.object(
+            client.transport, "predict_model_stream", return_value=iter([{"ok": 1}])
+        ) as mocked:
+            result = list(client.predict_model_stream(model_id="m", body={"a": 1}))
+        self.assertEqual(result, [{"ok": 1}])
+        mocked.assert_called_once_with(model_id="m", body={"a": 1})
+        client.transport.close()
+
+    def test_execute_agent_stream_delegates(self) -> None:
+        client = self._get_client()
+        with patch.object(
+            client.transport, "execute_agent_stream", return_value=iter([{"ok": 2}])
+        ) as mocked:
+            result = list(client.execute_agent_stream(agent_id="a", body=None))
+        self.assertEqual(result, [{"ok": 2}])
+        mocked.assert_called_once_with(agent_id="a", body=None)
+        client.transport.close()

--- a/test_opensearchpy/test_server/test_grpc/test_ml_stream.py
+++ b/test_opensearchpy/test_server/test_grpc/test_ml_stream.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+# mypy: ignore-errors
+"""
+test_ml_stream.py — gRPC ML Streaming Integration Tests
+
+Tests ML prediction and agent execution streamed over gRPC via
+MLService.PredictModelStream / ExecuteAgentStream.
+
+These require a deployed remote model / registered agent, so the streaming
+assertions skip unless OPENSEARCH_ML_MODEL_ID / OPENSEARCH_ML_AGENT_ID are set.
+The wiring tests always run (they only need the gRPC server to be reachable).
+"""
+
+import os
+from unittest import SkipTest
+
+from . import OpenSearchGrpcTestCase
+
+ML_MODEL_ID = os.environ.get("OPENSEARCH_ML_MODEL_ID")
+ML_AGENT_ID = os.environ.get("OPENSEARCH_ML_AGENT_ID")
+
+
+class TestMLStreamWiring(OpenSearchGrpcTestCase):
+    """The streaming methods are exposed on the gRPC client."""
+
+    def test_predict_model_stream_exists(self) -> None:
+        self.assertTrue(callable(self.client.predict_model_stream))
+
+    def test_execute_agent_stream_exists(self) -> None:
+        self.assertTrue(callable(self.client.execute_agent_stream))
+
+
+class TestPredictModelStream(OpenSearchGrpcTestCase):
+    def test_predict_model_stream(self) -> None:
+        """Stream predictions from a deployed model over gRPC."""
+        if not ML_MODEL_ID:
+            raise SkipTest("OPENSEARCH_ML_MODEL_ID not set")
+
+        chunks = list(
+            self.client.predict_model_stream(
+                model_id=ML_MODEL_ID,
+                body={
+                    "parameters": {"messages": [{"role": "user", "content": "Hello"}]}
+                },
+            )
+        )
+
+        self.assertGreater(len(chunks), 0)
+        # Each chunk is a dict; the stream ends with is_last=True on the last
+        # data_as_map chunk (when the model streams via data_as_map).
+        for chunk in chunks:
+            self.assertIsInstance(chunk, dict)
+
+
+class TestExecuteAgentStream(OpenSearchGrpcTestCase):
+    def test_execute_agent_stream(self) -> None:
+        """Stream agent execution results over gRPC."""
+        if not ML_AGENT_ID:
+            raise SkipTest("OPENSEARCH_ML_AGENT_ID not set")
+
+        chunks = list(
+            self.client.execute_agent_stream(
+                agent_id=ML_AGENT_ID,
+                body={"parameters": {"question": "What is OpenSearch?"}},
+            )
+        )
+
+        self.assertGreater(len(chunks), 0)
+        for chunk in chunks:
+            self.assertIsInstance(chunk, dict)

--- a/test_opensearchpy/test_translation/test_ml_stream_request.py
+++ b/test_opensearchpy/test_translation/test_ml_stream_request.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+"""
+test_ml_stream_request.py — Unit Tests for the ML streaming translation layer
+
+Tests the request builders and the streamed-response converter without
+requiring a running OpenSearch server. No network calls are made.
+
+Run:
+    pytest test_opensearchpy/test_translation/test_ml_stream_request.py -v
+"""
+
+from opensearch.protobufs.schemas.common_pb2 import (
+    STATUS_COMPLETED,
+    STATUS_RUNNING,
+    DataAsMap,
+    InferenceResults,
+    Output,
+    PredictResponse,
+)
+
+from opensearch_grpc.ml_translation import (
+    MlExecuteAgentStreamRequestBuilder,
+    MlPredictModelStreamRequestBuilder,
+    MlStreamResponseConverter,
+    _status_to_str,
+)
+
+
+class TestMlPredictModelStreamRequestBuilder:
+    """MlPredictModelStreamRequestBuilder builds correct protobuf requests."""
+
+    def test_model_id_is_set(self) -> None:
+        req = MlPredictModelStreamRequestBuilder(model_id="my-model").build()
+        assert req.model_id == "my-model"
+        assert not req.HasField("ml_predict_model_stream_request_body")
+
+    def test_parameters_messages(self) -> None:
+        req = MlPredictModelStreamRequestBuilder(
+            model_id="m",
+            parameters={"messages": [{"role": "user", "content": "Hello"}]},
+        ).build()
+        body = req.ml_predict_model_stream_request_body
+        assert len(body.parameters.messages) == 1
+        assert body.parameters.messages[0].role == "user"
+        assert body.parameters.messages[0].content == "Hello"
+
+    def test_parameters_inputs_question_interface(self) -> None:
+        req = MlPredictModelStreamRequestBuilder(
+            model_id="m",
+            parameters={
+                "inputs": "the input",
+                "question": "a question",
+                "x_llm_interface": "bedrock/converse",
+            },
+        ).build()
+        params = req.ml_predict_model_stream_request_body.parameters
+        assert params.inputs == "the input"
+        assert params.question == "a question"
+        assert params.x_llm_interface == "bedrock/converse"
+
+    def test_llm_interface_alias(self) -> None:
+        req = MlPredictModelStreamRequestBuilder(
+            model_id="m", parameters={"llm_interface": "openai/v1/chat/completions"}
+        ).build()
+        params = req.ml_predict_model_stream_request_body.parameters
+        assert params.x_llm_interface == "openai/v1/chat/completions"
+
+    def test_from_body(self) -> None:
+        req = MlPredictModelStreamRequestBuilder.from_body(
+            model_id="m", body={"parameters": {"question": "hi"}}
+        ).build()
+        assert req.model_id == "m"
+        assert req.ml_predict_model_stream_request_body.parameters.question == "hi"
+
+    def test_from_body_empty(self) -> None:
+        req = MlPredictModelStreamRequestBuilder.from_body(model_id="m").build()
+        assert req.model_id == "m"
+        assert not req.HasField("ml_predict_model_stream_request_body")
+
+
+class TestMlExecuteAgentStreamRequestBuilder:
+    """MlExecuteAgentStreamRequestBuilder builds correct protobuf requests."""
+
+    def test_agent_id_is_set(self) -> None:
+        req = MlExecuteAgentStreamRequestBuilder(agent_id="my-agent").build()
+        assert req.agent_id == "my-agent"
+        assert not req.HasField("ml_execute_agent_stream_request_body")
+
+    def test_parameters(self) -> None:
+        req = MlExecuteAgentStreamRequestBuilder(
+            agent_id="a", parameters={"question": "What is OpenSearch?"}
+        ).build()
+        params = req.ml_execute_agent_stream_request_body.parameters
+        assert params.question == "What is OpenSearch?"
+
+    def test_from_body(self) -> None:
+        req = MlExecuteAgentStreamRequestBuilder.from_body(
+            agent_id="a", body={"parameters": {"inputs": "x"}}
+        ).build()
+        assert req.agent_id == "a"
+        assert req.ml_execute_agent_stream_request_body.parameters.inputs == "x"
+
+
+class TestMlStreamResponseConverter:
+    """MlStreamResponseConverter converts PredictResponse chunks to dicts."""
+
+    def test_data_as_map_chunk(self) -> None:
+        response = PredictResponse(
+            status=STATUS_RUNNING,
+            inference_results=[
+                InferenceResults(
+                    output=[
+                        Output(
+                            name="response",
+                            data_as_map=DataAsMap(content="Hello", is_last=False),
+                        )
+                    ]
+                )
+            ],
+        )
+        result = MlStreamResponseConverter.from_predict_response(response)
+        assert result["status"] == "running"
+        output = result["inference_results"][0]["output"][0]
+        assert output["name"] == "response"
+        assert output["dataAsMap"] == {"content": "Hello", "is_last": False}
+
+    def test_last_chunk(self) -> None:
+        response = PredictResponse(
+            status=STATUS_COMPLETED,
+            inference_results=[
+                InferenceResults(
+                    output=[Output(data_as_map=DataAsMap(content="", is_last=True))]
+                )
+            ],
+        )
+        result = MlStreamResponseConverter.from_predict_response(response)
+        assert result["status"] == "completed"
+        assert (
+            result["inference_results"][0]["output"][0]["dataAsMap"]["is_last"] is True
+        )
+
+    def test_result_string_output(self) -> None:
+        response = PredictResponse(
+            inference_results=[InferenceResults(output=[Output(result="0.42")])]
+        )
+        result = MlStreamResponseConverter.from_predict_response(response)
+        assert result["inference_results"][0]["output"][0]["result"] == "0.42"
+        assert "status" not in result
+
+    def test_empty_response(self) -> None:
+        result = MlStreamResponseConverter.from_predict_response(PredictResponse())
+        assert result == {}
+
+
+class TestHelpers:
+    def test_status_to_str_known(self) -> None:
+        assert _status_to_str(STATUS_RUNNING) == "running"
+        assert _status_to_str(STATUS_COMPLETED) == "completed"
+
+    def test_status_to_str_unknown(self) -> None:
+        assert _status_to_str(999) == "unspecified"

--- a/utils/templates/grpc_client
+++ b/utils/templates/grpc_client
@@ -17,19 +17,23 @@
 # -----------------------------------------------------------------------------------------+
 
 
-from typing import Any
+from typing import TYPE_CHECKING, Any, Iterator, cast
 
 from ..exceptions import ImproperlyConfigured
 from . import OpenSearch
 
+if TYPE_CHECKING:
+    from opensearch_grpc.grpc_transport import GrpcTransport
+
 
 class OpenSearchGrpc(OpenSearch):
     """
-    OpenSearch client with gRPC transport for bulk document operations.
+    OpenSearch client with gRPC transport for bulk and ML streaming operations.
 
     Extends the standard OpenSearch client with gRPC channel management.
-    Bulk requests are routed over gRPC for better performance; all other
-    operations fall through to REST automatically.
+    Bulk requests are routed over gRPC for better performance; ML prediction
+    and agent execution can be streamed over gRPC; all other operations fall
+    through to REST automatically.
 
     Usage::
 
@@ -42,6 +46,20 @@ class OpenSearchGrpc(OpenSearch):
 
         # Bulk goes over gRPC automatically
         client.bulk(body=[...])
+
+        # ML prediction stream over gRPC
+        for chunk in client.predict_model_stream(
+            model_id='my-model',
+            body={'parameters': {'messages': [{'role': 'user', 'content': 'Hi'}]}},
+        ):
+            print(chunk)
+
+        # ML agent execution stream over gRPC
+        for chunk in client.execute_agent_stream(
+            agent_id='my-agent',
+            body={'parameters': {'question': 'How many indices are in my cluster?'}},
+        ):
+            print(chunk)
 
         # Everything else uses REST
         client.search(index='my-index', body={'query': {'match_all': {}}})
@@ -92,3 +110,33 @@ class OpenSearchGrpc(OpenSearch):
             kwargs["grpc_hosts"] = grpc_hosts
 
         super().__init__(hosts, transport_class=GrpcTransport, **kwargs)
+
+    def predict_model_stream(
+        self,
+        *,
+        model_id: Any,
+        body: Any = None,
+    ) -> Iterator[Any]:
+        """
+        Predict a model in streaming mode over gRPC.
+
+        :arg model_id: the deployed model id.
+        :arg body: request body, e.g. ``{"parameters": {"messages": [...]}}``.
+        """
+        transport = cast("GrpcTransport", self.transport)
+        return transport.predict_model_stream(model_id=model_id, body=body)
+
+    def execute_agent_stream(
+        self,
+        *,
+        agent_id: Any,
+        body: Any = None,
+    ) -> Iterator[Any]:
+        """
+        Execute an agent in streaming mode over gRPC.
+
+        :arg agent_id: the agent id.
+        :arg body: request body, e.g. ``{"parameters": {"question": "..."}}``.
+        """
+        transport = cast("GrpcTransport", self.transport)
+        return transport.execute_agent_stream(agent_id=agent_id, body=body)


### PR DESCRIPTION
### Description
Adds client support for the two new server-streaming gRPC RPCs introduced in ML Commons https://github.com/opensearch-project/ml-commons/pull/4790:
- `MLService.PredictModelStream` — stream predictions from a deployed model
- `MLService.ExecuteAgentStream` — stream agent execution results

This builds on the existing gRPC foundation (https://github.com/opensearch-project/opensearch-py/pull/1058) translation layer, (https://github.com/opensearch-project/opensearch-py/pull/1078) transport and follows the same three-layer structure: a translation layer that maps Python dicts ↔ protobufs, transport methods that open and iterate the server stream, and client methods on `OpenSearchGrpc` for ergonomics.

### Usage
```
  from opensearchpy import OpenSearchGrpc
  
  client = OpenSearchGrpc(
      hosts=[{"host": "localhost", "port": 9200}],
      grpc_hosts=[{"host": "localhost", "port": 9400}],
  )

  # Stream model predictions
  for chunk in client.predict_model_stream(                                                                                                                                                   
      model_id="my-model",
      body={"parameters": {"messages": [{"role": "user", "content": "Hello"}]}},
  ):
      print(chunk)

  # Stream agent execution
  for chunk in client.execute_agent_stream(
      agent_id="my-agent",
      body={"parameters": {"question": "How many indices are in my cluster?"}},
  ):
      print(chunk)
```
### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
