### PR TITLE
Do not bind path parts the generated URL cannot use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Fix `UnicodeEncodeError` on surrogate/emoji characters in bulk chunk sizing by passing `surrogatepass` error handler ([#1086](https://github.com/opensearch-project/opensearch-py/pull/1086))
+- Stop binding path parts the generated URL cannot use, so `nodes.info(node_id_or_metric=...)` no longer requests every node in the cluster ([#1097](https://github.com/opensearch-project/opensearch-py/pull/1097))
 ### Security
 - Refresh `samples/` and `benchmarks/` poetry locks and pin fixed transitive floors to clear all outstanding dependency CVE findings: aiohttp `>=3.14.1` (CVE-2026-54273..54280 et al.), urllib3 `>=2.7.0` (CVE-2025-50181/-50182/-66418/-66471, CVE-2026-21441/-44431/-44432), requests `>=2.33.0` (CVE-2024-47081, CVE-2026-25645), and idna `>=3.18` (CVE-2026-45409) ([#1082](https://github.com/opensearch-project/opensearch-py/pull/1082))
 ### Dependencies

--- a/opensearchpy/_async/client/nodes.py
+++ b/opensearchpy/_async/client/nodes.py
@@ -94,7 +94,6 @@ class NodesClient(NamespacedClient):
         *,
         node_id: Any = None,
         metric: Any = None,
-        node_id_or_metric: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -106,9 +105,6 @@ class NodesClient(NamespacedClient):
             to limit returned information.
         :arg metric: Limits the information returned to the specific
             metrics. Supports a comma-separated list, such as `http,ingest`.
-        :arg node_id_or_metric: Limits the information returned to a
-            list of node IDs or specific metrics. Supports a comma-separated list,
-            such as `node1,node2` or `http,ingest`.
         :arg error_trace: Whether to include the stack trace of returned
             errors. Default is false.
         :arg filter_path: A comma-separated list of filters used to

--- a/opensearchpy/client/nodes.py
+++ b/opensearchpy/client/nodes.py
@@ -94,7 +94,6 @@ class NodesClient(NamespacedClient):
         *,
         node_id: Any = None,
         metric: Any = None,
-        node_id_or_metric: Any = None,
         params: Any = None,
         headers: Any = None,
     ) -> Any:
@@ -106,9 +105,6 @@ class NodesClient(NamespacedClient):
             to limit returned information.
         :arg metric: Limits the information returned to the specific
             metrics. Supports a comma-separated list, such as `http,ingest`.
-        :arg node_id_or_metric: Limits the information returned to a
-            list of node IDs or specific metrics. Supports a comma-separated list,
-            such as `node1,node2` or `http,ingest`.
         :arg error_trace: Whether to include the stack trace of returned
             errors. Default is false.
         :arg filter_path: A comma-separated list of filters used to

--- a/utils/generate_api.py
+++ b/utils/generate_api.py
@@ -413,7 +413,18 @@ class API:
             if k in parts:
                 parts[sub] = parts.pop(k)
 
-        _, components = self.url_parts
+        dynamic, components = self.url_parts
+
+        # `parts` is collected from every path in the spec, but only ONE path is rendered
+        # (see `path`, which picks the variant with the most placeholders). A part that
+        # belongs solely to a path we did not pick has nowhere to appear in the generated
+        # URL, so binding it produces an argument the method silently ignores.
+        # nodes.info is the case in the current spec: it accepts `node_id_or_metric` from
+        # `/_nodes/{node_id_or_metric}` while rendering `/_nodes/{node_id}/{metric}`, so
+        # `info(node_id_or_metric="http")` requests `/_nodes` and returns every node and
+        # every metric instead of the one asked for.
+        if dynamic:
+            parts = {k: v for k, v in parts.items() if k in components}
 
         def ind(item: Any) -> Any:
             try:


### PR DESCRIPTION
`NodesClient.info()` accepts `node_id_or_metric`, documents it, and never uses it. The body builds `_make_path("_nodes", node_id, metric)`, so the argument has nowhere to go.

```python
client.nodes.info(node_id_or_metric="http")   # requests GET /_nodes
client.nodes.info(node_id="http")             # requests GET /_nodes/http
```

The first asks for every node and every metric in the cluster, with no error or warning. The second builds the URL the caller wanted, so nothing is unreachable, but the parameter named after the endpoint is the one that silently returns everything.

The cause is that two properties in `utils/generate_api.py` disagree. `path` picks a single path from the spec, the one with the most placeholders, which for `nodes.info` is `/_nodes/{node_id}/{metric}`. `all_parts` unions the parts of every path, so `node_id_or_metric` from `/_nodes/{node_id_or_metric}` is bound with no template to appear in. Parameters come from all paths, the URL comes from one.

This drops parts the chosen path cannot use. `all_parts` already identifies them, since its sort key returns `len(components)` for exactly those and sorts them last. The filter is guarded on `dynamic` because `url_parts` returns a string for a static path.

Verified by running `utils/generate_api.py` twice against the spec, before and after, then diffing the two sets of generated output against each other, since a fresh regen already drifts from what is checked in: of 45 generated client files exactly two change, `client/nodes.py` and `_async/client/nodes.py`, each losing the parameter and its docstring lines. `nodes.stats`, which has `node_id`, `metric` and `index_metric`, is byte-identical, so nested operations are unaffected. `black` and `isort` clean, 621 offline tests pass.

Severity is low. Nothing is unreachable and there is no security impact.

I did not run the server integration tests, which need a live cluster, and I have not checked whether other specs have this shape.
