### PR TITLE
Collect service time metrics on the async client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Fix `UnicodeEncodeError` on surrogate/emoji characters in bulk chunk sizing by passing `surrogatepass` error handler ([#1086](https://github.com/opensearch-project/opensearch-py/pull/1086))
+- Collect service time metrics on the async client, which accepted `metrics` and never recorded anything ([#1098](https://github.com/opensearch-project/opensearch-py/pull/1098))
 ### Security
 - Refresh `samples/` and `benchmarks/` poetry locks and pin fixed transitive floors to clear all outstanding dependency CVE findings: aiohttp `>=3.14.1` (CVE-2026-54273..54280 et al.), urllib3 `>=2.7.0` (CVE-2025-50181/-50182/-66418/-66471, CVE-2026-21441/-44431/-44432), requests `>=2.33.0` (CVE-2024-47081, CVE-2026-25645), and idna `>=3.18` (CVE-2026-45409) ([#1082](https://github.com/opensearch-project/opensearch-py/pull/1082))
 ### Dependencies

--- a/opensearchpy/_async/http_aiohttp.py
+++ b/opensearchpy/_async/http_aiohttp.py
@@ -41,6 +41,7 @@ from ..exceptions import (
     ImproperlyConfigured,
     SSLError,
 )
+from ..metrics import Metrics, MetricsNone
 from ._extra_imports import aiohttp, aiohttp_exceptions, yarl  # type: ignore
 from .compat import get_running_loop
 
@@ -94,6 +95,7 @@ class AIOHttpConnection(AsyncConnection):
         opaque_id: Optional[str] = None,
         loop: Any = None,
         trust_env: Optional[bool] = False,
+        metrics: Metrics = MetricsNone(),
         **kwargs: Any,
     ) -> None:
         """
@@ -128,9 +130,13 @@ class AIOHttpConnection(AsyncConnection):
         :arg opaque_id: Send this value in the 'X-Opaque-Id' HTTP header
             For tracing all requests made by this transport.
         :arg loop: asyncio Event Loop to use with aiohttp. This is set by default to the currently running loop.
+        :arg metrics: metrics is an instance of a subclass of the
+            :class:`~opensearchpy.Metrics` class, used for collecting
+            and reporting metrics related to the client's operations;
         """
 
         self.headers = {}
+        self.metrics = metrics
 
         super().__init__(
             host=host,
@@ -291,6 +297,8 @@ class AIOHttpConnection(AsyncConnection):
 
         start = self.loop.time()
         try:
+            self.metrics.request_start()
+
             async with self.session.request(
                 method,
                 url,
@@ -321,6 +329,8 @@ class AIOHttpConnection(AsyncConnection):
             ):
                 raise ConnectionTimeout("TIMEOUT", str(e), e)
             raise ConnectionError("N/A", str(e), e)
+        finally:
+            self.metrics.request_end()
 
         # raise warnings if any from the 'Warnings' header.
         warning_headers = response.headers.getall("warning", ())

--- a/opensearchpy/connection/http_async.py
+++ b/opensearchpy/connection/http_async.py
@@ -230,6 +230,8 @@ class AsyncHttpConnection(AIOHttpConnection):
 
         start = self.loop.time()
         try:
+            self.metrics.request_start()
+
             async with self.session.request(
                 method,
                 yarl.URL(url, encoded=True),
@@ -261,6 +263,8 @@ class AsyncHttpConnection(AIOHttpConnection):
             ):
                 raise ConnectionTimeout("TIMEOUT", str(e), e)
             raise ConnectionError("N/A", str(e), e)
+        finally:
+            self.metrics.request_end()
 
         # raise warnings if any from the 'Warnings' header.
         warning_headers = response.headers.getall("warning", ())

--- a/test_opensearchpy/test_async/test_connection.py
+++ b/test_opensearchpy/test_async/test_connection.py
@@ -45,6 +45,8 @@ from opensearchpy import AIOHttpConnection, AsyncOpenSearch, __versionstr__, ser
 from opensearchpy.compat import reraise_exceptions
 from opensearchpy.connection import Connection, async_connections
 from opensearchpy.exceptions import ConnectionError, NotFoundError, TransportError
+from opensearchpy.metrics.metrics_events import MetricsEvents
+from opensearchpy.metrics.metrics_none import MetricsNone
 from test_opensearchpy.test_http_server import TestHTTPServer
 
 pytestmark: MarkDecorator = pytest.mark.asyncio
@@ -389,6 +391,36 @@ class TestAIOHttpConnection:
             assert e.value.error == "snapshot_in_progress_exception"
         finally:
             await con.close()
+
+    async def test_metrics_default_is_metrics_none(self) -> None:
+        con = await self._get_mock_connection()
+        assert isinstance(con.metrics, MetricsNone)
+        await con.perform_request("GET", "/")
+        assert con.metrics.service_time is None
+
+    async def test_metrics_events_records_service_time(self) -> None:
+        metrics = MetricsEvents()
+        con = await self._get_mock_connection({"metrics": metrics})
+        await con.perform_request("GET", "/")
+        assert isinstance(metrics.service_time, float)
+        assert metrics.service_time > 0
+
+        first = metrics.service_time
+        await con.perform_request("GET", "/")
+        assert metrics.service_time != first
+
+    async def test_metrics_events_records_on_failure(self) -> None:
+        metrics = MetricsEvents()
+        con = AIOHttpConnection(metrics=metrics)
+        await con._create_aiohttp_session()
+
+        def request_raise(*_: Any, **__: Any) -> Any:
+            raise Exception("boom")
+
+        con.session.request = request_raise
+        with pytest.raises(ConnectionError):
+            await con.perform_request("GET", "/")
+        assert isinstance(metrics.service_time, float)
 
 
 class TestConnectionHttpServer:

--- a/test_opensearchpy/test_async/test_http_connection.py
+++ b/test_opensearchpy/test_async/test_http_connection.py
@@ -35,6 +35,8 @@ from multidict import CIMultiDict
 from opensearchpy._async._extra_imports import aiohttp  # type: ignore
 from opensearchpy._async.compat import get_running_loop
 from opensearchpy.connection.http_async import AsyncHttpConnection
+from opensearchpy.metrics.metrics_events import MetricsEvents
+from opensearchpy.metrics.metrics_none import MetricsNone
 
 
 class TestAsyncHttpConnection:
@@ -150,3 +152,24 @@ class TestAsyncHttpConnection:
             ),
             fingerprint=None,
         )
+
+    @pytest.mark.asyncio  # type: ignore
+    @mock.patch("aiohttp.ClientSession.request")
+    async def test_metrics_default_is_metrics_none(self, mock_request: Any) -> None:
+        mock_request.return_value = TestAsyncHttpConnection.MockResponse()
+
+        c = AsyncHttpConnection(loop=get_running_loop())
+        assert isinstance(c.metrics, MetricsNone)
+        await c.perform_request("get", "/test")
+        assert c.metrics.service_time is None
+
+    @pytest.mark.asyncio  # type: ignore
+    @mock.patch("aiohttp.ClientSession.request")
+    async def test_metrics_events_records_service_time(self, mock_request: Any) -> None:
+        mock_request.return_value = TestAsyncHttpConnection.MockResponse()
+
+        metrics = MetricsEvents()
+        c = AsyncHttpConnection(metrics=metrics, loop=get_running_loop())
+        await c.perform_request("get", "/test")
+        assert isinstance(metrics.service_time, float)
+        assert metrics.service_time > 0


### PR DESCRIPTION
`AsyncOpenSearch(hosts, metrics=MetricsEvents())` is accepted, reaches the transport and reaches the connection, and then records nothing. `service_time` stays `None` for the life of the client.

`AsyncTransport` inherits the sync `_create_connection`, which passes `metrics=self.metrics` through, and both async connection classes take it into `**kwargs` and drop it. The sync connections call `request_start` and `request_end`. Nothing on the async side does.

This is the half that #716 deferred, not something nobody wanted. That PR's own description carries an unchecked "Service time metrics will be implemented for AsyncOpensearch in a subsequent PR", the subsequent PR never came, and #678 has stayed open since. What looks accidental is only the silent accept, which falls out of `**kwargs` taking an argument nobody reads.

Both async connection classes needed it. `AsyncHttpConnection` reimplements `perform_request`, so patching `AIOHttpConnection` alone leaves it still returning `None`, which is easy to miss because the existing metrics tests enumerate the two sync classes by hand and no async one.

`probe_opensearch_async_metrics.py` drives all four connection classes against a localhost stub, with no server, network or credentials. On `main` the two sync paths collect and both async paths are `None`. With this change all four collect.

Unit suite is 850 passed before and 855 after, with the same 27 pre-existing AWS signer failures on both sides. `isort`, `black`, `flake8`, `pylint` at 10.00, `mypy` and the license header check all pass against the repo's own configs.

I have no live cluster, so `test_server` and `test_async/test_server` did not run, and I did not add an async case to the server-side `test_metrics.py`, which needs one. The evidence here is the stub plus the repo's mocked-session harness, not a real request.

Closes part of #678.
